### PR TITLE
refactor Accept handler handling to reduce cognitive complexity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sapcc/go-api-declarations v1.4.3
 	github.com/sapcc/go-bits v0.0.0-20230309085702-cdeffa7432aa
 	github.com/spf13/cobra v1.6.1
+	github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09
 	golang.org/x/crypto v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09 h1:QVxbx5l/0pzciWYOynixQMtUhPYC3YKD6EcUlOsgGqw=
+github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09/go.mod h1:Uy/Rnv5WKuOO+PuDhuYLEpUiiKIZtss3z519uk67aF0=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=

--- a/internal/api/registry/shared_test.go
+++ b/internal/api/registry/shared_test.go
@@ -235,7 +235,7 @@ func expectManifestExists(t *testing.T, h http.Handler, token, fullRepoName stri
 
 		//with mismatching Accept header
 		req.Header["Accept"] = "text/plain"
-		req.ExpectStatus = http.StatusNotFound
+		req.ExpectStatus = http.StatusNotAcceptable
 		req.ExpectHeader = test.VersionHeader
 		if method == "GET" {
 			req.ExpectBody = test.ErrorCode(keppel.ErrManifestUnknown)

--- a/internal/client/download.go
+++ b/internal/client/download.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/docker/distribution"
 	"github.com/opencontainers/go-digest"
@@ -61,7 +62,8 @@ func (c *RepoClient) DownloadManifest(reference keppel.ManifestReference, opts *
 		opts = &DownloadManifestOpts{}
 	}
 
-	hdr := http.Header{"Accept": distribution.ManifestMediaTypes()}
+	hdr := make(http.Header)
+	hdr.Set("Accept", strings.Join(distribution.ManifestMediaTypes(), ", "))
 	if opts.DoNotCountTowardsLastPulled {
 		hdr.Set("X-Keppel-No-Count-Towards-Last-Pulled", "1")
 	}

--- a/internal/keppel/manifest.go
+++ b/internal/keppel/manifest.go
@@ -59,6 +59,11 @@ type ParsedManifest interface {
 	BlobReferences() []distribution.Descriptor
 	//ManifestReferences returns all manifests referenced by this manifest.
 	ManifestReferences(pf PlatformFilter) []manifestlist.ManifestDescriptor
+	//AcceptableAlternates returns the subset of ManifestReferences() that is
+	//acceptable as alternate representations of this manifest. When a client
+	//asks for this manifest, but the Accept header does not match the manifest
+	//itself, the API will look for an acceptable alternate to serve instead.
+	AcceptableAlternates(pf PlatformFilter) []manifestlist.ManifestDescriptor
 }
 
 // ParseManifest parses a manifest. It also returns a Descriptor describing the manifest itself.
@@ -100,6 +105,10 @@ func (a v2ManifestAdapter) ManifestReferences(pf PlatformFilter) []manifestlist.
 	return nil
 }
 
+func (a v2ManifestAdapter) AcceptableAlternates(pf PlatformFilter) []manifestlist.ManifestDescriptor {
+	return nil
+}
+
 // ociManifestAdapter provides the ParsedManifest interface for the contained type.
 type ociManifestAdapter struct {
 	m *ocischema.DeserializedManifest
@@ -118,6 +127,10 @@ func (a ociManifestAdapter) BlobReferences() []distribution.Descriptor {
 }
 
 func (a ociManifestAdapter) ManifestReferences(pf PlatformFilter) []manifestlist.ManifestDescriptor {
+	return nil
+}
+
+func (a ociManifestAdapter) AcceptableAlternates(pf PlatformFilter) []manifestlist.ManifestDescriptor {
 	return nil
 }
 
@@ -143,6 +156,24 @@ func (a listManifestAdapter) ManifestReferences(pf PlatformFilter) []manifestlis
 	for _, m := range a.m.Manifests {
 		if pf.Includes(m.Platform) {
 			result = append(result, m)
+		}
+	}
+	return result
+}
+
+func (a listManifestAdapter) AcceptableAlternates(pf PlatformFilter) []manifestlist.ManifestDescriptor {
+	var result []manifestlist.ManifestDescriptor
+	for _, m := range a.ManifestReferences(pf) {
+		//If we have an application/vnd.docker.distribution.manifest.list.v2+json manifest, but the
+		//client only accepts application/vnd.docker.distribution.manifest.v2+json, in order to stay
+		//compatible with the reference implementation of Docker Hub, we serve this case by recursing
+		//into the image list and returning the linux/amd64 manifest to the client.
+		//
+		//This case is relevant for the support of tagged multi-arch images in `docker pull`.
+		if a.m.Versioned.MediaType == manifestlist.MediaTypeManifestList && m.MediaType == schema2.MediaTypeManifest {
+			if m.Platform.OS == "linux" && m.Platform.Architecture == "amd64" {
+				result = append(result, m)
+			}
 		}
 	}
 	return result

--- a/vendor/github.com/timewasted/go-accept-headers/LICENSE
+++ b/vendor/github.com/timewasted/go-accept-headers/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013, Ryan Rogers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/timewasted/go-accept-headers/README.md
+++ b/vendor/github.com/timewasted/go-accept-headers/README.md
@@ -1,0 +1,33 @@
+go-accept-headers
+=================
+
+Easily handle HTTP Accept(-Charset|-Encoding|-Language) headers in Go.
+
+This was inspired by [goautoneg](https://bitbucket.org/ww/goautoneg/).
+
+License:
+--------
+```
+Copyright (c) 2013, Ryan Rogers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/vendor/github.com/timewasted/go-accept-headers/accept.go
+++ b/vendor/github.com/timewasted/go-accept-headers/accept.go
@@ -1,0 +1,134 @@
+// Copyright 2013 Ryan Rogers. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package accept allows for easy handling of HTTP Accept headers.
+// Accept-Ranges is currently not handled.
+package accept
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Accept represents a parsed Accept(-Charset|-Encoding|-Language) header.
+type Accept struct {
+	Type, Subtype string
+	Q             float64
+	Extensions    map[string]string
+}
+
+// AcceptSlice is a slice of Accept.
+type AcceptSlice []Accept
+
+// Parse parses a HTTP Accept(-Charset|-Encoding|-Language) header and returns
+// AcceptSlice, sorted in decreasing order of preference.  If the header lists
+// multiple types that have the same level of preference (same specificity of
+// type and subtype, same qvalue, and same number of extensions), the type
+// that was listed in the header first comes first in the returned value.
+//
+// See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14 for more information.
+func Parse(header string) AcceptSlice {
+	mediaRanges := strings.Split(header, ",")
+	accepted := make(AcceptSlice, 0, len(mediaRanges))
+	for _, mediaRange := range mediaRanges {
+		rangeParams, typeSubtype, err := parseMediaRange(mediaRange)
+		if err != nil {
+			continue
+		}
+
+		accept := Accept{
+			Type:       typeSubtype[0],
+			Subtype:    typeSubtype[1],
+			Q:          1.0,
+			Extensions: make(map[string]string),
+		}
+
+		// If there is only one rangeParams, we can stop here.
+		if len(rangeParams) == 1 {
+			accepted = append(accepted, accept)
+			continue
+		}
+
+		// Validate the rangeParams.
+		validParams := true
+		for _, v := range rangeParams[1:] {
+			nameVal := strings.SplitN(v, "=", 2)
+			if len(nameVal) != 2 {
+				validParams = false
+				break
+			}
+			nameVal[1] = strings.TrimSpace(nameVal[1])
+			if name := strings.TrimSpace(nameVal[0]); name == "q" {
+				qval, err := strconv.ParseFloat(nameVal[1], 64)
+				if err != nil || qval < 0 {
+					validParams = false
+					break
+				}
+				if qval > 1.0 {
+					qval = 1.0
+				}
+				accept.Q = qval
+			} else {
+				accept.Extensions[name] = nameVal[1]
+			}
+		}
+
+		if validParams {
+			accepted = append(accepted, accept)
+		}
+	}
+
+	sort.Sort(accepted)
+	return accepted
+}
+
+// Negotiate returns a type that is accepted by both the header declaration,
+// and the list of types provided.  If no common types are found, an empty
+// string is returned.
+func Negotiate(header string, ctypes ...string) (string, error) {
+	a := Parse(header)
+	return a.Negotiate(ctypes...)
+}
+
+// Negotiate returns a type that is accepted by both the AcceptSlice, and the
+// list of types provided.  If no common types are found, an empty string is
+// returned.
+func (accept AcceptSlice) Negotiate(ctypes ...string) (string, error) {
+	if len(ctypes) == 0 {
+		return "", nil
+	}
+
+	typeSubtypes := make([][]string, 0, len(ctypes))
+	for _, v := range ctypes {
+		_, ts, err := parseMediaRange(v)
+		if err != nil {
+			return "", err
+		}
+		if ts[0] == "*" && ts[1] == "*" {
+			return v, nil
+		}
+		typeSubtypes = append(typeSubtypes, ts)
+	}
+
+	for _, a := range accept {
+		for i, ts := range typeSubtypes {
+			if ((a.Type == ts[0] || a.Type == "*") && (a.Subtype == ts[1] || a.Subtype == "*")) ||
+				(ts[0] == "*" && ts[1] == a.Subtype) ||
+				(ts[0] == a.Type && ts[1] == "*") {
+				return ctypes[i], nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// Accepts returns true if the provided type is accepted.
+func (accept AcceptSlice) Accepts(ctype string) bool {
+	t, err := accept.Negotiate(ctype)
+	if t == "" || err != nil {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/timewasted/go-accept-headers/helpers.go
+++ b/vendor/github.com/timewasted/go-accept-headers/helpers.go
@@ -1,0 +1,83 @@
+// Copyright 2013 Ryan Rogers. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package accept
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	errInvalidTypeSubtype = "accept: Invalid type '%s'."
+)
+
+// Len implements the Len() method of the Sort interface.
+func (a AcceptSlice) Len() int {
+	return len(a)
+}
+
+// Less implements the Less() method of the Sort interface.  Elements are
+// sorted in order of decreasing preference.
+func (a AcceptSlice) Less(i, j int) bool {
+	// Higher qvalues come first.
+	if a[i].Q > a[j].Q {
+		return true
+	} else if a[i].Q < a[j].Q {
+		return false
+	}
+
+	// Specific types come before wildcard types.
+	if a[i].Type != "*" && a[j].Type == "*" {
+		return true
+	} else if a[i].Type == "*" && a[j].Type != "*" {
+		return false
+	}
+
+	// Specific subtypes come before wildcard subtypes.
+	if a[i].Subtype != "*" && a[j].Subtype == "*" {
+		return true
+	} else if a[i].Subtype == "*" && a[j].Subtype != "*" {
+		return false
+	}
+
+	// A lot of extensions comes before not a lot of extensions.
+	if len(a[i].Extensions) > len(a[j].Extensions) {
+		return true
+	}
+
+	return false
+}
+
+// Swap implements the Swap() method of the Sort interface.
+func (a AcceptSlice) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+// parseMediaRange parses the provided media range, and on success returns the
+// parsed range params and type/subtype pair.
+func parseMediaRange(mediaRange string) (rangeParams, typeSubtype []string, err error) {
+	rangeParams = strings.Split(mediaRange, ";")
+	typeSubtype = strings.Split(rangeParams[0], "/")
+
+	// typeSubtype should have a length of exactly two.
+	if len(typeSubtype) > 2 {
+		err = fmt.Errorf(errInvalidTypeSubtype, rangeParams[0])
+		return
+	} else {
+		typeSubtype = append(typeSubtype, "*")
+	}
+
+	// Sanitize typeSubtype.
+	typeSubtype[0] = strings.TrimSpace(typeSubtype[0])
+	typeSubtype[1] = strings.TrimSpace(typeSubtype[1])
+	if typeSubtype[0] == "" {
+		typeSubtype[0] = "*"
+	}
+	if typeSubtype[1] == "" {
+		typeSubtype[1] = "*"
+	}
+
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,6 +180,9 @@ github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
+# github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09
+## explicit
+github.com/timewasted/go-accept-headers
 # github.com/yuin/gopher-lua v1.1.0
 ## explicit; go 1.17
 github.com/yuin/gopher-lua


### PR DESCRIPTION
The special case rules get moved into the ParsedManifest interface. According to gocognit, this reduces the complexity of handleGetOrHeadManifest() from 100 to 66. I also used the opportunity to turn an incorrect 404 response into the more appropriate 406 (Not Acceptable).

A change was needed in the RepoClient since my understanding of the Accept header was actually incorrect. It's not allowed to have multiple Accept headers. Instead, all acceptable MIME types, must be listed in a single header.