### PR TITLE
Add context to all database calls

### DIFF
--- a/cmd/api/gui_redirect.go
+++ b/cmd/api/gui_redirect.go
@@ -69,7 +69,7 @@ func (g *guiRedirecter) tryRedirectToGUI(w http.ResponseWriter, r *http.Request)
 
 	//is it publicly readable?
 	var policies []keppel.RBACPolicy
-	_, err = g.db.Select(&policies,
+	_, err = g.db.WithContext(r.Context()).Select(&policies,
 		"SELECT * FROM rbac_policies WHERE can_anon_pull AND account_name = $1",
 		account.Name,
 	)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -64,10 +64,11 @@ func run(cmd *cobra.Command, args []string) {
 	keppel.SetTaskName("api")
 
 	cfg := keppel.ParseConfiguration()
+	ctx := httpext.ContextWithSIGINT(context.Background(), 10*time.Second)
 	auditor := keppel.InitAuditTrail()
 
 	db := must.Return(keppel.InitDB(cfg.DatabaseURL))
-	must.Succeed(setupDBIfRequested(db))
+	must.Succeed(setupDBIfRequested(ctx, db))
 	rc := must.Return(initRedis())
 	ad := must.Return(keppel.NewAuthDriver(osext.MustGetenv("KEPPEL_DRIVER_AUTH"), rc))
 	fd := must.Return(keppel.NewFederationDriver(osext.MustGetenv("KEPPEL_DRIVER_FEDERATION"), ad, cfg))
@@ -83,7 +84,6 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	//start background goroutines
-	ctx := httpext.ContextWithSIGINT(context.Background(), 10*time.Second)
 	runPeering(ctx, cfg, db)
 
 	//wire up HTTP handlers
@@ -131,7 +131,9 @@ func initRedis() (*redis.Client, error) {
 	return redis.NewClient(opts), nil
 }
 
-func setupDBIfRequested(db *keppel.DB) error {
+func setupDBIfRequested(ctx context.Context, kdb *keppel.DB) error {
+	db := kdb.WithContext(ctx)
+
 	//This method performs specialized first-time setup for conformance test
 	//scenarios where we always start with a fresh empty database.
 	//

--- a/cmd/api/peering.go
+++ b/cmd/api/peering.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sapcc/keppel/internal/tasks"
 )
 
-func runPeering(ctx context.Context, cfg keppel.Configuration, db *keppel.DB) {
+func runPeering(ctx context.Context, cfg keppel.Configuration, kdb *keppel.DB) {
 	isPeerHostName := make(map[string]bool)
 	for _, hostName := range strings.Split(os.Getenv("KEPPEL_PEERS"), ",") {
 		hostName = strings.TrimSpace(hostName)
@@ -47,6 +47,8 @@ func runPeering(ctx context.Context, cfg keppel.Configuration, db *keppel.DB) {
 		//nothing to do
 		return
 	}
+
+	db := kdb.WithContext(ctx)
 
 	//add missing entries to `peers` table
 	for peerHostName := range isPeerHostName {
@@ -74,7 +76,7 @@ func runPeering(ctx context.Context, cfg keppel.Configuration, db *keppel.DB) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				err := tryIssueNewPasswordForPeer(ctx, cfg, db)
+				err := tryIssueNewPasswordForPeer(ctx, cfg, kdb)
 				if err != nil {
 					logg.Error("cannot issue new peer password: " + err.Error())
 				}

--- a/internal/api/auth/peering.go
+++ b/internal/api/auth/peering.go
@@ -58,9 +58,10 @@ func (a *API) handlePostPeering(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	db := a.db.WithContext(r.Context())
 	//do we even know that guy? :)
 	var peer keppel.Peer
-	err = a.db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, req.PeerHostName)
+	err = db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, req.PeerHostName)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "unknown issuer", http.StatusBadRequest)
 		return
@@ -89,7 +90,7 @@ func (a *API) handlePostPeering(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//update database
-	_, err = a.db.Exec(
+	_, err = db.Exec(
 		`UPDATE peers SET our_password = $1 WHERE hostname = $2`,
 		req.Password, req.PeerHostName,
 	)

--- a/internal/api/auth/peering_test.go
+++ b/internal/api/auth/peering_test.go
@@ -19,6 +19,7 @@
 package authapi_test
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -38,7 +39,7 @@ func TestPeeringAPI(t *testing.T) {
 
 		//set up peer.example.org as a peer of us, otherwise we will reject peering
 		//attempts from that source
-		err := s.DB.Insert(&keppel.Peer{HostName: "peer.example.org"})
+		err := s.DB.WithContext(context.TODO()).Insert(&keppel.Peer{HostName: "peer.example.org"})
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -57,6 +57,7 @@ func deterministicDummyVulnStatus(counter int) trivy.VulnerabilityStatus {
 
 func TestManifestsAPI(t *testing.T) {
 	test.WithRoundTripper(func(tt *test.RoundTripper) {
+		_ = tt
 		s := test.NewSetup(t, test.WithKeppelAPI, test.WithTrivyDouble)
 		h := s.Handler
 
@@ -419,7 +420,7 @@ func TestManifestsAPI(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		_, err = s.DB.Exec(
+		_, err = s.DB.WithContext(s.Ctx).Exec(
 			`INSERT INTO manifest_blob_refs (repo_id, digest, blob_id) VALUES ($1, $2, $3)`,
 			repos[0].ID, test.DeterministicDummyDigest(12), dummyBlob.ID,
 		)
@@ -488,6 +489,7 @@ func TestRateLimitsTrivyReport(t *testing.T) {
 	rle := &keppel.RateLimitEngine{Driver: rld, Client: nil}
 
 	test.WithRoundTripper(func(tt *test.RoundTripper) {
+		_ = tt
 		s := test.NewSetup(t,
 			test.WithKeppelAPI,
 			test.WithTrivyDouble,

--- a/internal/api/keppel/peers.go
+++ b/internal/api/keppel/peers.go
@@ -64,7 +64,7 @@ func (a *API) handleGetPeers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var peers []keppel.Peer
-	_, err := a.db.Select(&peers, `SELECT * FROM peers ORDER BY hostname`)
+	_, err := a.db.WithContext(r.Context()).Select(&peers, `SELECT * FROM peers ORDER BY hostname`)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/internal/api/keppel/peers_test.go
+++ b/internal/api/keppel/peers_test.go
@@ -19,6 +19,7 @@
 package keppelv1_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestPeersAPI(t *testing.T) {
 		{"hostname": "keppel.example.org"},
 	}
 	for _, peer := range expectedPeers {
-		err := s.DB.Insert(&keppel.Peer{HostName: peer["hostname"].(string)})
+		err := s.DB.WithContext(context.TODO()).Insert(&keppel.Peer{HostName: peer["hostname"].(string)})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/api/keppel/repos_test.go
+++ b/internal/api/keppel/repos_test.go
@@ -19,6 +19,7 @@
 package keppelv1_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -34,7 +35,7 @@ import (
 
 func mustInsert(t *testing.T, db *keppel.DB, obj interface{}) {
 	t.Helper()
-	err := db.Insert(obj)
+	err := db.WithContext(context.TODO()).Insert(obj)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -49,7 +50,7 @@ func mustDo(t *testing.T, err error) {
 
 func mustExec(t *testing.T, db *keppel.DB, query string, args ...interface{}) {
 	t.Helper()
-	_, err := db.Exec(query, args...)
+	_, err := db.WithContext(context.TODO()).Exec(query, args...)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/internal/api/peer/api.go
+++ b/internal/api/peer/api.go
@@ -68,7 +68,7 @@ func (a *API) authenticateRequest(w http.ResponseWriter, r *http.Request) *keppe
 	}
 
 	var peer keppel.Peer
-	err := a.db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, uid.PeerHostName)
+	err := a.db.WithContext(r.Context()).SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, uid.PeerHostName)
 	if err != nil {
 		keppel.AsRegistryV2Error(err).WriteAsTextTo(w)
 		return nil

--- a/internal/api/registry/blobs.go
+++ b/internal/api/registry/blobs.go
@@ -209,8 +209,9 @@ func (a *API) handleDeleteBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	db := a.db.WithContext(r.Context())
 	//can only delete blob mount if it's not used by any manifests
-	refCount, err := a.db.SelectInt(`SELECT COUNT(*) FROM manifest_blob_refs WHERE blob_id = $1 AND repo_id = $2`, blob.ID, repo.ID)
+	refCount, err := db.SelectInt(`SELECT COUNT(*) FROM manifest_blob_refs WHERE blob_id = $1 AND repo_id = $2`, blob.ID, repo.ID)
 	if respondWithError(w, r, err) {
 		return
 	}
@@ -225,7 +226,7 @@ func (a *API) handleDeleteBlob(w http.ResponseWriter, r *http.Request) {
 	//unmount the blob from this particular repo (if it is mounted in other
 	//repos, it will still be accessible there; otherwise keppel-janitor will
 	//clean it up soon)
-	_, err = a.db.Exec(`DELETE FROM blob_mounts WHERE blob_id = $1 AND repo_id = $2`, blob.ID, repo.ID)
+	_, err = db.Exec(`DELETE FROM blob_mounts WHERE blob_id = $1 AND repo_id = $2`, blob.ID, repo.ID)
 	if respondWithError(w, r, err) {
 		return
 	}

--- a/internal/api/registry/blobs_test.go
+++ b/internal/api/registry/blobs_test.go
@@ -182,7 +182,8 @@ func TestBlobMonolithicUpload(t *testing.T) {
 				"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`,
 			},
 		}.Check(t, h)
-		_, err := s.DB.Exec(
+		db := s.DB.WithContext(s.Ctx)
+		_, err := db.Exec(
 			`INSERT INTO rbac_policies (account_name, match_repository, match_username, can_anon_pull) VALUES ('test1', 'foo', '', TRUE)`,
 		)
 		if err != nil {
@@ -195,7 +196,7 @@ func TestBlobMonolithicUpload(t *testing.T) {
 			ExpectHeader: test.VersionHeader,
 			ExpectBody:   assert.ByteData(blob.Contents),
 		}.Check(t, h)
-		_, err = s.DB.Exec(`DELETE FROM rbac_policies`)
+		_, err = db.Exec(`DELETE FROM rbac_policies`)
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/registry/catalog_test.go
+++ b/internal/api/registry/catalog_test.go
@@ -19,6 +19,7 @@
 package registryv2_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -32,10 +33,11 @@ import (
 
 func TestCatalogEndpoint(t *testing.T) {
 	s := test.NewSetup(t, test.WithAnycast(true))
+	db := s.DB.WithContext(context.TODO())
 
 	//set up dummy accounts for testing
 	for idx := 1; idx <= 3; idx++ {
-		err := s.DB.Insert(&keppel.Account{
+		err := db.Insert(&keppel.Account{
 			Name:                     fmt.Sprintf("test%d", idx),
 			AuthTenantID:             authTenantID,
 			GCPoliciesJSON:           "[]",
@@ -46,7 +48,7 @@ func TestCatalogEndpoint(t *testing.T) {
 		}
 
 		for _, repoName := range []string{"foo", "bar", "qux"} {
-			err := s.DB.Insert(&keppel.Repository{
+			err := db.Insert(&keppel.Repository{
 				Name:        repoName,
 				AccountName: fmt.Sprintf("test%d", idx),
 			})

--- a/internal/auth/request.go
+++ b/internal/auth/request.go
@@ -237,7 +237,7 @@ func checkBasicAuth(ctx context.Context, authHeader string, ad keppel.AuthDriver
 	//recognize peer credentials
 	if strings.HasPrefix(userName, "replication@") {
 		peerHostName := strings.TrimPrefix(userName, "replication@")
-		peer, err := checkPeerCredentials(db, peerHostName, password)
+		peer, err := checkPeerCredentials(ctx, db, peerHostName, password)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/auth/uid_peer.go
+++ b/internal/auth/uid_peer.go
@@ -20,6 +20,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/sapcc/go-bits/audittools"
@@ -80,7 +81,7 @@ func (uid *PeerUserIdentity) DeserializeFromJSON(in []byte, _ keppel.AuthDriver)
 // Returns whether the given peer credentials are valid. On success, the Peer
 // instance is returned. If the credentials do not match, (nil, nil) is
 // returned. Error values are only returned for unexpected failures.
-func checkPeerCredentials(db *keppel.DB, peerHostName, password string) (*keppel.Peer, error) {
+func checkPeerCredentials(ctx context.Context, db *keppel.DB, peerHostName, password string) (*keppel.Peer, error) {
 	//NOTE: This function is technically vulnerable to a timing side-channel attack.
 	//It returns much faster if `peerHostName` refers to a peer that does not exist,
 	//so an attacker could use it to infer which peers exist. I don't consider
@@ -88,7 +89,7 @@ func checkPeerCredentials(db *keppel.DB, peerHostName, password string) (*keppel
 	//In fact, it's literally exposed in an API call in the Keppel API.
 
 	var peer keppel.Peer
-	err := db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, peerHostName)
+	err := db.WithContext(ctx).SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, peerHostName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -20,6 +20,8 @@
 package keppel
 
 import (
+	"context"
+	"database/sql"
 	"net/url"
 
 	"github.com/go-gorp/gorp/v3"
@@ -278,16 +280,93 @@ var sqlMigrations = map[string]string{
 	`,
 }
 
-// DB adds convenience functions on top of gorp.DbMap.
+// DB adds convenience functions on top of gorp.DbMap and reimplements the SqlExecutor interface to enforce context'ed function calls
 type DB struct {
 	gorp.DbMap
 }
+
+// Deprecated: use db.withContext!
+func (db *DB) Get(i interface{}, keys ...interface{}) (interface{}, error) {
+	return db.WithContext(context.TODO()).Get(i, keys)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) Insert(list ...interface{}) error {
+	return db.WithContext(context.TODO()).Insert(list...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) Update(list ...interface{}) (int64, error) {
+	return db.WithContext(context.TODO()).Update(list...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) Delete(list ...interface{}) (int64, error) {
+	return db.WithContext(context.TODO()).Delete(list...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return db.WithContext(context.TODO()).Exec(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) Select(i interface{}, query string, args ...interface{}) ([]interface{}, error) {
+	return db.WithContext(context.TODO()).Select(i, query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectInt(query string, args ...interface{}) (int64, error) {
+	return db.WithContext(context.TODO()).SelectInt(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectNullInt(query string, args ...interface{}) (sql.NullInt64, error) {
+	return db.WithContext(context.TODO()).SelectNullInt(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectFloat(query string, args ...interface{}) (float64, error) {
+	return db.WithContext(context.TODO()).SelectFloat(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectNullFloat(query string, args ...interface{}) (sql.NullFloat64, error) {
+	return db.WithContext(context.TODO()).SelectNullFloat(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectStr(query string, args ...interface{}) (string, error) {
+	return db.WithContext(context.TODO()).SelectStr(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectNullStr(query string, args ...interface{}) (sql.NullString, error) {
+	return db.WithContext(context.TODO()).SelectNullStr(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) SelectOne(holder interface{}, query string, args ...interface{}) error {
+	return db.WithContext(context.TODO()).SelectOne(holder, query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return db.WithContext(context.TODO()).Query(query, args...)
+}
+
+// Deprecated: use db.withContext!
+func (db *DB) QueryRow(query string, args ...interface{}) *sql.Row {
+	return db.WithContext(context.TODO()).QueryRow(query, args...)
+}
+
+// convience functions
 
 // SelectBool is analogous to the other SelectFoo() functions from gorp.DbMap
 // like SelectFloat, SelectInt, SelectStr, etc.
 func (db *DB) SelectBool(query string, args ...interface{}) (bool, error) {
 	var result bool
-	err := db.QueryRow(query, args...).Scan(&result)
+	err := db.WithContext(context.TODO()).QueryRow(query, args...).Scan(&result)
 	return result, err
 }
 

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -20,6 +20,7 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -137,7 +138,7 @@ func (p *Processor) checkQuotaForManifestPush(account keppel.Account) error {
 
 // Takes a repo in a replica account and returns a RepoClient for accessing its
 // the upstream repo in the corresponding primary account.
-func (p *Processor) getRepoClientForUpstream(account keppel.Account, repo keppel.Repository) (*client.RepoClient, error) {
+func (p *Processor) getRepoClientForUpstream(ctx context.Context, account keppel.Account, repo keppel.Repository) (*client.RepoClient, error) {
 	//use cached client if possible (this one probably already contains a valid
 	//pull token)
 	if c, ok := p.repoClients[repo.FullName()]; ok {
@@ -146,7 +147,7 @@ func (p *Processor) getRepoClientForUpstream(account keppel.Account, repo keppel
 
 	if account.UpstreamPeerHostName != "" {
 		var peer keppel.Peer
-		err := p.db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, account.UpstreamPeerHostName)
+		err := p.db.WithContext(ctx).SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, account.UpstreamPeerHostName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tasks/accounts.go
+++ b/internal/tasks/accounts.go
@@ -56,8 +56,8 @@ func (j *Janitor) AccountFederationAnnouncementJob(registerer prometheus.Registe
 				Help: "Counter for announcements of existing accounts to the federation driver.",
 			},
 		},
-		DiscoverTask: func(_ context.Context, _ prometheus.Labels) (account keppel.Account, err error) {
-			err = j.db.SelectOne(&account, accountAnnouncementSearchQuery, j.timeNow())
+		DiscoverTask: func(ctx context.Context, _ prometheus.Labels) (account keppel.Account, err error) {
+			err = j.db.WithContext(ctx).SelectOne(&account, accountAnnouncementSearchQuery, j.timeNow())
 			return account, err
 		},
 		ProcessTask: j.announceAccountToFederation,
@@ -72,6 +72,6 @@ func (j *Janitor) announceAccountToFederation(ctx context.Context, account keppe
 		logg.Error("cannot announce account %q to federation: %s", account.Name, err.Error())
 	}
 
-	_, err = j.db.Exec(accountAnnouncementDoneQuery, account.Name, j.timeNow().Add(j.addJitter(1*time.Hour)))
+	_, err = j.db.WithContext(ctx).Exec(accountAnnouncementDoneQuery, account.Name, j.timeNow().Add(j.addJitter(1*time.Hour)))
 	return err
 }

--- a/internal/tasks/accounts_test.go
+++ b/internal/tasks/accounts_test.go
@@ -33,9 +33,10 @@ func TestAnnounceAccountsToFederation(t *testing.T) {
 	j, s := setup(t)
 	s.FD.RecordedAccounts = nil
 	s.Clock.StepBy(1 * time.Hour)
+	db := s.DB.WithContext(s.Ctx)
 
 	var account1 keppel.Account
-	mustDo(t, s.DB.SelectOne(&account1, `SELECT * FROM accounts`))
+	mustDo(t, db.SelectOne(&account1, `SELECT * FROM accounts`))
 
 	accountJob := j.AccountFederationAnnouncementJob(s.Registry)
 
@@ -49,7 +50,7 @@ func TestAnnounceAccountsToFederation(t *testing.T) {
 	//setup another account; only that one should need announcing initially
 	s.Clock.StepBy(5 * time.Minute)
 	account2 := keppel.Account{Name: "test2", AuthTenantID: "test2authtenant", GCPoliciesJSON: "[]"}
-	mustDo(t, s.DB.Insert(&account2))
+	mustDo(t, db.Insert(&account2))
 	expectSuccess(t, accountJob.ProcessOne(s.Ctx))
 	expectAccountsAnnouncedJustNow(t, s, account2)
 	expectError(t, sql.ErrNoRows.Error(), accountJob.ProcessOne(s.Ctx))

--- a/internal/tasks/blobs.go
+++ b/internal/tasks/blobs.go
@@ -82,36 +82,38 @@ func (j *Janitor) BlobSweepJob(registerer prometheus.Registerer) jobloop.Job { /
 				Help: "Counter for garbage collections on blobs in an account.",
 			},
 		},
-		DiscoverTask: func(_ context.Context, _ prometheus.Labels) (account keppel.Account, err error) {
-			err = j.db.SelectOne(&account, blobSweepSearchQuery, j.timeNow())
+		DiscoverTask: func(ctx context.Context, _ prometheus.Labels) (account keppel.Account, err error) {
+			err = j.db.WithContext(ctx).SelectOne(&account, blobSweepSearchQuery, j.timeNow())
 			return account, err
 		},
 		ProcessTask: j.sweepBlobsInRepo,
 	}).Setup(registerer)
 }
 
-func (j *Janitor) sweepBlobsInRepo(_ context.Context, account keppel.Account, _ prometheus.Labels) error {
+func (j *Janitor) sweepBlobsInRepo(ctx context.Context, account keppel.Account, _ prometheus.Labels) error {
 	//allow next pass in 1 hour to delete the newly marked blob mounts, but use a
 	//slighly earlier cut-off time to account for the marking taking some time
 	canBeDeletedAt := j.timeNow().Add(30 * time.Minute)
+
+	db := j.db.WithContext(ctx)
 
 	//NOTE: We don't need to pack the following steps in a single transaction, so
 	//we won't. The mark and unmark are obviously safe since they only update
 	//metadata, and the sweep only touches stuff that was marked in the
 	//*previous* sweep. The only thing that we need to make sure is that unmark
 	//is strictly ordered before sweep.
-	_, err := j.db.Exec(blobMarkQuery, account.Name, canBeDeletedAt)
+	_, err := db.Exec(blobMarkQuery, account.Name, canBeDeletedAt)
 	if err != nil {
 		return err
 	}
-	_, err = j.db.Exec(blobUnmarkQuery, account.Name)
+	_, err = db.Exec(blobUnmarkQuery, account.Name)
 	if err != nil {
 		return err
 	}
 
 	//select blobs for deletion that were marked in the last run
 	var blobs []keppel.Blob
-	_, err = j.db.Select(&blobs, blobSelectMarkedQuery, account.Name, j.timeNow())
+	_, err = db.Select(&blobs, blobSelectMarkedQuery, account.Name, j.timeNow())
 	if err != nil {
 		return err
 	}
@@ -133,7 +135,7 @@ func (j *Janitor) sweepBlobsInRepo(_ context.Context, account keppel.Account, _ 
 	}
 	for _, blob := range blobs {
 		//without transaction: we need this committed right now
-		_, err := j.db.Delete(&blob) //nolint:gosec // Delete is not holding onto the pointer after it returns
+		_, err := db.Delete(&blob) //nolint:gosec // Delete is not holding onto the pointer after it returns
 		if err != nil {
 			return err
 		}
@@ -145,7 +147,7 @@ func (j *Janitor) sweepBlobsInRepo(_ context.Context, account keppel.Account, _ 
 		}
 	}
 
-	_, err = j.db.Exec(blobSweepDoneQuery, account.Name, j.timeNow().Add(j.addJitter(1*time.Hour)))
+	_, err = db.Exec(blobSweepDoneQuery, account.Name, j.timeNow().Add(j.addJitter(1*time.Hour)))
 	return err
 }
 
@@ -169,29 +171,30 @@ func (j *Janitor) BlobValidationJob(registerer prometheus.Registerer) jobloop.Jo
 				Help: "Counter for blob validations.",
 			},
 		},
-		DiscoverTask: func(_ context.Context, _ prometheus.Labels) (blob keppel.Blob, err error) {
+		DiscoverTask: func(ctx context.Context, _ prometheus.Labels) (blob keppel.Blob, err error) {
 			//find blob: validate once every 7 days, but recheck after 10 minutes if validation failed
 			maxSuccessfulValidatedAt := j.timeNow().Add(-7 * 24 * time.Hour)
 			maxFailedValidatedAt := j.timeNow().Add(-10 * time.Minute)
-			err = j.db.SelectOne(&blob, validateBlobSearchQuery, maxSuccessfulValidatedAt, maxFailedValidatedAt)
+			err = j.db.WithContext(ctx).SelectOne(&blob, validateBlobSearchQuery, maxSuccessfulValidatedAt, maxFailedValidatedAt)
 			return blob, err
 		},
 		ProcessTask: j.validateBlob,
 	}).Setup(registerer)
 }
 
-func (j *Janitor) validateBlob(_ context.Context, blob keppel.Blob, _ prometheus.Labels) error {
+func (j *Janitor) validateBlob(ctx context.Context, blob keppel.Blob, _ prometheus.Labels) error {
 	//find corresponding account
 	account, err := keppel.FindAccount(j.db, blob.AccountName)
 	if err != nil {
 		return fmt.Errorf("cannot find account for manifest %s/%s: %s", blob.AccountName, blob.Digest, err.Error())
 	}
 
+	db := j.db.WithContext(ctx)
 	//perform validation
 	err = j.processor().ValidateExistingBlob(*account, blob)
 	if err == nil {
 		//update `validated_at` and reset error message
-		_, err := j.db.Exec(`
+		_, err := db.Exec(`
 			UPDATE blobs SET validated_at = $1, validation_error_message = ''
 			 WHERE account_name = $2 AND digest = $3`,
 			j.timeNow(), account.Name, blob.Digest,
@@ -203,7 +206,7 @@ func (j *Janitor) validateBlob(_ context.Context, blob keppel.Blob, _ prometheus
 		//attempt to log the error message, and also update the `validated_at`
 		//timestamp to ensure that the BlobValidationJob loop does not get stuck
 		//on this one
-		_, updateErr := j.db.Exec(`
+		_, updateErr := db.Exec(`
 			UPDATE blobs SET validated_at = $1, validation_error_message = $2
 			 WHERE account_name = $3 AND digest = $4`,
 			j.timeNow(), err.Error(), account.Name, blob.Digest,

--- a/internal/tasks/manifests_test.go
+++ b/internal/tasks/manifests_test.go
@@ -146,7 +146,8 @@ func TestManifestValidationJobError(t *testing.T) {
 	//manually since the MustUpload functions care about uploading stuff intact)
 	s.Clock.StepBy(1 * time.Hour)
 	image := test.GenerateImage( /* no layers */ )
-	mustDo(t, s.DB.Insert(&keppel.Manifest{
+	db := s.DB.WithContext(s.Ctx)
+	mustDo(t, db.Insert(&keppel.Manifest{
 		RepositoryID: 1,
 		Digest:       image.Manifest.Digest,
 		MediaType:    image.Manifest.MediaType,
@@ -154,12 +155,12 @@ func TestManifestValidationJobError(t *testing.T) {
 		PushedAt:     s.Clock.Now(),
 		ValidatedAt:  s.Clock.Now(),
 	}))
-	mustDo(t, s.DB.Insert(&keppel.ManifestContent{
+	mustDo(t, db.Insert(&keppel.ManifestContent{
 		RepositoryID: 1,
 		Digest:       image.Manifest.Digest.String(),
 		Content:      image.Manifest.Contents,
 	}))
-	mustDo(t, s.DB.Insert(&keppel.TrivySecurityInfo{
+	mustDo(t, db.Insert(&keppel.TrivySecurityInfo{
 		RepositoryID:        1,
 		Digest:              image.Manifest.Digest,
 		NextCheckAt:         time.Unix(0, 0),

--- a/internal/tasks/peering.go
+++ b/internal/tasks/peering.go
@@ -85,7 +85,7 @@ func IssueNewPasswordForPeer(ctx context.Context, cfg keppel.Configuration, db *
 		if resultErr == nil {
 			return
 		}
-		_, err := db.Exec(`
+		_, err := db.WithContext(ctx).Exec(`
 			UPDATE peers SET
 				their_current_password_hash = $1,
 				their_previous_password_hash = $2,

--- a/internal/tasks/peering_test.go
+++ b/internal/tasks/peering_test.go
@@ -19,6 +19,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -38,7 +39,7 @@ func TestIssueNewPasswordForPeer(t *testing.T) {
 		s := test.NewSetup(t)
 
 		//setup a peer
-		mustDo(t, s.DB.Insert(&keppel.Peer{HostName: "peer.example.org"}))
+		mustDo(t, s.DB.WithContext(s.Ctx).Insert(&keppel.Peer{HostName: "peer.example.org"}))
 
 		//setup a mock for the peer that just swallows any password that we give to it
 		mockPeer := mockPeerReceivingPassword{}
@@ -114,7 +115,7 @@ func TestIssueNewPasswordForPeer(t *testing.T) {
 func getPeerFromDB(t *testing.T, db *keppel.DB) keppel.Peer {
 	t.Helper()
 	var peer keppel.Peer
-	err := db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, "peer.example.org")
+	err := db.WithContext(context.TODO()).SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, "peer.example.org")
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/internal/tasks/storage_test.go
+++ b/internal/tasks/storage_test.go
@@ -92,7 +92,8 @@ func TestSweepStorageBlobs(t *testing.T) {
 	sizeBytes := uint64(len(testBlob3.Contents))
 	mustDo(t, s.SD.AppendToBlob(account, storageID, 1, &sizeBytes, bytes.NewReader(testBlob3.Contents)))
 	//^ but no FinalizeBlob() since we're still uploading!
-	mustDo(t, s.DB.Insert(&keppel.Upload{
+	db := s.DB.WithContext(s.Ctx)
+	mustDo(t, db.Insert(&keppel.Upload{
 		RepositoryID: 1,
 		UUID:         "a29d525c-2273-44ba-83a8-eafd447f1cb8", //chosen at random, but fixed
 		StorageID:    storageID,
@@ -136,7 +137,7 @@ func TestSweepStorageBlobs(t *testing.T) {
 		PushedAt:    s.Clock.Now(),
 		ValidatedAt: s.Clock.Now(),
 	}
-	mustDo(t, s.DB.Insert(&dbTestBlob1))
+	mustDo(t, db.Insert(&dbTestBlob1))
 
 	//next StorageSweepJob should unmark blob 1 (because it's now in
 	//the DB) and sweep blobs 2 and 4 (since it is still not in the DB)
@@ -187,7 +188,7 @@ func TestSweepStorageManifests(t *testing.T) {
 	//upload that happened while StorageSweepJob: manifest was written
 	//to storage already, but not yet to DB)
 	s.Clock.StepBy(1 * time.Hour)
-	mustDo(t, s.DB.Insert(&keppel.Manifest{
+	mustDo(t, s.DB.WithContext(s.Ctx).Insert(&keppel.Manifest{
 		RepositoryID: 1,
 		Digest:       testImageList1.Manifest.Digest,
 		MediaType:    testImageList1.Manifest.MediaType,

--- a/internal/tasks/uploads_test.go
+++ b/internal/tasks/uploads_test.go
@@ -99,7 +99,7 @@ func testDeleteUpload(t *testing.T, setupUploadObject func(keppel.StorageDriver,
 	upload.UUID = testUploadUUID
 	upload.StorageID = testStorageID
 	upload.UpdatedAt = s.Clock.Now()
-	err := s.DB.Insert(&upload)
+	err := s.DB.WithContext(s.Ctx).Insert(&upload)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/internal/test/helper_auth.go
+++ b/internal/test/helper_auth.go
@@ -142,7 +142,7 @@ func (s Setup) findAuthTenantIDForAccountName(accountName string) (string, error
 	}
 
 	//base case: look up in the DB
-	return s.DB.SelectStr(`SELECT auth_tenant_id FROM accounts WHERE name = $1`, accountName)
+	return s.DB.WithContext(s.Ctx).SelectStr(`SELECT auth_tenant_id FROM accounts WHERE name = $1`, accountName)
 }
 
 // AddHeadersForCorrectAuthChallenge adds X-Forwarded-... headers to a request

--- a/internal/test/helper_upload.go
+++ b/internal/test/helper_upload.go
@@ -91,7 +91,7 @@ var checkBlobExistsQuery = sqlext.SimplifyWhitespace(`
 func (i Image) MustUpload(t *testing.T, s Setup, repo keppel.Repository, tagName string) keppel.Manifest {
 	//upload missing blobs
 	for _, blob := range append(i.Layers, i.Config) {
-		count, err := s.DB.SelectInt(checkBlobExistsQuery, repo.AccountName, blob.Digest.String())
+		count, err := s.DB.WithContext(s.Ctx).SelectInt(checkBlobExistsQuery, repo.AccountName, blob.Digest.String())
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -148,7 +148,7 @@ var checkManifestExistsQuery = sqlext.SimplifyWhitespace(`
 func (l ImageList) MustUpload(t *testing.T, s Setup, repo keppel.Repository, tagName string) keppel.Manifest {
 	//upload missing images
 	for _, image := range l.Images {
-		count, err := s.DB.SelectInt(checkManifestExistsQuery, repo.AccountName, repo.Name, image.Manifest.Digest)
+		count, err := s.DB.WithContext(s.Ctx).SelectInt(checkManifestExistsQuery, repo.AccountName, repo.Name, image.Manifest.Digest)
 		if err != nil {
 			t.Fatal(err.Error())
 		}


### PR DESCRIPTION
Also fix all unused parameters

I wanted to achieve a maintainable solution that also works for future addition. For that reason I choose to mirror the interface in internal/keppel/database.go and mark all the functions deprecated which then get marked ci golangci-lint.