### PR TITLE
refactor handlePutAccount

### DIFF
--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -1176,6 +1176,24 @@ func TestPutAccountErrorCases(t *testing.T) {
 				}},
 			},
 		},
+		ExpectStatus: http.StatusConflict,
+		ExpectBody:   assert.StringData("cannot change platform filter on existing account\n"),
+	}.Check(t, h)
+
+	// test unexpected platform filter on new primary account
+	assert.HTTPRequest{
+		Method: "PUT",
+		Path:   "/keppel/v1/accounts/third",
+		Header: map[string]string{"X-Test-Perms": "change:tenant1"},
+		Body: assert.JSONObject{
+			"account": assert.JSONObject{
+				"auth_tenant_id": "tenant1",
+				"platform_filter": []assert.JSONObject{{
+					"os":           "linux",
+					"architecture": "amd64",
+				}},
+			},
+		},
 		ExpectStatus: http.StatusUnprocessableEntity,
 		ExpectBody:   assert.StringData("platform filter is only allowed on replica accounts\n"),
 	}.Check(t, h)
@@ -2222,7 +2240,7 @@ func TestReplicaAccountsInheritPlatformFilter(t *testing.T) {
 				},
 			},
 			ExpectStatus: http.StatusConflict,
-			ExpectBody:   assert.StringData("peer account filter needs to match primary account filter: primary account [{\"architecture\":\"arm64\",\"os\":\"linux\",\"variant\":\"v8\"}], peer account [{\"architecture\":\"amd64\",\"os\":\"linux\"}] \n"),
+			ExpectBody:   assert.StringData("peer account filter needs to match primary account filter: local account [{\"architecture\":\"arm64\",\"os\":\"linux\",\"variant\":\"v8\"}], peer account [{\"architecture\":\"amd64\",\"os\":\"linux\"}] \n"),
 		}.Check(t, s2.Handler)
 	})
 }

--- a/internal/keppel/rbac_policy.go
+++ b/internal/keppel/rbac_policy.go
@@ -80,7 +80,7 @@ func (r RBACPolicy) Matches(ip, repoName, userName string) bool {
 
 // ValidateAndNormalize performs some normalizations and returns an error if
 // this policy is invalid.
-func (r *RBACPolicy) ValidateAndNormalize() error {
+func (r *RBACPolicy) ValidateAndNormalize(strategy ReplicationStrategy) error {
 	if r.CidrPattern != "" {
 		_, network, err := net.ParseCIDR(r.CidrPattern)
 		if err != nil {
@@ -118,6 +118,9 @@ func (r *RBACPolicy) ValidateAndNormalize() error {
 	}
 	if hasPerm[GrantsDelete] && r.UserNamePattern == "" {
 		return errors.New(`RBAC policy with "delete" must have the "match_username" attribute`)
+	}
+	if hasPerm[GrantsAnonymousFirstPull] && strategy != FromExternalOnFirstUseStrategy {
+		return errors.New(`RBAC policy with "anonymous_first_pull" may only be for external replica accounts`)
 	}
 
 	return nil

--- a/internal/keppel/replication.go
+++ b/internal/keppel/replication.go
@@ -22,19 +22,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/sapcc/keppel/internal/models"
 )
 
 // ReplicationPolicy represents a replication policy in the API.
 type ReplicationPolicy struct {
-	Strategy string `json:"strategy"`
+	Strategy ReplicationStrategy `json:"strategy"`
 	// only for `on_first_use`
 	UpstreamPeerHostName string `json:"upstream_peer_hostname"`
 	// only for `from_external_on_first_use`
 	ExternalPeer ReplicationExternalPeerSpec `json:"external_peer"`
 }
+
+// ReplicationStrategy is an enum that appears in type ReplicationPolicy.
+type ReplicationStrategy string
+
+const (
+	NoReplicationStrategy          ReplicationStrategy = ""
+	OnFirstUseStrategy             ReplicationStrategy = "on_first_use"
+	FromExternalOnFirstUseStrategy ReplicationStrategy = "from_external_on_first_use"
+)
 
 // ReplicationExternalPeerSpec appears in type ReplicationPolicy.
 type ReplicationExternalPeerSpec struct {
@@ -46,15 +54,15 @@ type ReplicationExternalPeerSpec struct {
 // MarshalJSON implements the json.Marshaler interface.
 func (r ReplicationPolicy) MarshalJSON() ([]byte, error) {
 	switch r.Strategy {
-	case "on_first_use":
+	case OnFirstUseStrategy:
 		data := struct {
-			Strategy             string `json:"strategy"`
-			UpstreamPeerHostName string `json:"upstream"`
+			Strategy             ReplicationStrategy `json:"strategy"`
+			UpstreamPeerHostName string              `json:"upstream"`
 		}{r.Strategy, r.UpstreamPeerHostName}
 		return json.Marshal(data)
-	case "from_external_on_first_use":
+	case FromExternalOnFirstUseStrategy:
 		data := struct {
-			Strategy     string                      `json:"strategy"`
+			Strategy     ReplicationStrategy         `json:"strategy"`
 			ExternalPeer ReplicationExternalPeerSpec `json:"upstream"`
 		}{r.Strategy, r.ExternalPeer}
 		return json.Marshal(data)
@@ -66,8 +74,8 @@ func (r ReplicationPolicy) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (r *ReplicationPolicy) UnmarshalJSON(buf []byte) error {
 	var s struct {
-		Strategy string          `json:"strategy"`
-		Upstream json.RawMessage `json:"upstream"`
+		Strategy ReplicationStrategy `json:"strategy"`
+		Upstream json.RawMessage     `json:"upstream"`
 	}
 	err := json.Unmarshal(buf, &s)
 	if err != nil {
@@ -76,41 +84,103 @@ func (r *ReplicationPolicy) UnmarshalJSON(buf []byte) error {
 	r.Strategy = s.Strategy
 
 	switch r.Strategy {
-	case "on_first_use":
+	case OnFirstUseStrategy:
 		return json.Unmarshal(s.Upstream, &r.UpstreamPeerHostName)
-	case "from_external_on_first_use":
+	case FromExternalOnFirstUseStrategy:
 		return json.Unmarshal(s.Upstream, &r.ExternalPeer)
 	default:
 		return fmt.Errorf("do not know how to deserialize ReplicationPolicy with strategy %q", r.Strategy)
 	}
 }
 
-// ApplyToAccount validates this policy and stores it in the given account model.
-func (r ReplicationPolicy) ApplyToAccount(db *DB, dbAccount *models.Account) *RegistryV2Error {
-	switch r.Strategy {
-	case "on_first_use":
-		peerCount, err := db.SelectInt(`SELECT COUNT(*) FROM peers WHERE hostname = $1`, r.UpstreamPeerHostName)
-		if err != nil {
-			return AsRegistryV2Error(err).WithStatus(http.StatusInternalServerError)
+// RenderReplicationPolicy builds a ReplicationPolicy object out of the
+// information in the given account model.
+func RenderReplicationPolicy(account models.Account) *ReplicationPolicy {
+	if account.UpstreamPeerHostName != "" {
+		return &ReplicationPolicy{
+			Strategy:             OnFirstUseStrategy,
+			UpstreamPeerHostName: account.UpstreamPeerHostName,
 		}
-
-		if peerCount == 0 {
-			err := fmt.Errorf(`unknown peer registry: %q`, r.UpstreamPeerHostName)
-			return AsRegistryV2Error(err).WithStatus(http.StatusUnprocessableEntity)
-		}
-		dbAccount.UpstreamPeerHostName = r.UpstreamPeerHostName
-	case "from_external_on_first_use":
-		if r.ExternalPeer.URL == "" {
-			err := errors.New(`missing upstream URL for "from_external_on_first_use" replication`)
-			return AsRegistryV2Error(err).WithStatus(http.StatusUnprocessableEntity)
-		}
-		dbAccount.ExternalPeerURL = r.ExternalPeer.URL
-		dbAccount.ExternalPeerUserName = r.ExternalPeer.UserName
-		dbAccount.ExternalPeerPassword = r.ExternalPeer.Password
-	default:
-		err := fmt.Errorf("strategy %s is unsupported", r.Strategy)
-		return AsRegistryV2Error(err).WithStatus(http.StatusUnprocessableEntity)
 	}
 
+	if account.ExternalPeerURL != "" {
+		return &ReplicationPolicy{
+			Strategy: FromExternalOnFirstUseStrategy,
+			ExternalPeer: ReplicationExternalPeerSpec{
+				URL:      account.ExternalPeerURL,
+				UserName: account.ExternalPeerUserName,
+				//NOTE: Password is omitted here for security reasons
+			},
+		}
+	}
+
+	return nil
+}
+
+var (
+	ErrIncompatibleReplicationPolicy = errors.New("cannot change replication policy on existing account")
+)
+
+// ApplyToAccount validates this policy and stores it in the given account model.
+//
+// WARNING 1: For existing accounts, the caller must ensure that the policy uses
+// the same replication strategy as the given account already does.
+//
+// WARNING 2: For internal replica accounts, the caller must ensure that the
+// UpstreamPeerHostName refers to a known peer. This method does not do it
+// itself because callers often need to do other things with the peer, too.
+func (r ReplicationPolicy) ApplyToAccount(account *models.Account) error {
+	switch r.Strategy {
+	case OnFirstUseStrategy:
+		if account.UpstreamPeerHostName == "" {
+			// on new accounts, accept any upstream peer
+			account.UpstreamPeerHostName = r.UpstreamPeerHostName
+		} else if account.UpstreamPeerHostName != r.UpstreamPeerHostName {
+			// on existing accounts, changing the upstream peer is not allowed
+			return ErrIncompatibleReplicationPolicy
+		}
+
+	case FromExternalOnFirstUseStrategy:
+		rerr := r.ExternalPeer.applyToAccount(account)
+		if rerr != nil {
+			return rerr
+		}
+
+	default:
+		return fmt.Errorf("strategy %s is unsupported", r.Strategy)
+	}
+
+	return nil
+}
+
+func (r ReplicationExternalPeerSpec) applyToAccount(account *models.Account) error {
+	// peer URL must be given for new accounts, and stay consistent for existing accounts
+	if r.URL == "" {
+		return errors.New(`missing upstream URL for "from_external_on_first_use" replication`)
+	}
+	isNewAccount := account.ExternalPeerURL == ""
+	if isNewAccount {
+		account.ExternalPeerURL = r.URL
+	} else if account.ExternalPeerURL != r.URL {
+		return ErrIncompatibleReplicationPolicy
+	}
+
+	// on existing accounts, having only a username is acceptable if it's unchanged
+	// (this case occurs when a client GETs the account, changes something not related
+	// to replication, and PUTs the result; the password is redacted in GET)
+	if !isNewAccount && r.UserName != "" && r.Password == "" {
+		if r.UserName == account.ExternalPeerUserName {
+			r.Password = account.ExternalPeerPassword // to save it from being overwritten below
+		} else {
+			return errors.New(`cannot change username for "from_external_on_first_use" replication without also changing password`)
+		}
+	}
+
+	// pull credentials can be updated mostly at will
+	if (r.UserName == "") != (r.Password == "") {
+		return errors.New(`need either both username and password or neither for "from_external_on_first_use" replication`)
+	}
+	account.ExternalPeerUserName = r.UserName
+	account.ExternalPeerPassword = r.Password
 	return nil
 }

--- a/internal/models/platform_filter.go
+++ b/internal/models/platform_filter.go
@@ -83,3 +83,17 @@ func (f PlatformFilter) Includes(platform manifestlist.PlatformSpec) bool {
 	}
 	return false
 }
+
+// IsEqualTo checks whether both filters are equal.
+func (f PlatformFilter) IsEqualTo(other PlatformFilter) bool {
+	if len(f) != len(other) {
+		return false
+	}
+
+	for idx, p := range f {
+		if !reflect.DeepEqual(p, other[idx]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/processor/accounts.go
+++ b/internal/processor/accounts.go
@@ -1,0 +1,69 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package processor
+
+import (
+	"context"
+
+	"github.com/sapcc/keppel/internal/auth"
+	peerclient "github.com/sapcc/keppel/internal/client/peer"
+	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
+)
+
+// GetPlatformFilterFromPrimaryAccount takes a replica account and queries the
+// peer holding the primary account for that account's platform filter.
+//
+// Returns sql.ErrNoRows if the configured peer does not exist.
+func (p *Processor) GetPlatformFilterFromPrimaryAccount(ctx context.Context, replicaAccount models.Account) (models.PlatformFilter, error) {
+	var peer models.Peer
+	err := p.db.SelectOne(&peer, `SELECT * FROM peers WHERE hostname = $1`, replicaAccount.UpstreamPeerHostName)
+	if err != nil {
+		return nil, err
+	}
+
+	viewScope := auth.Scope{
+		ResourceType: "keppel_account",
+		ResourceName: replicaAccount.Name,
+		Actions:      []string{"view"},
+	}
+	client, err := peerclient.New(ctx, p.cfg, peer, viewScope)
+	if err != nil {
+		return nil, err
+	}
+
+	//TODO: use type keppelv1.Account once it is moved to package keppel
+	var upstreamAccount struct {
+		Name              string                    `json:"name"`
+		AuthTenantID      string                    `json:"auth_tenant_id"`
+		GCPolicies        []keppel.GCPolicy         `json:"gc_policies,omitempty"`
+		InMaintenance     bool                      `json:"in_maintenance"`
+		Metadata          map[string]string         `json:"metadata"`
+		RBACPolicies      []keppel.RBACPolicy       `json:"rbac_policies"`
+		ReplicationPolicy *keppel.ReplicationPolicy `json:"replication,omitempty"`
+		ValidationPolicy  *keppel.ValidationPolicy  `json:"validation,omitempty"`
+		PlatformFilter    models.PlatformFilter     `json:"platform_filter,omitempty"`
+	}
+	err = client.GetForeignAccountConfigurationInto(ctx, &upstreamAccount, replicaAccount.Name)
+	if err != nil {
+		return nil, err
+	}
+	return upstreamAccount.PlatformFilter, nil
+}


### PR DESCRIPTION
- load `originalAccount` very early to remove the distinction between early and late validations
- move more validation code to live in the respective types (esp. ReplicationPolicy and RBACPolicy)
- have less code in the update phase for existing accounts