### PR TITLE
Delete image lists before manifests in account deletion

### DIFF
--- a/internal/api/keppel/accounts.go
+++ b/internal/api/keppel/accounts.go
@@ -783,7 +783,8 @@ var (
 			FROM manifests m
 			JOIN repos r ON m.repo_id = r.id
 			JOIN accounts a ON a.name = r.account_name
-		 WHERE a.name = $1
+			LEFT OUTER JOIN manifest_manifest_refs mmr ON mmr.repo_id = r.id AND m.digest = mmr.child_digest
+		 WHERE a.name = $1 AND parent_digest IS NULL
 		 LIMIT 10
 	`)
 	deleteAccountCountManifestsQuery = keppel.SimplifyWhitespaceInSQL(`

--- a/internal/api/keppel/fixtures/delete-account-000.sql
+++ b/internal/api/keppel/fixtures/delete-account-000.sql
@@ -14,6 +14,11 @@ INSERT INTO manifest_blob_refs (repo_id, digest, blob_id) VALUES (1, 'sha256:7ce
 INSERT INTO manifest_blob_refs (repo_id, digest, blob_id) VALUES (1, 'sha256:7ce8d2ddbc66e475563019803ff254fb78b7becafd39959dc735ace4efaf395e', 2);
 INSERT INTO manifest_blob_refs (repo_id, digest, blob_id) VALUES (1, 'sha256:7ce8d2ddbc66e475563019803ff254fb78b7becafd39959dc735ace4efaf395e', 3);
 
+INSERT INTO manifest_contents (repo_id, digest, content) VALUES (1, 'sha256:13493afd2a64d1a14fb5ca0d2fe312117239b935ea40dc35ca59c55931a86ab7', '{"manifests":[{"digest":"sha256:7ce8d2ddbc66e475563019803ff254fb78b7becafd39959dc735ace4efaf395e","mediaType":"application/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":592}],"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","schemaVersion":2}');
+
+INSERT INTO manifest_manifest_refs (repo_id, parent_digest, child_digest) VALUES (1, 'sha256:13493afd2a64d1a14fb5ca0d2fe312117239b935ea40dc35ca59c55931a86ab7', 'sha256:7ce8d2ddbc66e475563019803ff254fb78b7becafd39959dc735ace4efaf395e');
+
+INSERT INTO manifests (repo_id, digest, media_type, size_bytes, pushed_at, validated_at, validation_error_message, last_pulled_at, next_vuln_check_at, vuln_status, vuln_scan_error, labels_json) VALUES (1, 'sha256:13493afd2a64d1a14fb5ca0d2fe312117239b935ea40dc35ca59c55931a86ab7', 'application/vnd.docker.distribution.manifest.list.v2+json', 909, 0, 0, '', NULL, NULL, 'Pending', '', '');
 INSERT INTO manifests (repo_id, digest, media_type, size_bytes, pushed_at, validated_at, validation_error_message, last_pulled_at, next_vuln_check_at, vuln_status, vuln_scan_error, labels_json) VALUES (1, 'sha256:7ce8d2ddbc66e475563019803ff254fb78b7becafd39959dc735ace4efaf395e', 'application/vnd.docker.distribution.manifest.v2+json', 592, 100, 100, '', NULL, NULL, 'Pending', '', '');
 
 INSERT INTO repos (id, account_name, name, next_blob_mount_sweep_at, next_manifest_sync_at, next_gc_at) VALUES (1, 'test1', 'foo/bar', NULL, NULL, NULL);

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -44,7 +44,7 @@ func deterministicDummyVulnStatus(counter int) clair.VulnerabilityStatus {
 }
 
 func TestManifestsAPI(t *testing.T) {
-	h, _, _, auditor, sd, db, claird := setup(t)
+	h, _, _, auditor, sd, db, _, claird := setup(t)
 
 	//setup two test accounts
 	mustInsert(t, db, &keppel.Account{

--- a/internal/api/keppel/peers_test.go
+++ b/internal/api/keppel/peers_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestPeersAPI(t *testing.T) {
-	h, _, _, _, _, db, _ := setup(t)
+	h, _, _, _, _, db, _, _ := setup(t)
 
 	//check empty response when there are no peers in the DB
 	assert.HTTPRequest{

--- a/internal/api/keppel/quotas_test.go
+++ b/internal/api/keppel/quotas_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestQuotasAPI(t *testing.T) {
-	r, _, _, auditor, _, db, _ := setup(t)
+	r, _, _, auditor, _, db, _, _ := setup(t)
 
 	//GET on auth tenant without more specific configuration shows default values
 	assert.HTTPRequest{

--- a/internal/api/keppel/repos_test.go
+++ b/internal/api/keppel/repos_test.go
@@ -41,13 +41,28 @@ func mustInsert(t *testing.T, db *keppel.DB, obj interface{}) {
 	}
 }
 
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func mustExec(t *testing.T, db *keppel.DB, query string, args ...interface{}) {
+	t.Helper()
+	_, err := db.Exec(query, args...)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func deterministicDummyDigest(counter int) string {
 	hash := sha256.Sum256(bytes.Repeat([]byte{1}, counter))
 	return "sha256:" + hex.EncodeToString(hash[:])
 }
 
 func TestReposAPI(t *testing.T) {
-	h, _, _, _, _, db, _ := setup(t)
+	h, _, _, _, _, db, _, _ := setup(t)
 
 	//setup two test accounts
 	mustInsert(t, db, &keppel.Account{


### PR DESCRIPTION
to remove all contents of accounts without triggering foreign key constraints