### PR TITLE
remove Trivy-specific names

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -480,8 +480,7 @@ response body like this:
       "gc_status": {
         "protected_by_recent_upload": true
       },
-      "vulnerability_status": "Clean",
-      "trivy_vulnerability_status": "Low"
+      "vulnerability_status": "Clean"
     },
     {
       "digest": "sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
@@ -489,8 +488,7 @@ response body like this:
       "size_bytes": 2791084,
       "pushed_at": 1575467980,
       "last_pulled_at": null,
-      "vulnerability_status": "High",
-      "trivy_vulnerability_status": "Critical"
+      "vulnerability_status": "High"
     }
   ]
 }
@@ -517,8 +515,6 @@ The following fields may be returned:
 | `manifests[].gc_status.relevant_policies` | array of objects or omitted | If shown, this manifest was not protected from deletion during the last GC run, but no deleting policy matched either. The array will contain the definitions of all deleting policies that could apply to this manifest, in the same format as described above for `accounts[].gc_policies[]`. |
 | `manifests[].vulnerability_status` | string | Either `Clean` (no vulnerabilities have been found in this image), `Pending` (vulnerability scanning is not enabled on this server or is still in progress for this image or has failed for this image), `Error` (vulnerability scanning failed for this image or an image referenced in this manifest), or any of the following severity strings: `Unknown`, `Low`, `Medium`, `High`, `Critical`. The full vulnerability report can be retrieved with [a separate API call](#delete-keppelv1accountsnamerepositoriesname_manifestsdigesttrivy_report). |
 | `manifests[].vulnerability_scan_error` | string | Only shown if `vulnerability_status` is `Error` or `Unsupported`. Contains the error message from Trivy that explains why this image could not be scanned (for status `Error`) or an error message from Keppel that explains why this image was not submitted to Trivy (for status `Unsupported`). When `vulnerability_status` is `Error` or `Unsupported` because scanning failed for an image referenced in this manifest, the error message will be shown on the referenced manifest instead of on this manifest. |
-| `manifests[].trivy_vulnerability_status` | string | The same value as `vulnerability_status`. This field is deprecated and will be removed shortly. |
-| `manifests[].trivy_scan_error` | string | The same value as `vulnerability_scan_error`. This field is deprecated and will be removed shortly. |
 | `truncated` | boolean | Indicates whether [marker-based pagination](#marker-based-pagination) must be used to retrieve the rest of the result. |
 
 ## DELETE /keppel/v1/accounts/:name/repositories/:name/\_manifests/:digest
@@ -527,6 +523,8 @@ Deletes the specified manifest and all tags pointing to it. Returns 204 (No Cont
 The digest that identifies the manifest must be that manifest's canonical digest, otherwise 404 is returned.
 
 ## GET /keppel/v1/accounts/:name/repositories/:name/\_manifests/:digest/vulnerability\_report
+
+**Deprecated:** Will be removed in a few weeks (along with the entire Clair integration).
 
 Retrieves the vulnerability report for the specified manifest. If the manifest exists and a vulnerability report is available for it, returns 200 (OK) and a JSON response body containing the vulnerability report in the [format defined by Clair](https://quay.github.io/clair/reference/api.html#schemavulnerabilityreport).
 

--- a/internal/api/keppel/manifests.go
+++ b/internal/api/keppel/manifests.go
@@ -49,9 +49,7 @@ type Manifest struct {
 	LabelsJSON                    json.RawMessage           `json:"labels,omitempty"`
 	GCStatusJSON                  json.RawMessage           `json:"gc_status,omitempty"`
 	VulnerabilityStatus           clair.VulnerabilityStatus `json:"vulnerability_status"`
-	TrivyVulnerabilityStatus      clair.VulnerabilityStatus `json:"trivy_vulnerability_status"`
 	VulnerabilityScanErrorMessage string                    `json:"vulnerability_scan_error,omitempty"`
-	TrivyScanErrorMessage         string                    `json:"trivy_scan_error,omitempty"`
 	MinLayerCreatedAt             *int64                    `json:"min_layer_created_at"`
 	MaxLayerCreatedAt             *int64                    `json:"max_layer_created_at"`
 }
@@ -166,9 +164,7 @@ func (a *API) handleGetManifests(w http.ResponseWriter, r *http.Request) {
 			LabelsJSON:                    json.RawMessage(dbManifest.LabelsJSON),
 			GCStatusJSON:                  json.RawMessage(dbManifest.GCStatusJSON),
 			VulnerabilityStatus:           securityInfo.VulnerabilityStatus,
-			TrivyVulnerabilityStatus:      securityInfo.VulnerabilityStatus,
 			VulnerabilityScanErrorMessage: securityInfo.Message,
-			TrivyScanErrorMessage:         securityInfo.Message,
 			MinLayerCreatedAt:             keppel.MaybeTimeToUnix(dbManifest.MinLayerCreatedAt),
 			MaxLayerCreatedAt:             keppel.MaybeTimeToUnix(dbManifest.MaxLayerCreatedAt),
 		})

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -176,17 +176,16 @@ func TestManifestsAPI(t *testing.T) {
 		renderedManifests := make([]assert.JSONObject, 10)
 		for idx := 1; idx <= 10; idx++ {
 			renderedManifests[idx-1] = assert.JSONObject{
-				"digest":                     deterministicDummyDigest(10 + idx),
-				"media_type":                 schema2.MediaTypeManifest,
-				"size_bytes":                 uint64(1000 * idx),
-				"pushed_at":                  int64(1000 * (10 + idx)),
-				"last_pulled_at":             nil,
-				"labels":                     assert.JSONObject{"foo": "is there"},
-				"gc_status":                  assert.JSONObject{"protected_by_recent_upload": true},
-				"vulnerability_status":       string(deterministicDummyVulnStatus(idx)),
-				"trivy_vulnerability_status": string(deterministicDummyVulnStatus(idx)),
-				"min_layer_created_at":       20001,
-				"max_layer_created_at":       20002,
+				"digest":               deterministicDummyDigest(10 + idx),
+				"media_type":           schema2.MediaTypeManifest,
+				"size_bytes":           uint64(1000 * idx),
+				"pushed_at":            int64(1000 * (10 + idx)),
+				"last_pulled_at":       nil,
+				"labels":               assert.JSONObject{"foo": "is there"},
+				"gc_status":            assert.JSONObject{"protected_by_recent_upload": true},
+				"vulnerability_status": string(deterministicDummyVulnStatus(idx)),
+				"min_layer_created_at": 20001,
+				"max_layer_created_at": 20002,
 			}
 		}
 		renderedManifests[0]["last_pulled_at"] = 11100

--- a/internal/api/registry/manifests.go
+++ b/internal/api/registry/manifests.go
@@ -176,7 +176,6 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Docker-Content-Digest", dbManifest.Digest.String())
 	if securityInfo != nil {
 		w.Header().Set("X-Keppel-Vulnerability-Status", string(securityInfo.VulnerabilityStatus))
-		w.Header().Set("X-Keppel-Trivy-Vulnerability-Status", string(securityInfo.VulnerabilityStatus))
 	}
 	if dbManifest.MinLayerCreatedAt != nil {
 		w.Header().Set("X-Keppel-Min-Layer-Created-At", timeToString(*dbManifest.MinLayerCreatedAt))

--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -313,11 +313,10 @@ func TestImageManifestLifecycle(t *testing.T) {
 					Header:       map[string]string{"Authorization": "Bearer " + readOnlyToken},
 					ExpectStatus: http.StatusOK,
 					ExpectHeader: map[string]string{
-						test.VersionHeaderKey:                 test.VersionHeaderValue,
-						"X-Keppel-Vulnerability-Status":       string(clair.CleanSeverity),
-						"X-Keppel-Trivy-Vulnerability-Status": string(clair.CleanSeverity),
-						"X-Keppel-Min-Layer-Created-At":       "23",
-						"X-Keppel-Max-Layer-Created-At":       "42",
+						test.VersionHeaderKey:           test.VersionHeaderValue,
+						"X-Keppel-Vulnerability-Status": string(clair.CleanSeverity),
+						"X-Keppel-Min-Layer-Created-At": "23",
+						"X-Keppel-Max-Layer-Created-At": "42",
 					},
 				}.Check(t, h)
 			}


### PR DESCRIPTION
All usage of these names in our internal applications (Gatekeeper and Elektra) has been removed. Customers likely did not use these names because they existed for a short amount of time only and were not publicly announced.