### PR TITLE
renovate: enable for OCI conformance workflow

### DIFF
--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -54,6 +54,10 @@ githubWorkflow:
 
 renovate:
   enabled: true
+  packageRules:
+    - matchDepTypes: ["action"]
+      matchFiles: [".github/workflows/oci-distribution-conformance.yml"]
+      enabled: true
 
 verbatim: |
   # This is for manual testing.


### PR DESCRIPTION
Merge after https://github.com/sapcc/go-makefile-maker/pull/29 .