### PR TITLE
trivyproxy: transform trivy log lines into a single line

### DIFF
--- a/cmd/trivyproxy/main.go
+++ b/cmd/trivyproxy/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/sapcc/keppel/internal/keppel"
@@ -118,7 +119,8 @@ func (a *API) proxyToTrivy(w http.ResponseWriter, r *http.Request) {
 
 	stdout, stderr, err := a.runTrivy(r.Context(), imageURL, format, keppelToken)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("trivy: %s:\n%s", err, stderr), http.StatusInternalServerError)
+		cleanedErr := strings.ReplaceAll(strings.TrimSpace(string(stderr)), "\n", " ")
+		http.Error(w, fmt.Sprintf("trivy: %s: %s", err, cleanedErr), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
The following now gets transformed into one line:
```
ERROR: scan error 6af3a3d97a42b331f5fca50a653bbc4bf1d61846ff00cbceeac17dae1b482b1a: trivy proxy did not return 200: 500 trivy: exit status 1:
INFO    Vulnerability scanning is enabled
FATAL   image scan error: scan error: unable to initialize a scanner: unable to initialize the remote docker scanner: 4 errors occurred:
        * unable to inspect the image (keppel.eu-de-1.cloud.sap/someone/something/something@sha256:4719d476278718e84c148d5845d856781afaa17514daf851d894739bad76e660): Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
        * Get "https://keppel.eu-de-1.cloud.sap/v2/": dial tcp 10.0.0.0:443: connect: connection refused
```

```
trivy: ABC: ERROR: scan error 6af3a3d97a42b331f5fca50a653bbc4bf1d61846ff00cbceeac17dae1b482b1a: trivy proxy did not return 200: 500 trivy: exit status 1: INFO    Vulnerability scanning is enabled FATAL   image scan error: scan error: unable to initialize a scanner: unable to initialize the remote docker scanner: 4 errors occurred:         * unable to inspect the image (keppel.eu-de-1.cloud.sap/someone/something/something@sha256:4719d476278718e84c148d5845d856781afaa17514daf851d894739bad76e660): Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?         * Get "https://keppel.eu-de-1.cloud.sap/v2/": dial tcp 10.0.0.0:443: connect: connection refused
```

https://goplay.tools/snippet/TN4zXt72mzC