### PR TITLE
add new accounts.rbac_policies_json field

### DIFF
--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -224,6 +224,14 @@ var sqlMigrations = map[string]string{
 		DROP TABLE rbac_policies;
 		DROP TABLE accounts;
 	`,
+	"036_add_accounts_rbac_policies_json.up.sql": `
+		ALTER TABLE accounts
+			ADD COLUMN rbac_policies_json TEXT NOT NULL DEFAULT '';
+	`,
+	"036_add_accounts_rbac_policies_json.down.sql": `
+		ALTER TABLE accounts
+			DROP COLUMN rbac_policies_json;
+	`,
 }
 
 // DB adds convenience functions on top of gorp.DbMap.

--- a/internal/keppel/gc_policy.go
+++ b/internal/keppel/gc_policy.go
@@ -31,6 +31,7 @@ import (
 )
 
 // GCPolicy is a policy enabling optional garbage collection runs in an account.
+// It is stored in serialized form in the GCPoliciesJSON field of type Account.
 type GCPolicy struct {
 	RepositoryRx         regexpext.BoundedRegexp `json:"match_repository"`
 	NegativeRepositoryRx regexpext.BoundedRegexp `json:"except_repository,omitempty"`

--- a/internal/keppel/models.go
+++ b/internal/keppel/models.go
@@ -57,6 +57,8 @@ type Account struct {
 
 	//MetadataJSON contains a JSON string of a map[string]string, or the empty string.
 	MetadataJSON string `db:"metadata_json"`
+	//RBACPoliciesJSON contains a JSON string of []keppel.RBACPolicy, or the empty string.
+	RBACPoliciesJSON string `db:"rbac_policies_json"`
 	//GCPoliciesJSON contains a JSON string of []keppel.GCPolicy, or the empty string.
 	GCPoliciesJSON string `db:"gc_policies_json"`
 	//SecurityScanPoliciesJSON contains a JSON string of []keppel.SecurityScanPolicy, or the empty string.
@@ -88,6 +90,8 @@ func FindAccount(db gorp.SqlExecutor, name string) (*Account, error) {
 ////////////////////////////////////////////////////////////////////////////////
 
 // RBACPolicy contains a record from the `rbac_policies` table.
+//
+// TODO Replace this DB table with the new `accounts.rbac_policies_json` field.
 type RBACPolicy struct {
 	AccountName             string `db:"account_name"`
 	CidrPattern             string `db:"match_cidr"`

--- a/internal/keppel/rbac_policy.go
+++ b/internal/keppel/rbac_policy.go
@@ -1,0 +1,35 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package keppel
+
+import (
+	"github.com/sapcc/go-bits/regexpext"
+)
+
+// NewRBACPolicy is a policy granting user-defined access to repos in an account.
+// It is stored in serialized form in the RBACPoliciesJSON field of type Account.
+//
+// TODO: rename to type RBACPolicy after the `rbac_policies` table has been removed
+type NewRBACPolicy struct {
+	CidrPattern       string                `json:"match_cidr,omitempty"`
+	RepositoryPattern regexpext.PlainRegexp `json:"match_repository,omitempty"`
+	UserNamePattern   regexpext.PlainRegexp `json:"match_username,omitempty"`
+	Permissions       []string              `json:"permissions"`
+}


### PR DESCRIPTION
There is not really any advantage to having the RBAC policies in their own table, so I want to move them into the accounts table in order to simplify the code that writes policies into the DB, similar to what we already have for GC policies and security scan policies.

This first phase just adds the new field and makes the Keppel API populate it whenever it touches the rbac_policies table. Once we have this rolled out and the new field is filled on all accounts, we will move into the next phase where the old table is removed and all usages are cut over to the new table.