### PR TITLE
Sort /keppel/v1/accounts/:account api endpoint also by match_cidr

### DIFF
--- a/internal/api/keppel/accounts.go
+++ b/internal/api/keppel/accounts.go
@@ -143,7 +143,7 @@ func (a *API) renderAccount(dbAccount keppel.Account) (Account, error) {
 	}
 
 	var dbPolicies []keppel.RBACPolicy
-	_, err = a.db.Select(&dbPolicies, `SELECT * FROM rbac_policies WHERE account_name = $1 ORDER BY account_name, match_repository, match_username`, dbAccount.Name)
+	_, err = a.db.Select(&dbPolicies, `SELECT * FROM rbac_policies WHERE account_name = $1 ORDER BY account_name, match_repository, match_username, match_cidr`, dbAccount.Name)
 	if err != nil {
 		return Account{}, err
 	}


### PR DESCRIPTION
Before this we could get diffs like the following:

```diff
     ],
     "rbac_policies": [
       {
+        "match_cidr": "1.2.3.4/32",
         "match_repository": ".*",
         "permissions": [
-          "anonymous_pull"
+          "anonymous_first_pull"
         ]
       },
       {
-        "match_cidr": "1.2.3.4/32",
         "match_repository": ".*",
         "permissions": [
-          "anonymous_first_pull"
+          "anonymous_pull"
         ]
       }
     ],
```