### PR TITLE
replace `rbac_policies` table with `accounts.rbac_policies_json`

### DIFF
--- a/internal/api/auth/api_test.go
+++ b/internal/api/auth/api_test.go
@@ -51,7 +51,7 @@ type TestCase struct {
 	CannotPush   bool
 	CannotPull   bool
 	CannotDelete bool
-	RBACPolicy   keppel.RBACPolicy
+	RBACPolicy   *keppel.RBACPolicy
 	//result
 	GrantedActions   string
 	AdditionalScopes []string
@@ -59,47 +59,42 @@ type TestCase struct {
 
 var (
 	policyAnonPull = keppel.RBACPolicy{
-		RepositoryPattern:  "fo+",
-		CanPullAnonymously: true,
+		RepositoryPattern: "fo+",
+		Permissions:       []keppel.RBACPermission{keppel.GrantsAnonymousPull},
 	}
 	policyAnonFirstPull = keppel.RBACPolicy{
-		RepositoryPattern:       "fo+",
-		CanPullAnonymously:      true,
-		CanFirstPullAnonymously: true,
+		RepositoryPattern: "fo+",
+		Permissions:       []keppel.RBACPermission{keppel.GrantsAnonymousPull, keppel.GrantsAnonymousFirstPull},
 	}
 	policyPullMatches = keppel.RBACPolicy{
 		RepositoryPattern: "fo+",
 		UserNamePattern:   "correct.*",
-		CanPull:           true,
+		Permissions:       []keppel.RBACPermission{keppel.GrantsPull},
 	}
 	policyPushMatches = keppel.RBACPolicy{
 		RepositoryPattern: "fo+",
 		UserNamePattern:   "correct.*",
-		CanPull:           true,
-		CanPush:           true,
+		Permissions:       []keppel.RBACPermission{keppel.GrantsPull, keppel.GrantsPush},
 	}
 	policyDeleteMatches = keppel.RBACPolicy{
 		RepositoryPattern: "fo+",
 		UserNamePattern:   "correct.*",
-		CanPull:           true,
-		CanDelete:         true,
+		Permissions:       []keppel.RBACPermission{keppel.GrantsPull, keppel.GrantsDelete},
 	}
 	policyPullDoesNotMatch = keppel.RBACPolicy{
 		RepositoryPattern: "fo+",
 		UserNamePattern:   "doesnotmatch",
-		CanPull:           true,
+		Permissions:       []keppel.RBACPermission{keppel.GrantsPull},
 	}
 	policyPushDoesNotMatch = keppel.RBACPolicy{
 		RepositoryPattern: "doesnotmatch",
 		UserNamePattern:   "correct.*",
-		CanPull:           true,
-		CanPush:           true,
+		Permissions:       []keppel.RBACPermission{keppel.GrantsPull, keppel.GrantsPush},
 	}
 	policyDeleteDoesNotMatch = keppel.RBACPolicy{
 		RepositoryPattern: "fo+",
 		UserNamePattern:   "doesnotmatch",
-		CanPull:           true,
-		CanDelete:         true,
+		Permissions:       []keppel.RBACPermission{keppel.GrantsPull, keppel.GrantsDelete},
 	}
 )
 
@@ -205,213 +200,213 @@ var testCases = []TestCase{
 		GrantedActions: ""},
 	//anonymous pull (but not push) is allowed by a matching RBAC policy
 	{Scope: "repository:test1/foo:pull", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:delete", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	//RBAC policy with RepositoryPattern only works when repository name matches
 	{Scope: "repository:test1/foobar:pull", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foobar:push", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foobar:pull,push", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foobar:delete", AnonymousLogin: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	//RBAC policy for anonymous pull also enables pull access for all authenticated users
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: ""},
 	//RBAC policy for anonymous pull does not change anything if the user already has pull access
 	{Scope: "repository:test1/foo:pull",
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "push"},
 	{Scope: "repository:test1/foo:pull,push",
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "pull,push"},
 	{Scope: "repository:test1/foo:delete",
-		RBACPolicy:     policyAnonPull,
+		RBACPolicy:     &policyAnonPull,
 		GrantedActions: "delete"},
 	//anonymous first pull is allowed by a matching RBAC policy
 	{Scope: "repository:test1/foo:pull", AnonymousLogin: true,
-		RBACPolicy:     policyAnonFirstPull,
+		RBACPolicy:     &policyAnonFirstPull,
 		GrantedActions: "pull,anonymous_first_pull"},
 	{Scope: "repository:test1/foo:push", AnonymousLogin: true,
-		RBACPolicy:     policyAnonFirstPull,
+		RBACPolicy:     &policyAnonFirstPull,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push", AnonymousLogin: true,
-		RBACPolicy:     policyAnonFirstPull,
+		RBACPolicy:     &policyAnonFirstPull,
 		GrantedActions: "pull,anonymous_first_pull"},
 	{Scope: "repository:test1/foo:delete", AnonymousLogin: true,
-		RBACPolicy:     policyAnonFirstPull,
+		RBACPolicy:     &policyAnonFirstPull,
 		GrantedActions: ""},
 	//RBAC policy with CanPull grants pull permissions to matching users
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: ""},
 	//RBAC policy with CanPull does not grant permissions if it does not match
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullDoesNotMatch,
+		RBACPolicy:     &policyPullDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullDoesNotMatch,
+		RBACPolicy:     &policyPullDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullDoesNotMatch,
+		RBACPolicy:     &policyPullDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPullDoesNotMatch,
+		RBACPolicy:     &policyPullDoesNotMatch,
 		GrantedActions: ""},
 	//RBAC policy with CanPull does not change anything if the user already has pull access
 	{Scope: "repository:test1/foo:pull",
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: "push"},
 	{Scope: "repository:test1/foo:pull,push",
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: "pull,push"},
 	{Scope: "repository:test1/foo:delete",
-		RBACPolicy:     policyPullMatches,
+		RBACPolicy:     &policyPullMatches,
 		GrantedActions: "delete"},
 	//RBAC policy with CanPull/CanPush grants pull/push permissions to matching users
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "push"},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "pull,push"},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: ""},
 	//RBAC policy with CanPull/CanPush does not grant permissions if it does not match
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushDoesNotMatch,
+		RBACPolicy:     &policyPushDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushDoesNotMatch,
+		RBACPolicy:     &policyPushDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushDoesNotMatch,
+		RBACPolicy:     &policyPushDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyPushDoesNotMatch,
+		RBACPolicy:     &policyPushDoesNotMatch,
 		GrantedActions: ""},
 	//RBAC policy with CanPull/CanPush does not change anything if the user already has pull/push access
 	{Scope: "repository:test1/foo:pull",
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "push"},
 	{Scope: "repository:test1/foo:pull,push",
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "pull,push"},
 	{Scope: "repository:test1/foo:delete",
-		RBACPolicy:     policyPushMatches,
+		RBACPolicy:     &policyPushMatches,
 		GrantedActions: "delete"},
 	//RBAC policy with CanPull/CanDelete grants pull/delete permissions to matching users
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "delete"},
 	//RBAC policy with CanPull/CanDelete does not grant permissions if it does not match
 	{Scope: "repository:test1/foo:pull",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteDoesNotMatch,
+		RBACPolicy:     &policyDeleteDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteDoesNotMatch,
+		RBACPolicy:     &policyDeleteDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:pull,push",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteDoesNotMatch,
+		RBACPolicy:     &policyDeleteDoesNotMatch,
 		GrantedActions: ""},
 	{Scope: "repository:test1/foo:delete",
 		CannotPull: true, CannotPush: true, CannotDelete: true,
-		RBACPolicy:     policyDeleteDoesNotMatch,
+		RBACPolicy:     &policyDeleteDoesNotMatch,
 		GrantedActions: ""},
 	//RBAC policy with CanPull/CanDelete does not change anything if the user already has pull/push access
 	{Scope: "repository:test1/foo:pull",
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "pull"},
 	{Scope: "repository:test1/foo:push",
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "push"},
 	{Scope: "repository:test1/foo:pull,push",
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "pull,push"},
 	{Scope: "repository:test1/foo:delete",
-		RBACPolicy:     policyDeleteMatches,
+		RBACPolicy:     &policyDeleteMatches,
 		GrantedActions: "delete"},
 }
 
@@ -552,17 +547,17 @@ func TestIssueToken(t *testing.T) {
 		t.Logf("----- testcase %d/%d -----\n", idx+1, len(testCases))
 
 		//setup RBAC policies for test
-		_, err := s.DB.Exec(`DELETE FROM rbac_policies WHERE account_name = $1`, "test1")
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		if c.RBACPolicy != (keppel.RBACPolicy{}) {
-			policy := c.RBACPolicy //take a clone for modifying
-			policy.AccountName = "test1"
-			err := s.DB.Insert(&policy)
+		rbacPoliciesJSONStr := ""
+		if c.RBACPolicy != nil {
+			buf, err := json.Marshal([]keppel.RBACPolicy{*c.RBACPolicy})
 			if err != nil {
 				t.Fatal(err.Error())
 			}
+			rbacPoliciesJSONStr = string(buf)
+		}
+		_, err := s.DB.Exec(`UPDATE accounts SET rbac_policies_json = $1 WHERE name = $2`, rbacPoliciesJSONStr, "test1")
+		if err != nil {
+			t.Fatal(err.Error())
 		}
 
 		//setup permissions for test

--- a/internal/api/keppel/audit.go
+++ b/internal/api/keppel/audit.go
@@ -48,6 +48,15 @@ func (a AuditAccount) Render() cadf.Resource {
 		})
 	}
 
+	rbacPoliciesJSON := a.Account.RBACPoliciesJSON
+	if rbacPoliciesJSON != "" && rbacPoliciesJSON != "[]" {
+		res.Attachments = append(res.Attachments, cadf.Attachment{
+			Name:    "rbac-policies",
+			TypeURI: "mime:application/json",
+			Content: a.Account.RBACPoliciesJSON,
+		})
+	}
+
 	return res
 }
 
@@ -86,47 +95,6 @@ func quotasToJSON(q keppel.Quotas) string {
 	}
 	buf, _ := json.Marshal(data)
 	return string(buf)
-}
-
-// AuditRBACPolicy is an audittools.TargetRenderer.
-type AuditRBACPolicy struct {
-	Account keppel.Account
-	Before  *RBACPolicy //give nil for newly created policies
-	After   *RBACPolicy //give nil for deleted policies
-}
-
-// Render implements the audittools.TargetRenderer interface.
-func (a AuditRBACPolicy) Render() cadf.Resource {
-	var attachments []cadf.Attachment
-
-	if a.After != nil {
-		content, _ := json.Marshal(*a.After)
-		attachments = append(attachments, cadf.Attachment{
-			Name:    "payload",
-			TypeURI: "mime:application/json",
-			Content: string(content),
-		})
-	}
-
-	if a.Before != nil {
-		content, _ := json.Marshal(*a.Before)
-		name := "payload"
-		if a.After != nil {
-			name = "payload-before"
-		}
-		attachments = append(attachments, cadf.Attachment{
-			Name:    name,
-			TypeURI: "mime:application/json",
-			Content: string(content),
-		})
-	}
-
-	return cadf.Resource{
-		TypeURI:     "docker-registry/account",
-		ID:          a.Account.Name,
-		ProjectID:   a.Account.AuthTenantID,
-		Attachments: attachments,
-	}
 }
 
 // AuditSecurityScanPolicy is an audittools.TargetRenderer.

--- a/internal/api/peer/api_test.go
+++ b/internal/api/peer/api_test.go
@@ -33,7 +33,6 @@ func TestAlternativeAuthSchemes(t *testing.T) {
 	h := s.Handler
 
 	//anonymous auth is never allowed, generates an auth challenge for auth.PeerAPIScope
-	//test anonymous auth: fails without RBAC policy, succeeds with RBAC policy
 	assert.HTTPRequest{
 		Method:       "POST",
 		Path:         "/peer/v1/sync-replica/test1/foo",

--- a/internal/api/registry/blobs_test.go
+++ b/internal/api/registry/blobs_test.go
@@ -182,8 +182,11 @@ func TestBlobMonolithicUpload(t *testing.T) {
 				"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`,
 			},
 		}.Check(t, h)
-		_, err := s.DB.Exec(
-			`INSERT INTO rbac_policies (account_name, match_repository, match_username, can_anon_pull) VALUES ('test1', 'foo', '', TRUE)`,
+		_, err := s.DB.Exec(`UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
+			test.ToJSON([]keppel.RBACPolicy{{
+				RepositoryPattern: "foo",
+				Permissions:       []keppel.RBACPermission{keppel.GrantsAnonymousPull},
+			}}),
 		)
 		if err != nil {
 			t.Fatal(err.Error())
@@ -195,7 +198,7 @@ func TestBlobMonolithicUpload(t *testing.T) {
 			ExpectHeader: test.VersionHeader,
 			ExpectBody:   assert.ByteData(blob.Contents),
 		}.Check(t, h)
-		_, err = s.DB.Exec(`DELETE FROM rbac_policies`)
+		_, err = s.DB.Exec(`UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1", "")
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -316,11 +316,12 @@ func TestReplicationForbidAnonymousReplicationFromExternal(t *testing.T) {
 			expectManifestExists(t, h2, token, "test1/foo", image.Manifest, "second", nil)
 
 			//enable anonymous pull on the account
-			err := s2.DB.Insert(&keppel.RBACPolicy{
-				AccountName:        "test1",
-				RepositoryPattern:  ".*",
-				CanPullAnonymously: true,
-			})
+			_, err := s2.DB.Exec(`UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
+				test.ToJSON([]keppel.RBACPolicy{{
+					RepositoryPattern: ".*",
+					Permissions:       []keppel.RBACPermission{keppel.GrantsAnonymousPull},
+				}}),
+			)
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -382,12 +383,12 @@ func TestReplicationAllowAnonymousReplicationFromExternal(t *testing.T) {
 			h2 := s2.Handler
 
 			// enable anonymous pull and replication on test1/bar
-			err := s2.DB.Insert(&keppel.RBACPolicy{
-				AccountName:             "test1",
-				RepositoryPattern:       "foo",
-				CanPullAnonymously:      true,
-				CanFirstPullAnonymously: true,
-			})
+			_, err := s2.DB.Exec(`UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
+				test.ToJSON([]keppel.RBACPolicy{{
+					RepositoryPattern: "foo",
+					Permissions:       []keppel.RBACPermission{keppel.GrantsAnonymousPull, keppel.GrantsAnonymousFirstPull},
+				}}),
+			)
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -232,6 +232,23 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE accounts
 			DROP COLUMN rbac_policies_json;
 	`,
+	"037_drop_rbac_policies_table.up.sql": `
+		DROP TABLE rbac_policies;
+	`,
+	"037_drop_rbac_policies_table.down.sql": `
+		CREATE TABLE rbac_policies (
+			account_name        TEXT    NOT NULL REFERENCES accounts ON DELETE CASCADE,
+			match_repository    TEXT    NOT NULL,
+			match_username      TEXT    NOT NULL,
+			can_anon_pull       BOOLEAN NOT NULL DEFAULT FALSE,
+			can_pull            BOOLEAN NOT NULL DEFAULT FALSE,
+			can_push            BOOLEAN NOT NULL DEFAULT FALSE,
+			can_delete          BOOLEAN NOT NULL DEFAULT FALSE,
+			match_cidr          TEXT    NOT NULL DEFAULT '0.0.0.0/0',
+			can_anon_first_pull BOOLEAN NOT NULL DEFAULT FALSE,
+			PRIMARY KEY (account_name, match_cidr, match_repository, match_username)
+		);
+	`,
 }
 
 // DB adds convenience functions on top of gorp.DbMap.

--- a/internal/keppel/rbac_policy.go
+++ b/internal/keppel/rbac_policy.go
@@ -20,16 +20,113 @@
 package keppel
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+
 	"github.com/sapcc/go-bits/regexpext"
 )
 
-// NewRBACPolicy is a policy granting user-defined access to repos in an account.
+// RBACPolicy is a policy granting user-defined access to repos in an account.
 // It is stored in serialized form in the RBACPoliciesJSON field of type Account.
-//
-// TODO: rename to type RBACPolicy after the `rbac_policies` table has been removed
-type NewRBACPolicy struct {
-	CidrPattern       string                `json:"match_cidr,omitempty"`
-	RepositoryPattern regexpext.PlainRegexp `json:"match_repository,omitempty"`
-	UserNamePattern   regexpext.PlainRegexp `json:"match_username,omitempty"`
-	Permissions       []string              `json:"permissions"`
+type RBACPolicy struct {
+	CidrPattern       string                  `json:"match_cidr,omitempty"`
+	RepositoryPattern regexpext.BoundedRegexp `json:"match_repository,omitempty"`
+	UserNamePattern   regexpext.BoundedRegexp `json:"match_username,omitempty"`
+	Permissions       []RBACPermission        `json:"permissions"`
+}
+
+// RBACPermission enumerates permissions that can be granted by an RBAC policy.
+type RBACPermission string
+
+const (
+	GrantsPull               RBACPermission = "pull"
+	GrantsPush               RBACPermission = "push"
+	GrantsDelete             RBACPermission = "delete"
+	GrantsAnonymousPull      RBACPermission = "anonymous_pull"
+	GrantsAnonymousFirstPull RBACPermission = "anonymous_first_pull"
+)
+
+var isRBACPermission = map[RBACPermission]bool{
+	GrantsPull:               true,
+	GrantsPush:               true,
+	GrantsDelete:             true,
+	GrantsAnonymousPull:      true,
+	GrantsAnonymousFirstPull: true,
+}
+
+// Matches evaluates the cidr and regexes in this policy.
+func (r RBACPolicy) Matches(ip, repoName, userName string) bool {
+	if r.CidrPattern != "" {
+		ip := net.ParseIP(ip)
+		_, network, err := net.ParseCIDR(r.CidrPattern)
+		if err != nil || !network.Contains(ip) {
+			return false
+		}
+	}
+
+	if r.RepositoryPattern != "" && !r.RepositoryPattern.MatchString(repoName) {
+		return false
+	}
+	if r.UserNamePattern != "" && !r.UserNamePattern.MatchString(userName) {
+		return false
+	}
+
+	return true
+}
+
+// ValidateAndNormalize performs some normalizations and returns an error if
+// this policy is invalid.
+func (r *RBACPolicy) ValidateAndNormalize() error {
+	if r.CidrPattern != "" {
+		_, network, err := net.ParseCIDR(r.CidrPattern)
+		if err != nil {
+			// err.Error() sadly does not contain any useful information why the cidr is invalid
+			return fmt.Errorf("%q is not a valid CIDR", r.CidrPattern)
+		}
+		r.CidrPattern = network.String()
+		if network.String() == "0.0.0.0/0" {
+			return errors.New("0.0.0.0/0 cannot be used as CIDR because it matches everything")
+		}
+	}
+
+	hasPerm := make(map[RBACPermission]bool)
+	for _, perm := range r.Permissions {
+		if !isRBACPermission[perm] {
+			return fmt.Errorf("%q is not a valid RBAC policy permission", perm)
+		}
+		hasPerm[perm] = true
+	}
+
+	if len(r.Permissions) == 0 {
+		return errors.New(`RBAC policy must grant at least one permission`)
+	}
+	if r.CidrPattern == "" && r.UserNamePattern == "" && r.RepositoryPattern == "" {
+		return errors.New(`RBAC policy must have at least one "match_..." attribute`)
+	}
+	if (hasPerm[GrantsAnonymousPull] || hasPerm[GrantsAnonymousFirstPull]) && r.UserNamePattern != "" {
+		return errors.New(`RBAC policy with "anonymous_pull" or "anonymous_first_pull" may not have the "match_username" attribute`)
+	}
+	if hasPerm[GrantsPull] && r.CidrPattern == "" && r.UserNamePattern == "" {
+		return errors.New(`RBAC policy with "pull" must have the "match_cidr" or "match_username" attribute`)
+	}
+	if hasPerm[GrantsPush] && !hasPerm[GrantsPull] {
+		return errors.New(`RBAC policy with "push" must also grant "pull"`)
+	}
+	if hasPerm[GrantsDelete] && r.UserNamePattern == "" {
+		return errors.New(`RBAC policy with "delete" must have the "match_username" attribute`)
+	}
+
+	return nil
+}
+
+// ParseRBACPolicies parses the RBAC policies for the given account.
+func (a Account) ParseRBACPolicies() ([]RBACPolicy, error) {
+	if a.RBACPoliciesJSON == "" || a.RBACPoliciesJSON == "[]" {
+		return nil, nil
+	}
+	var policies []RBACPolicy
+	err := json.Unmarshal([]byte(a.RBACPoliciesJSON), &policies)
+	return policies, err
 }


### PR DESCRIPTION
This simplifies a lot of the CRUD for accounts and RBAC policies, and reduces the number of SQL queries for each auth by one, at the expense of making `accounts` records a bit larger.

I have verified that the logic from the previous PR has migrated all existing policies into the new DB column, so it is safe to drop the old table.