### PR TITLE
cmd/validate: allow multiple args, cache validation results

### DIFF
--- a/internal/client/validate.go
+++ b/internal/client/validate.go
@@ -30,36 +30,66 @@ import (
 // ValidationLogger can be passed to ValidateManifest, primarily to allow the
 // caller to log the progress of the validation operation.
 type ValidationLogger interface {
-	LogManifest(reference keppel.ManifestReference, level int, validationResult error)
-	LogBlob(d digest.Digest, level int, validationResult error)
+	LogManifest(reference keppel.ManifestReference, level int, validationResult error, resultFromCache bool)
+	LogBlob(d digest.Digest, level int, validationResult error, resultFromCache bool)
 }
 
 type noopLogger struct{}
 
-func (noopLogger) LogManifest(keppel.ManifestReference, int, error) {}
-func (noopLogger) LogBlob(digest.Digest, int, error)                {}
+func (noopLogger) LogManifest(keppel.ManifestReference, int, error, bool) {}
+func (noopLogger) LogBlob(digest.Digest, int, error, bool)                {}
+
+// ValidationSession holds state and caches intermediate results over the
+// course of several ValidateManifest() and ValidateBlobContents() calls.
+// The cache optimizes the validation of submanifests and blobs that are
+// referenced multiple times. The session instance should only be used for as
+// long as the caller wishes to cache validation results.
+type ValidationSession struct {
+	Logger  ValidationLogger
+	isValid map[string]bool
+}
+
+func (s *ValidationSession) applyDefaults() *ValidationSession {
+	if s == nil {
+		//This branch is taken when the caller supplied `nil` for the
+		//*ValidationSession argument in ValidateManifest or ValidateBlobContents.
+		s = &ValidationSession{}
+	}
+	if s.Logger == nil {
+		s.Logger = noopLogger{}
+	}
+	if s.isValid == nil {
+		s.isValid = make(map[string]bool)
+	}
+	return s
+}
+
+func (c *RepoClient) validationCacheKey(digestOrTagName string) string {
+	// We allow sharing a ValidationSession between multiple RepoClients to keep
+	// the API simple. But we cannot share validation results between repos: For
+	// any given digest, validation could succeed in one repo, fail in a second
+	// repo, and fail *in a different way* in the third repo. Therefore we need
+	// to store validation results keyed by digest *and* repo URL.
+	return fmt.Sprintf("%s/%s/%s", c.Host, c.RepoName, digestOrTagName)
+}
 
 // ValidateManifest fetches the given manifest from the repo and verifies that
 // it parses correctly. It also validates all references manifests and blobs
 // recursively.
-func (c *RepoClient) ValidateManifest(reference keppel.ManifestReference, logger ValidationLogger, platformFilter keppel.PlatformFilter) error {
-	cache := make(map[string]error)
-	if logger == nil {
-		logger = noopLogger{}
-	}
-	return c.doValidateManifest(reference, 0, logger, platformFilter, cache)
+func (c *RepoClient) ValidateManifest(reference keppel.ManifestReference, session *ValidationSession, platformFilter keppel.PlatformFilter) error {
+	return c.doValidateManifest(reference, 0, session.applyDefaults(), platformFilter)
 }
 
-func (c *RepoClient) doValidateManifest(reference keppel.ManifestReference, level int, logger ValidationLogger, platformFilter keppel.PlatformFilter, cache map[string]error) (returnErr error) {
-	if cachedResult, exists := cache[reference.String()]; exists {
-		logger.LogManifest(reference, level, cachedResult)
-		return cachedResult
+func (c *RepoClient) doValidateManifest(reference keppel.ManifestReference, level int, session *ValidationSession, platformFilter keppel.PlatformFilter) (returnErr error) {
+	if session.isValid[c.validationCacheKey(reference.String())] {
+		session.Logger.LogManifest(reference, level, nil, true)
+		return nil
 	}
 
 	logged := false
 	defer func() {
 		if !logged {
-			logger.LogManifest(reference, level, returnErr)
+			session.Logger.LogManifest(reference, level, returnErr, false)
 		}
 	}()
 
@@ -73,36 +103,45 @@ func (c *RepoClient) doValidateManifest(reference keppel.ManifestReference, leve
 	}
 
 	//the manifest itself looks good...
-	logger.LogManifest(keppel.ManifestReference{Digest: manifestDesc.Digest}, level, nil)
+	session.Logger.LogManifest(keppel.ManifestReference{Digest: manifestDesc.Digest}, level, nil, false)
 	logged = true
-	cache[manifestDesc.Digest.String()] = nil
 
 	//...now recurse into the manifests and blobs that it references
 	for _, desc := range manifest.BlobReferences() {
-		if cachedResult, exists := cache[desc.Digest.String()]; exists {
-			logger.LogBlob(desc.Digest, level+1, cachedResult)
-		} else {
-			err := c.ValidateBlobContents(desc.Digest)
-			logger.LogBlob(desc.Digest, level+1, err)
-			cache[desc.Digest.String()] = err
-			if err != nil {
-				return err
-			}
+		err := c.doValidateBlobContents(desc.Digest, level+1, session)
+		if err != nil {
+			return err
 		}
 	}
 	for _, desc := range manifest.ManifestReferences(platformFilter) {
-		err := c.doValidateManifest(keppel.ManifestReference{Digest: desc.Digest}, level+1, logger, platformFilter, cache)
+		err := c.doValidateManifest(keppel.ManifestReference{Digest: desc.Digest}, level+1, session, platformFilter)
 		if err != nil {
 			return err
 		}
 	}
 
+	//write validity into cache only after all references have been validated as well
+	session.isValid[c.validationCacheKey(manifestDesc.Digest.String())] = true
+	session.isValid[c.validationCacheKey(reference.String())] = true
 	return nil
 }
 
 // ValidateBlobContents fetches the given blob from the repo and verifies that
 // the contents produce the correct digest.
-func (c *RepoClient) ValidateBlobContents(blobDigest digest.Digest) (returnErr error) {
+func (c *RepoClient) ValidateBlobContents(blobDigest digest.Digest, session *ValidationSession) error {
+	return c.doValidateBlobContents(blobDigest, 0, session.applyDefaults())
+}
+
+func (c *RepoClient) doValidateBlobContents(blobDigest digest.Digest, level int, session *ValidationSession) (returnErr error) {
+	cacheKey := c.validationCacheKey(blobDigest.String())
+	if session.isValid[cacheKey] {
+		session.Logger.LogBlob(blobDigest, level, nil, true)
+		return nil
+	}
+	defer func() {
+		session.Logger.LogBlob(blobDigest, level, returnErr, false)
+	}()
+
 	readCloser, _, err := c.DownloadBlob(blobDigest)
 	if err != nil {
 		return err
@@ -125,5 +164,7 @@ func (c *RepoClient) ValidateBlobContents(blobDigest digest.Digest) (returnErr e
 	if actualDigest != blobDigest {
 		return fmt.Errorf("actual digest is %s", actualDigest)
 	}
+
+	session.isValid[cacheKey] = true
 	return nil
 }


### PR DESCRIPTION
We already had a cache for the scope of a single ValidateManifest() and its recursive subcalls, but that was not really helpful. We only stand to gain when reusing the validation results for common base layers shared by multiple images.

```
$ ./build/keppel validate alpine:latest alpine:3.17 --platform-filter '[{"os":"linux","architecture":"amd64"}]'
2023/03/17 16:38:57 INFO: interpreting alpine:latest as docker-pullable://registry-1.docker.io/alpine:latest
2023/03/17 16:39:23 INFO: manifest sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 looks good
2023/03/17 16:39:23 INFO:   manifest sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 looks good
2023/03/17 16:39:29 INFO:     blob     sha256:b2aa39c304c27b96c1fef0c06bee651ac9241d49c4fe34381cab8453f9a89c7d looks good
2023/03/17 16:39:50 INFO:     blob     sha256:63b65145d645c1250c391b2d16ebe53b3747c295ca8ba2fcb6b0cf064a4dc21c looks good
2023/03/17 16:39:50 INFO: interpreting alpine:3.17 as docker-pullable://registry-1.docker.io/alpine:3.17
2023/03/17 16:39:53 INFO: manifest sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 looks good
2023/03/17 16:39:53 INFO:   manifest sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 looks good (cached result)
```

This change is interesting when `keppel validate` is used to force replication of lots of images at once, like in the Kubernikus pipeline.

While adding in the long-lived cache in the new ValidationSession struct, I also refactored the validation functions in internal/client/ to be more internally consistent: Both ValidateManifest and ValidateBlobContents now have a public facade and a private do...() function with similar interfaces and behavior with regards to logging and caching.

I also changed the cache to only remember positive results. In all current usecases (cmd/anycastmonitor, cmd/healthmonitor, cmd/validate), negative results lead to immediate failure anyway, so we would never even attempt to hit the cache again for an object that had a negative cache result. I'm considering to add a retry loop for intermittent validation errors (esp. "currently replicating on a different worker"), and that would not play well with caching of negative validation results.