### PR TITLE
janitor: add jitter to task schedules

### DIFF
--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -686,6 +686,7 @@ func TestImageManifestWrongBlobSize(t *testing.T) {
 func TestImageManifestCmdEntrypointAsString(t *testing.T) {
 	testWithPrimary(t, nil, func(s test.Setup) {
 		j := tasks.NewJanitor(s.Config, s.FD, s.SD, s.ICD, s.DB, s.Auditor).OverrideTimeNow(s.Clock.Now).OverrideGenerateStorageID(s.SIDGenerator.Next)
+		j.DisableJitter()
 
 		//generate an image that has strings as Entrypoint and Cmd
 		image := test.GenerateImageWithCustomConfig(func(cfg map[string]interface{}) {

--- a/internal/tasks/accounts.go
+++ b/internal/tasks/accounts.go
@@ -75,6 +75,6 @@ func (j *Janitor) AnnounceNextAccountToFederation() (returnErr error) {
 		logg.Error("cannot announce account %q to federation: %s", account.Name, err.Error())
 	}
 
-	_, err = j.db.Exec(accountAnnouncementDoneQuery, account.Name, j.timeNow().Add(1*time.Hour))
+	_, err = j.db.Exec(accountAnnouncementDoneQuery, account.Name, j.timeNow().Add(j.addJitter(1*time.Hour)))
 	return err
 }

--- a/internal/tasks/blob_mounts.go
+++ b/internal/tasks/blob_mounts.go
@@ -128,6 +128,6 @@ func (j *Janitor) SweepBlobMountsInNextRepo() (returnErr error) {
 		logg.Info("%d blob mounts sweeped in repo %s", rowsDeleted, repo.FullName())
 	}
 
-	_, err = j.db.Exec(blobMountSweepDoneQuery, repo.ID, j.timeNow().Add(1*time.Hour))
+	_, err = j.db.Exec(blobMountSweepDoneQuery, repo.ID, j.timeNow().Add(j.addJitter(1*time.Hour)))
 	return err
 }

--- a/internal/tasks/blobs.go
+++ b/internal/tasks/blobs.go
@@ -148,7 +148,7 @@ func (j *Janitor) SweepBlobsInNextAccount() (returnErr error) {
 		}
 	}
 
-	_, err = j.db.Exec(blobSweepDoneQuery, account.Name, j.timeNow().Add(1*time.Hour))
+	_, err = j.db.Exec(blobSweepDoneQuery, account.Name, j.timeNow().Add(j.addJitter(1*time.Hour)))
 	return err
 }
 

--- a/internal/tasks/image_gc.go
+++ b/internal/tasks/image_gc.go
@@ -111,7 +111,7 @@ func (j *Janitor) GarbageCollectManifestsInNextRepo() (returnErr error) {
 		}
 	}
 
-	_, err = j.db.Exec(imageGCRepoDoneQuery, repo.ID, j.timeNow().Add(1*time.Hour))
+	_, err = j.db.Exec(imageGCRepoDoneQuery, repo.ID, j.timeNow().Add(j.addJitter(1*time.Hour)))
 	return err
 }
 

--- a/internal/tasks/janitor_test.go
+++ b/internal/tasks/janitor_test.go
@@ -1,0 +1,63 @@
+/*******************************************************************************
+*
+* Copyright 2022 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package tasks
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAddJitter(t *testing.T) {
+	baseDuration := 60 * time.Minute
+	lowerBound := baseDuration * 9 / 10
+	upperBound := baseDuration * 11 / 10
+
+	smallerCount := 0
+	biggerCount := 0
+
+	//take 1000 samples of addJitter()
+	for idx := 0; idx < 1000; idx++ {
+		d := addJitter(baseDuration)
+		//no sample should be outside the +/-10% range of the base duration
+		if d < lowerBound {
+			t.Errorf("expected jittered duration to be above %s, but got %s", lowerBound.String(), d.String())
+		}
+		if d > upperBound {
+			t.Errorf("expected jittered duration to be below %s, but got %s", upperBound.String(), d.String())
+		}
+		//count samples into two simple buckets
+		if d < baseDuration {
+			smallerCount++
+		}
+		if d > baseDuration {
+			biggerCount++
+		}
+	}
+
+	//very simple sanity-check: both buckets should have ~500 samples
+	if smallerCount < 450 {
+		t.Errorf("expected half of the samples to be smaller than %s, but got only %.2f%% smaller samples",
+			baseDuration, float64(smallerCount)/1000.)
+	}
+	if biggerCount < 450 {
+		t.Errorf("expected half of the samples to be bigger than %s, but got only %.2f%% bigger samples",
+			baseDuration, float64(biggerCount)/1000.)
+	}
+}

--- a/internal/tasks/shared_test.go
+++ b/internal/tasks/shared_test.go
@@ -40,6 +40,7 @@ func setup(t *testing.T) (*Janitor, test.Setup) {
 		test.WithQuotas,
 	)
 	j := NewJanitor(s.Config, s.FD, s.SD, s.ICD, s.DB, s.Auditor).OverrideTimeNow(s.Clock.Now).OverrideGenerateStorageID(s.SIDGenerator.Next)
+	j.DisableJitter()
 	return j, s
 }
 
@@ -74,6 +75,7 @@ func setupReplica(t *testing.T, s1 test.Setup, strategy string) (*Janitor, test.
 	)
 
 	j2 := NewJanitor(s.Config, s.FD, s.SD, s.ICD, s.DB, s.Auditor).OverrideTimeNow(s.Clock.Now).OverrideGenerateStorageID(s.SIDGenerator.Next)
+	j2.DisableJitter()
 	return j2, s
 }
 

--- a/internal/tasks/storage.go
+++ b/internal/tasks/storage.go
@@ -99,7 +99,7 @@ func (j *Janitor) SweepStorageInNextAccount() (returnErr error) {
 		return err
 	}
 
-	_, err = j.db.Exec(storageSweepDoneQuery, account.Name, j.timeNow().Add(6*time.Hour))
+	_, err = j.db.Exec(storageSweepDoneQuery, account.Name, j.timeNow().Add(j.addJitter(6*time.Hour)))
 	return err
 }
 


### PR DESCRIPTION
This came out of an investigation into our vulnerability check performance. The queue length metric is very jumpy: Sometimes 1000 images become due for a vulnerability check at the same time, and then eventually they are all checked in rapid succession and the queue length drops by 1000 again. That makes the queue length metric not very useful as an overall measurement of how far we're lagging behind in vulnerability checks.

With this change, once a task is completed, we schedule the next task with a certain random variation. For example, a vulnerability check is supposed to be executed hourly. With this change, we're setting the next scheduled check not at exactly 60 minutes from now, but at somewhere between 54-66 minutes from now. This should smoothen out the workload and thus make the queue length metric steadier and thus more useful.

I've also applied this change to all other tasks that are driven by a "next_XXX_at" schedule. We have some tasks (namely, blob validation and manifest validation) that are driven in the inverse way (by "fixed time since last check"); I did not adjust these since it is not very easy to add jitter here. Longterm, I would like to move these over into the forward-looking schedule model instead, but that's a change for another day.