### PR TITLE
populate labels_json for list manifests

### DIFF
--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -576,7 +576,10 @@ func TestManifestRequiredLabels(t *testing.T) {
 			Body:         assert.ByteData(image.Manifest.Contents),
 			ExpectStatus: http.StatusBadRequest,
 			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrManifestInvalid),
+			ExpectBody: test.ErrorCodeWithMessage{
+				Code:    keppel.ErrManifestInvalid,
+				Message: "missing required labels: somethingelse, andalsothis",
+			},
 		}.Check(t, h)
 
 		//setup required labels on account for success


### PR DESCRIPTION
List manifests do not have an image config, so they cannot have labels themselves. However, it would be nice to show labels on list manifests (i.e. multi-arch images): When a repo contains multi-arch images, the labeled single-arch images are buried in the "Untagged images" section and thus practically no labels appear on the UI.

To make the label display for multi-arch images useful, this PR makes Keppel populate the `labels_json` field of multi-arch images (i.e. list manifests) with all labels that the constituent single-arch images agree on.