### PR TITLE
do not patch http.DefaultClient

### DIFF
--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -522,7 +522,7 @@ func TestReplicationFailingOverIntoPullDelegation(t *testing.T) {
 					return
 				}
 			}
-			http.DefaultClient.Transport.(*test.RoundTripper).Handlers["registry-tertiary.example.org"] = http.HandlerFunc(tertiaryHandler)
+			http.DefaultTransport.(*test.RoundTripper).Handlers["registry-tertiary.example.org"] = http.HandlerFunc(tertiaryHandler)
 
 			//reconfigure "test1" into an external replica of tertiary
 			for _, db := range []*keppel.DB{s1.DB, s2.DB} {

--- a/internal/api/registry/shared_test.go
+++ b/internal/api/registry/shared_test.go
@@ -95,7 +95,7 @@ func testWithReplica(t *testing.T, s1 test.Setup, strategy string, action func(f
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		tt := http.DefaultClient.Transport.(*test.RoundTripper) //nolint:errcheck
+		tt := http.DefaultTransport.(*test.RoundTripper) //nolint:errcheck
 		tt.Handlers["registry-secondary.example.org"] = nil
 	}()
 

--- a/internal/drivers/openstack/keystone.go
+++ b/internal/drivers/openstack/keystone.go
@@ -106,8 +106,6 @@ func init() {
 func createProviderClient(ao gophercloud.AuthOptions) (*gophercloud.ProviderClient, error) {
 	provider, err := openstack.NewClient(ao.IdentityEndpoint)
 	if err == nil {
-		//use http.DefaultClient, esp. to pick up the KEPPEL_INSECURE flag
-		provider.HTTPClient = *http.DefaultClient
 		provider.UserAgent.Prepend(fmt.Sprintf("%s/%s", bininfo.Component(), bininfo.Version()))
 		err = openstack.Authenticate(provider, ao)
 	}
@@ -147,9 +145,8 @@ func (d *keystoneDriver) AuthenticateUser(userName, password string) (keppel.Use
 	//response will trigger a useless reauthentication of the service user
 	throwAwayClient := gophercloud.ServiceClient{
 		ProviderClient: &gophercloud.ProviderClient{
-			HTTPClient: *http.DefaultClient,
-			Throwaway:  true,
-			Context:    ctx,
+			Throwaway: true,
+			Context:   ctx,
 		},
 		Endpoint: d.IdentityV3.Endpoint,
 	}

--- a/internal/tasks/manifests_test.go
+++ b/internal/tasks/manifests_test.go
@@ -466,7 +466,7 @@ func TestSyncManifestsInNextRepo(t *testing.T) {
 			//(We do allow the /keppel/v1/auth endpoint to work properly because
 			//otherwise the error messages are not reproducible between passes.)
 			s1.Clock.StepBy(7 * time.Hour)
-			http.DefaultClient.Transport.(*test.RoundTripper).Handlers["registry.example.org"] = answerMostWith404(s1.Handler)
+			http.DefaultTransport.(*test.RoundTripper).Handlers["registry.example.org"] = answerMostWith404(s1.Handler)
 			//This is particularly devious since 404 is returned by the GET endpoint for
 			//a manifest when the manifest was deleted. We want to check that the next
 			//SyncManifestsInNextRepo understands that this is a network issue and not
@@ -490,7 +490,7 @@ func TestSyncManifestsInNextRepo(t *testing.T) {
 			}
 
 			//flip back to the actual primary registry's API
-			http.DefaultClient.Transport.(*test.RoundTripper).Handlers["registry.example.org"] = s1.Handler
+			http.DefaultTransport.(*test.RoundTripper).Handlers["registry.example.org"] = s1.Handler
 			//delete the entire repository on the primary
 			s1.Clock.StepBy(7 * time.Hour)
 			mustExec(t, s1.DB, `DELETE FROM manifests`)
@@ -574,7 +574,7 @@ func TestCheckVulnerabilitiesForNextManifest(t *testing.T) {
 			"clair.example.org":    httpapi.Compose(claird),
 		},
 	}
-	http.DefaultClient.Transport = tt
+	http.DefaultTransport = tt
 	clairBaseURL := must.Return(url.Parse("https://clair.example.org/"))
 	j.cfg.ClairClient = &clair.Client{
 		BaseURL:      *clairBaseURL,

--- a/internal/test/mock_roundtripper.go
+++ b/internal/test/mock_roundtripper.go
@@ -29,22 +29,33 @@ type RoundTripper struct {
 	Handlers map[string]http.Handler
 }
 
+var originalDefaultTransport http.RoundTripper
+
 //WithRoundTripper sets up a RoundTripper instance as the default HTTP
 //transport for the duration of the given action.
 func WithRoundTripper(action func(*RoundTripper)) {
+	if originalDefaultTransport != nil {
+		panic("WithRoundTripper calls may not be nested")
+	}
+
 	t := RoundTripper{Handlers: make(map[string]http.Handler)}
-	prevTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &t
+	originalDefaultTransport = http.DefaultTransport
+	http.DefaultTransport = &t
 	action(&t)
-	http.DefaultClient.Transport = prevTransport
+	http.DefaultTransport = originalDefaultTransport
+	originalDefaultTransport = nil
 }
 
 //WithoutRoundTripper can be used during WithRoundTripper() to temporarily revert back to the
 func WithoutRoundTripper(action func()) {
-	prevTransport := http.DefaultClient.Transport
-	http.DefaultClient.Transport = nil
+	if originalDefaultTransport == nil {
+		panic("WithoutRoundTripper must be called from within WithRoundTripper")
+	}
+
+	prevTransport := http.DefaultTransport
+	http.DefaultTransport = originalDefaultTransport
 	action()
-	http.DefaultClient.Transport = prevTransport
+	http.DefaultTransport = prevTransport
 }
 
 //RoundTrip implements the http.RoundTripper interface.
@@ -52,7 +63,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	//only intercept requests when the target host is known to us
 	h := t.Handlers[req.URL.Host]
 	if h == nil {
-		return http.DefaultTransport.RoundTrip(req)
+		return originalDefaultTransport.RoundTrip(req)
 	}
 
 	w := httptest.NewRecorder()

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -235,7 +235,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 			BaseURL:      *clairURL,
 			PresharedKey: []byte("doesnotmatter"), //since the ClairDouble does not check the Authorization header
 		}
-		if tt, ok := http.DefaultClient.Transport.(*RoundTripper); ok {
+		if tt, ok := http.DefaultTransport.(*RoundTripper); ok {
 			tt.Handlers[clairURL.Host] = httpapi.Compose(s.ClairDouble)
 		}
 	}
@@ -322,7 +322,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		apis = append(apis, peerv1.NewAPI(s.Config, ad, s.DB))
 	}
 	s.Handler = httpapi.Compose(apis...)
-	if tt, ok := http.DefaultClient.Transport.(*RoundTripper); ok {
+	if tt, ok := http.DefaultTransport.(*RoundTripper); ok {
 		//make our own API reachable to other peers
 		tt.Handlers[s.Config.APIPublicHostname] = s.Handler
 		//if accounts are being set up, also expose their domain-remapped APIs

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
-		http.DefaultClient.Transport = userAgentInjector{http.DefaultTransport}
+		http.DefaultTransport = userAgentInjector{http.DefaultTransport}
 	}
 
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
My overwriting of DefaultClient.Transport was based on incorrect assumptions about how DefaultClient and DefaultTransport interact. It's always enough to only fiddle with DefaultTransport, since DefaultClient will default to using it anyway (as will freshly-constructed http.Client instances like the one in gophercloud.ProviderClient).