### PR TITLE
Add index to some queries in BlobMountSweepJob

### DIFF
--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -278,6 +278,15 @@ var sqlMigrations = map[string]string{
 		DROP INDEX blobs_next_validation_at_idx;
 		DROP INDEX manifests_next_validation_at_idx;
 	`,
+	// Re 040: index is used by BlobMountSweepJob
+	"040_add_index_blob_mounts.up.sql": `
+		CREATE INDEX ON blob_mounts (can_be_deleted_at NULLS FIRST, repo_id);
+		CREATE INDEX ON manifests (validation_error_message) WHERE validation_error_message != '';
+	`,
+	"040_add_index_blob_mounts.down.sql": `
+		DROP INDEX blob_mounts_can_be_deleted_at_repo_id_idx;
+		DROP INDEX manifests_validation_error_message_idx;
+	`,
 }
 
 // DB adds convenience functions on top of gorp.DbMap.


### PR DESCRIPTION
```
Before:
> EXPLAIN ANALYZE UPDATE blob_mounts SET can_be_deleted_at = NOW() WHERE repo_id = 1234 AND can_be_deleted_at IS NULL AND blob_id NOT IN (SELECT DISTINCT blob_id FROM manifest_blob_refs WHERE repo_id = 1234);
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                       |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Update on blob_mounts  (cost=339.62..8881.41 rows=0 width=0) (actual time=45.235..45.239 rows=0 loops=1)                                                         |
|   ->  Seq Scan on blob_mounts  (cost=339.62..8881.41 rows=25 width=14) (actual time=45.234..45.236 rows=0 loops=1)                                               |
|         Filter: ((can_be_deleted_at IS NULL) AND (NOT (hashed SubPlan 1)) AND (repo_id = 1))                                                                     |
|         Rows Removed by Filter: 383982                                                                                                                           |
|         SubPlan 1                                                                                                                                                |
|           ->  Unique  (cost=338.95..339.40 rows=89 width=8) (actual time=0.012..0.014 rows=0 loops=1)                                                            |
|                 ->  Sort  (cost=338.95..339.17 rows=89 width=8) (actual time=0.012..0.014 rows=0 loops=1)                                                        |
|                       Sort Key: manifest_blob_refs.blob_id                                                                                                       |
|                       Sort Method: quicksort  Memory: 25kB                                                                                                       |
|                       ->  Bitmap Heap Scan on manifest_blob_refs  (cost=5.11..336.07 rows=89 width=8) (actual time=0.008..0.008 rows=0 loops=1)                  |
|                             Recheck Cond: (repo_id = 1)                                                                                                          |
|                             ->  Bitmap Index Scan on manifest_blob_refs_repo_id_idx  (cost=0.00..5.09 rows=89 width=0) (actual time=0.007..0.007 rows=0 loops=1) |
|                                   Index Cond: (repo_id = 1)                                                                                                      |
| Planning Time: 4.296 ms                                                                                                                                          |
| Execution Time: 45.290 ms                                                                                                                                        |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+

After:
> EXPLAIN ANALYZE UPDATE blob_mounts SET can_be_deleted_at = NOW() WHERE repo_id = 1234 AND can_be_deleted_at IS NULL AND blob_id NOT IN (SELECT DISTINCT blob_id FROM manifest_blob_refs WHERE repo_id = 1234);
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                         |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Update on blob_mounts  (cost=11.80..185.25 rows=0 width=0) (actual time=0.017..0.018 rows=0 loops=1)                                                               |
|   ->  Index Scan using blob_mounts_can_be_deleted_at_repo_id_idx on blob_mounts  (cost=11.80..185.25 rows=26 width=14) (actual time=0.016..0.017 rows=0 loops=1)   |
|         Index Cond: ((can_be_deleted_at IS NULL) AND (repo_id = 1234))                                                                                             |
|         Filter: (NOT (hashed SubPlan 1))                                                                                                                           |
|         SubPlan 1                                                                                                                                                  |
|           ->  HashAggregate  (cost=10.29..11.16 rows=87 width=8) (never executed)                                                                                  |
|                 Group Key: manifest_blob_refs.blob_id                                                                                                              |
|                 ->  Index Only Scan using manifest_blob_refs_repo_id_digest_blob_id_key on manifest_blob_refs  (cost=0.55..10.07 rows=87 width=8) (never executed) |
|                       Index Cond: (repo_id = 1234)                                                                                                                 |
|                       Heap Fetches: 0                                                                                                                              |
| Planning Time: 0.192 ms                                                                                                                                            |
| Execution Time: 0.071 ms                                                                                                                                           |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Before:
> EXPLAIN ANALYZE SELECT * FROM repos WHERE next_blob_mount_sweep_at IS NULL OR next_blob_mount_sweep_at < NOW() AND id NOT IN (SELECT DISTINCT repo_id
 FROM manifests WHERE validation_error_message != '')  ORDER BY next_blob_mount_sweep_at IS NULL DESC, next_blob_mount_sweep_at ASC  LIMIT 3;
+----------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                             |
|----------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=7347.36..7347.36 rows=3 width=64) (actual time=18.313..18.315 rows=2 loops=1)                                             |
|   ->  Sort  (cost=7347.36..7347.64 rows=112 width=64) (actual time=18.312..18.313 rows=2 loops=1)                                      |
|         Sort Key: ((repos.next_blob_mount_sweep_at IS NULL)) DESC, repos.next_blob_mount_sweep_at                                      |
|         Sort Method: quicksort  Memory: 25kB                                                                                           |
|         ->  Seq Scan on repos  (cost=7201.94..7345.91 rows=112 width=64) (actual time=18.101..18.303 rows=2 loops=1)                   |
|               Filter: ((next_blob_mount_sweep_at IS NULL) OR ((next_blob_mount_sweep_at < now()) AND (NOT (hashed SubPlan 1))))        |
|               Rows Removed by Filter: 4453                                                                                             |
|               SubPlan 1                                                                                                                |
|                 ->  Unique  (cost=7201.94..7201.94 rows=1 width=8) (actual time=17.658..17.659 rows=0 loops=1)                         |
|                       ->  Sort  (cost=7201.94..7201.94 rows=1 width=8) (actual time=17.658..17.658 rows=0 loops=1)                     |
|                             Sort Key: manifests.repo_id                                                                                |
|                             Sort Method: quicksort  Memory: 25kB                                                                       |
|                             ->  Seq Scan on manifests  (cost=0.00..7201.93 rows=1 width=8) (actual time=17.653..17.653 rows=0 loops=1) |
|                                   Filter: (validation_error_message <> ''::text)                                                       |
|                                   Rows Removed by Filter: 45034                                                                        |
| Planning Time: 3.231 ms                                                                                                                |
| Execution Time: 18.348 ms                                                                                                              |
+----------------------------------------------------------------------------------------------------------------------------------------+

After:
> EXPLAIN ANALYZE SELECT * FROM repos WHERE next_blob_mount_sweep_at IS NULL OR next_blob_mount_sweep_at < NOW() AND id NOT IN (SELECT DISTINCT repo_id FROM manifests WHERE validation_error_message != '')  ORDER BY next_blob_mount_sweep_at IS NULL DESC, next_blob_mount_sweep_at ASC  LIMIT 3;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                       |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=148.15..148.15 rows=3 width=64) (actual time=0.705..0.707 rows=2 loops=1)                                                                                           |
|   ->  Sort  (cost=148.15..148.15 rows=3 width=64) (actual time=0.704..0.706 rows=2 loops=1)                                                                                      |
|         Sort Key: ((repos.next_blob_mount_sweep_at IS NULL)) DESC, repos.next_blob_mount_sweep_at                                                                                |
|         Sort Method: quicksort  Memory: 25kB                                                                                                                                     |
|         ->  Seq Scan on repos  (cost=4.16..148.12 rows=3 width=64) (actual time=0.297..0.699 rows=2 loops=1)                                                                     |
|               Filter: ((next_blob_mount_sweep_at IS NULL) OR ((next_blob_mount_sweep_at < now()) AND (NOT (hashed SubPlan 1))))                                                  |
|               Rows Removed by Filter: 4453                                                                                                                                       |
|               SubPlan 1                                                                                                                                                          |
|                 ->  Unique  (cost=4.15..4.16 rows=1 width=8) (actual time=0.006..0.006 rows=0 loops=1)                                                                           |
|                       ->  Sort  (cost=4.15..4.15 rows=1 width=8) (actual time=0.005..0.006 rows=0 loops=1)                                                                       |
|                             Sort Key: manifests.repo_id                                                                                                                          |
|                             Sort Method: quicksort  Memory: 25kB                                                                                                                 |
|                             ->  Index Scan using manifests_validation_error_message_idx on manifests  (cost=0.12..4.14 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=1) |
| Planning Time: 0.225 ms                                                                                                                                                          |
| Execution Time: 0.737 ms                                                                                                                                                         |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```