### PR TITLE
add LIQUID support

### DIFF
--- a/docs/drivers/auth-keystone.md
+++ b/docs/drivers/auth-keystone.md
@@ -39,8 +39,14 @@ Keppel understands access rules in the [`oslo.policy` JSON][os-pol-json] and [`o
 
 All policy rules can use the object attribute `%(target.project.id)s`.
 
+### Keystone service catalog
+
+- The top-level path of the Keppel API (e.g. `https://keppel.example.com/`) should be entered in the service catalog as service type `keppel`.
+- If integration with [Limes][limes] is desired, the `/liquid/` subpath of the Keppel API (e.g. `https://keppel.example.com/liquid/`) can be entered in the service catalog as service type `liquid-keppel`.
+
 See also: [List of available API attributes](https://github.com/sapcc/go-bits/blob/53eeb20fde03c3d0a35e76cf9c9a06b63a415e6b/gopherpolicy/pkg.go#L151-L164)
 
+[limes]: https://github.com/sapcc/limes
 [os-env]: https://docs.openstack.org/python-openstackclient/latest/cli/man/openstack.html
 [os-pol-json]: https://docs.openstack.org/oslo.policy/latest/admin/policy-json-file.html
 [os-pol-yaml]: https://docs.openstack.org/oslo.policy/latest/admin/policy-yaml-file.html

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/redis/go-redis/v9 v9.6.0
 	github.com/rs/cors v1.11.0
-	github.com/sapcc/go-api-declarations v1.11.3
+	github.com/sapcc/go-api-declarations v1.12.0
 	github.com/sapcc/go-bits v0.0.0-20240718093810-9d9ecb2e98b2
 	github.com/spf13/cobra v1.8.1
 	github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
 github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
-github.com/sapcc/go-api-declarations v1.11.3 h1:A8JgeSmOdziYXuiOes9Lp3LKZ0FsU2lc9FOxoM3kRR0=
-github.com/sapcc/go-api-declarations v1.11.3/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.12.0 h1:lFgLbufRQ+rZOaJctF0Tw+6KWYvtRhnpVimtaNzc2So=
+github.com/sapcc/go-api-declarations v1.12.0/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20240718093810-9d9ecb2e98b2 h1:2bh51QSfIiPybsQT14a/w1toifny+1meIdaBSYmQK6k=
 github.com/sapcc/go-bits v0.0.0-20240718093810-9d9ecb2e98b2/go.mod h1:d9JN0Gm8lF5jUMQeH/3MS5iNhs6/AlR/wVQ8vxRAGmo=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/internal/api/keppel/accounts.go
+++ b/internal/api/keppel/accounts.go
@@ -104,11 +104,8 @@ func (a *API) handlePutAccount(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Account keppel.Account `json:"account"`
 	}
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	err := decoder.Decode(&req)
-	if err != nil {
-		http.Error(w, "request body is not valid JSON: "+err.Error(), http.StatusBadRequest)
+	ok := decodeJSONRequestBody(w, r.Body, &req)
+	if !ok {
 		return
 	}
 	// we do not allow to set name in the request body ...
@@ -365,11 +362,8 @@ func (a *API) handlePutSecurityScanPolicies(w http.ResponseWriter, r *http.Reque
 	var req struct {
 		Policies []keppel.SecurityScanPolicy `json:"policies"`
 	}
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&req)
-	if err != nil {
-		http.Error(w, "request body is not valid JSON: "+err.Error(), http.StatusBadRequest)
+	ok := decodeJSONRequestBody(w, r.Body, &req)
+	if !ok {
 		return
 	}
 

--- a/internal/api/keppel/api.go
+++ b/internal/api/keppel/api.go
@@ -20,8 +20,10 @@ package keppelv1
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -185,6 +187,17 @@ func (a *API) findRepositoryFromRequest(w http.ResponseWriter, r *http.Request, 
 		return nil
 	}
 	return repo
+}
+
+func decodeJSONRequestBody(w http.ResponseWriter, body io.Reader, target any) (ok bool) {
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	err := decoder.Decode(&target)
+	if err != nil {
+		http.Error(w, "request body is not valid JSON: "+err.Error(), http.StatusBadRequest)
+		return false
+	}
+	return true
 }
 
 func isValidRepoName(name string) bool {

--- a/internal/api/keppel/api.go
+++ b/internal/api/keppel/api.go
@@ -81,6 +81,13 @@ func (a *API) AddTo(r *mux.Router) {
 
 	r.Methods("GET").Path("/keppel/v1/quotas/{auth_tenant_id}").HandlerFunc(a.handleGetQuotas)
 	r.Methods("PUT").Path("/keppel/v1/quotas/{auth_tenant_id}").HandlerFunc(a.handlePutQuotas)
+
+	// Besides the native Keppel API, this handler also implements LIQUID.
+	// Ref: <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>
+	r.Methods("GET").Path("/liquid/v1/info").HandlerFunc(a.handleLiquidGetInfo)
+	r.Methods("POST").Path("/liquid/v1/report-capacity").HandlerFunc(a.handleLiquidReportCapacity)
+	r.Methods("POST").Path("/liquid/v1/projects/{auth_tenant_id}/report-usage").HandlerFunc(a.handleLiquidReportUsage)
+	r.Methods("PUT").Path("/liquid/v1/projects/{auth_tenant_id}/quota").HandlerFunc(a.handleLiquidSetQuota)
 }
 
 func (a *API) processor() *processor.Processor {

--- a/internal/api/keppel/audit.go
+++ b/internal/api/keppel/audit.go
@@ -27,43 +27,6 @@ import (
 	"github.com/sapcc/keppel/internal/models"
 )
 
-// AuditQuotas is an audittools.TargetRenderer.
-type AuditQuotas struct {
-	QuotasBefore models.Quotas
-	QuotasAfter  models.Quotas
-}
-
-// Render implements the audittools.TargetRenderer interface.
-func (a AuditQuotas) Render() cadf.Resource {
-	return cadf.Resource{
-		TypeURI:   "docker-registry/project-quota",
-		ID:        a.QuotasAfter.AuthTenantID,
-		ProjectID: a.QuotasAfter.AuthTenantID,
-		Attachments: []cadf.Attachment{
-			{
-				Name:    "payload-before",
-				TypeURI: "mime:application/json",
-				Content: quotasToJSON(a.QuotasBefore),
-			},
-			{
-				Name:    "payload",
-				TypeURI: "mime:application/json",
-				Content: quotasToJSON(a.QuotasAfter),
-			},
-		},
-	}
-}
-
-func quotasToJSON(q models.Quotas) string {
-	data := struct {
-		ManifestCount uint64 `json:"manifests"`
-	}{
-		ManifestCount: q.ManifestCount,
-	}
-	buf, _ := json.Marshal(data)
-	return string(buf)
-}
-
 // AuditSecurityScanPolicy is an audittools.TargetRenderer.
 type AuditSecurityScanPolicy struct {
 	Account models.Account

--- a/internal/api/keppel/liquid.go
+++ b/internal/api/keppel/liquid.go
@@ -1,0 +1,141 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package keppelv1
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/errext"
+	"github.com/sapcc/go-bits/httpapi"
+	"github.com/sapcc/go-bits/respondwith"
+
+	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/processor"
+)
+
+// Increment this whenever the output of handleLiquidGetInfo() changes.
+const LiquidInfoVersion int64 = 1
+
+func (a *API) handleLiquidGetInfo(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/liquid/v1/info")
+	respondwith.JSON(w, http.StatusOK, liquid.ServiceInfo{
+		Version: LiquidInfoVersion,
+		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
+			"images": {
+				Unit:        liquid.UnitNone,
+				HasCapacity: false,
+				HasQuota:    true,
+			},
+		},
+	})
+}
+
+func (a *API) handleLiquidReportCapacity(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/liquid/v1/report-capacity")
+
+	// we don't need the request data, but we check it to satisfy the spec
+	var req liquid.ServiceCapacityRequest
+	ok := decodeJSONRequestBody(w, r.Body, &req)
+	if !ok {
+		return
+	}
+
+	// but we don't need to do any actual work since nothing reports capacity
+	respondwith.JSON(w, http.StatusOK, liquid.ServiceCapacityReport{
+		InfoVersion: LiquidInfoVersion,
+		Resources:   map[liquid.ResourceName]*liquid.ResourceCapacityReport{},
+	})
+}
+
+func (a *API) handleLiquidReportUsage(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/liquid/v1/projects/:auth_tenant_id/report-usage")
+	authTenantID := mux.Vars(r)["auth_tenant_id"]
+	authz := a.authenticateRequest(w, r, authTenantScope(keppel.CanViewQuotas, authTenantID))
+	if authz == nil {
+		return
+	}
+
+	// we don't need the request data, but we check it to satisfy the spec
+	var req liquid.ServiceUsageRequest
+	ok := decodeJSONRequestBody(w, r.Body, &req)
+	if !ok {
+		return
+	}
+
+	resp, err := a.processor().GetQuotas(authTenantID)
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+	respondwith.JSON(w, http.StatusOK, liquidConvertQuotaResponse(*resp))
+}
+
+func pointerTo[T any](value T) *T {
+	return &value
+}
+
+func (a *API) handleLiquidSetQuota(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/liquid/v1/projects/:auth_tenant_id/quota")
+	authTenantID := mux.Vars(r)["auth_tenant_id"]
+	authz := a.authenticateRequest(w, r, authTenantScope(keppel.CanChangeQuotas, authTenantID))
+	if authz == nil {
+		return
+	}
+
+	var req liquid.ServiceQuotaRequest
+	ok := decodeJSONRequestBody(w, r.Body, &req)
+	if !ok {
+		return
+	}
+
+	_, err := a.processor().SetQuotas(authTenantID, liquidConvertQuotaRequest(req), authz.UserIdentity.UserInfo(), r)
+	if iqerr, ok := errext.As[processor.ImpossibleQuotaError](err); ok {
+		http.Error(w, iqerr.Message, http.StatusUnprocessableEntity)
+		return
+	}
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func liquidConvertQuotaRequest(req liquid.ServiceQuotaRequest) processor.QuotaRequest {
+	return processor.QuotaRequest{
+		Manifests: processor.SingleQuotaRequest{
+			Quota: req.Resources["images"].Quota,
+		},
+	}
+}
+
+func liquidConvertQuotaResponse(resp processor.QuotaResponse) liquid.ServiceUsageReport {
+	return liquid.ServiceUsageReport{
+		InfoVersion: LiquidInfoVersion,
+		Metrics:     map[liquid.MetricName][]liquid.Metric{},
+		Resources: map[liquid.ResourceName]*liquid.ResourceUsageReport{
+			"images": {
+				Quota: pointerTo(int64(resp.Manifests.Quota)),
+				PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{
+					Usage: resp.Manifests.Usage,
+				}),
+			},
+		},
+	}
+}

--- a/internal/api/keppel/quotas.go
+++ b/internal/api/keppel/quotas.go
@@ -19,7 +19,6 @@
 package keppelv1
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -54,13 +53,9 @@ func (a *API) handlePutQuotas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// parse request
 	var req processor.QuotaRequest
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	err := decoder.Decode(&req)
-	if err != nil {
-		http.Error(w, "request body is not valid JSON: "+err.Error(), http.StatusBadRequest)
+	ok := decodeJSONRequestBody(w, r.Body, &req)
+	if !ok {
 		return
 	}
 

--- a/internal/api/keppel/quotas.go
+++ b/internal/api/keppel/quotas.go
@@ -20,37 +20,16 @@ package keppelv1
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/sapcc/go-api-declarations/cadf"
-	"github.com/sapcc/go-bits/audittools"
+	"github.com/sapcc/go-bits/errext"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/respondwith"
-	"github.com/sapcc/go-bits/sqlext"
 
 	"github.com/sapcc/keppel/internal/keppel"
-	"github.com/sapcc/keppel/internal/models"
+	"github.com/sapcc/keppel/internal/processor"
 )
-
-type quotaAndUsage struct {
-	Quota uint64 `json:"quota"`
-	Usage uint64 `json:"usage"`
-}
-
-type quotaResponse struct {
-	Manifests quotaAndUsage `json:"manifests"`
-}
-
-type justQuota struct {
-	Quota uint64 `json:"quota"`
-}
-
-type quotaRequest struct {
-	Manifests justQuota `json:"manifests"`
-}
 
 func (a *API) handleGetQuotas(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/keppel/v1/quotas/:auth_tenant_id")
@@ -60,25 +39,11 @@ func (a *API) handleGetQuotas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	quotas, err := keppel.FindQuotas(a.db, authTenantID)
+	resp, err := a.processor().GetQuotas(authTenantID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
-	if quotas == nil {
-		quotas = models.DefaultQuotas(authTenantID)
-	}
-
-	manifestCount, err := keppel.GetManifestUsage(a.db, *quotas)
-	if respondwith.ErrorText(w, err) {
-		return
-	}
-
-	respondwith.JSON(w, http.StatusOK, quotaResponse{
-		Manifests: quotaAndUsage{
-			Quota: quotas.ManifestCount,
-			Usage: manifestCount,
-		},
-	})
+	respondwith.JSON(w, http.StatusOK, resp)
 }
 
 func (a *API) handlePutQuotas(w http.ResponseWriter, r *http.Request) {
@@ -89,78 +54,24 @@ func (a *API) handlePutQuotas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	quotas, err := keppel.FindQuotas(a.db, authTenantID)
-	if respondwith.ErrorText(w, err) {
-		return
-	}
-	isUpdate := true
-	if quotas == nil {
-		quotas = models.DefaultQuotas(authTenantID)
-		isUpdate = false
-	}
-	quotasBefore := *quotas
-
 	// parse request
-	var req quotaRequest
+	var req processor.QuotaRequest
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&req)
+	err := decoder.Decode(&req)
 	if err != nil {
 		http.Error(w, "request body is not valid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// check usage
-	tx, err := a.db.Begin()
+	resp, err := a.processor().SetQuotas(authTenantID, req, authz.UserIdentity.UserInfo(), r)
+	if iqerr, ok := errext.As[processor.ImpossibleQuotaError](err); ok {
+		http.Error(w, iqerr.Message, http.StatusUnprocessableEntity)
+		return
+	}
 	if respondwith.ErrorText(w, err) {
 		return
 	}
-	defer sqlext.RollbackUnlessCommitted(tx)
 
-	manifestCount, err := keppel.GetManifestUsage(tx, *quotas)
-	if respondwith.ErrorText(w, err) {
-		return
-	}
-	if req.Manifests.Quota < manifestCount {
-		msg := fmt.Sprintf("requested manifest quota (%d) is below usage (%d)",
-			req.Manifests.Quota, manifestCount)
-		http.Error(w, msg, http.StatusUnprocessableEntity)
-		return
-	}
-
-	if quotas.ManifestCount != req.Manifests.Quota {
-		// apply quotas if necessary
-		quotas.ManifestCount = req.Manifests.Quota
-		if isUpdate {
-			_, err = tx.Update(quotas)
-		} else {
-			err = tx.Insert(quotas)
-		}
-		if respondwith.ErrorText(w, err) {
-			return
-		}
-		err = tx.Commit()
-		if respondwith.ErrorText(w, err) {
-			return
-		}
-
-		// record audit event when quotas have changed
-		if userInfo := authz.UserIdentity.UserInfo(); userInfo != nil {
-			a.auditor.Record(audittools.EventParameters{
-				Time:       time.Now(),
-				Request:    r,
-				User:       userInfo,
-				ReasonCode: http.StatusOK,
-				Action:     cadf.UpdateAction,
-				Target:     AuditQuotas{QuotasBefore: quotasBefore, QuotasAfter: *quotas},
-			})
-		}
-	}
-
-	respondwith.JSON(w, http.StatusOK, quotaResponse{
-		Manifests: quotaAndUsage{
-			Quota: req.Manifests.Quota,
-			Usage: manifestCount,
-		},
-	})
+	respondwith.JSON(w, http.StatusOK, resp)
 }

--- a/internal/processor/audit.go
+++ b/internal/processor/audit.go
@@ -20,6 +20,8 @@
 package processor
 
 import (
+	"encoding/json"
+
 	"github.com/sapcc/go-api-declarations/cadf"
 
 	"github.com/sapcc/keppel/internal/models"
@@ -57,4 +59,41 @@ func (a AuditAccount) Render() cadf.Resource {
 	}
 
 	return res
+}
+
+// AuditQuotas is an audittools.TargetRenderer.
+type AuditQuotas struct {
+	QuotasBefore models.Quotas
+	QuotasAfter  models.Quotas
+}
+
+// Render implements the audittools.TargetRenderer interface.
+func (a AuditQuotas) Render() cadf.Resource {
+	return cadf.Resource{
+		TypeURI:   "docker-registry/project-quota",
+		ID:        a.QuotasAfter.AuthTenantID,
+		ProjectID: a.QuotasAfter.AuthTenantID,
+		Attachments: []cadf.Attachment{
+			{
+				Name:    "payload-before",
+				TypeURI: "mime:application/json",
+				Content: quotasToJSON(a.QuotasBefore),
+			},
+			{
+				Name:    "payload",
+				TypeURI: "mime:application/json",
+				Content: quotasToJSON(a.QuotasAfter),
+			},
+		},
+	}
+}
+
+func quotasToJSON(q models.Quotas) string {
+	data := struct {
+		ManifestCount uint64 `json:"manifests"`
+	}{
+		ManifestCount: q.ManifestCount,
+	}
+	buf, _ := json.Marshal(data)
+	return string(buf)
 }

--- a/internal/processor/quotas.go
+++ b/internal/processor/quotas.go
@@ -1,0 +1,155 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package processor
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sapcc/go-api-declarations/cadf"
+	"github.com/sapcc/go-bits/audittools"
+	"github.com/sapcc/go-bits/sqlext"
+
+	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
+)
+
+// QuotaResponse is the response body payload for GET or PUT /keppel/v1/quotas/:auth_tenant_id.
+type QuotaResponse struct {
+	Manifests SingleQuotaResponse `json:"manifests"`
+}
+
+// SingleQuotaResponse appears in type QuotaRequest.
+type SingleQuotaResponse struct {
+	Quota uint64 `json:"quota"`
+	Usage uint64 `json:"usage"`
+}
+
+// QuotaRequest is the request body payload for PUT /keppel/v1/quotas/:auth_tenant_id.
+type QuotaRequest struct {
+	Manifests SingleQuotaRequest `json:"manifests"`
+}
+
+// SingleQuotaRequest appears in type QuotaRequest.
+type SingleQuotaRequest struct {
+	Quota uint64 `json:"quota"`
+}
+
+// ImpossibleQuotaError is emitted when SetQuotas() fails because the requested quota is impossible.
+type ImpossibleQuotaError struct {
+	Message string
+}
+
+// Error implements the error interface.
+func (e ImpossibleQuotaError) Error() string {
+	return e.Message
+}
+
+// GetQuotas builds a response for GET /keppel/v1/quotas/:auth_tenant_id.
+func (p *Processor) GetQuotas(authTenantID string) (*QuotaResponse, error) {
+	quotas, err := keppel.FindQuotas(p.db, authTenantID)
+	if err != nil {
+		return nil, err
+	}
+	if quotas == nil {
+		quotas = models.DefaultQuotas(authTenantID)
+	}
+
+	manifestCount, err := keppel.GetManifestUsage(p.db, *quotas)
+	if err != nil {
+		return nil, err
+	}
+
+	return &QuotaResponse{
+		Manifests: SingleQuotaResponse{
+			Quota: quotas.ManifestCount,
+			Usage: manifestCount,
+		},
+	}, nil
+}
+
+// SetQuotas changes quotas for an auth tenant and then renders a response
+// for PUT /keppel/v1/quotas/:auth_tenant_id.
+func (p *Processor) SetQuotas(authTenantID string, req QuotaRequest, userInfo audittools.UserInfo, r *http.Request) (*QuotaResponse, error) {
+	quotas, err := keppel.FindQuotas(p.db, authTenantID)
+	if err != nil {
+		return nil, err
+	}
+	isUpdate := true
+	if quotas == nil {
+		quotas = models.DefaultQuotas(authTenantID)
+		isUpdate = false
+	}
+	quotasBefore := *quotas
+
+	// check usage
+	tx, err := p.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer sqlext.RollbackUnlessCommitted(tx)
+
+	manifestCount, err := keppel.GetManifestUsage(tx, *quotas)
+	if err != nil {
+		return nil, err
+	}
+	if req.Manifests.Quota < manifestCount {
+		msg := fmt.Sprintf("requested manifest quota (%d) is below usage (%d)",
+			req.Manifests.Quota, manifestCount)
+		return nil, ImpossibleQuotaError{Message: msg}
+	}
+
+	if quotas.ManifestCount != req.Manifests.Quota {
+		// apply quotas if necessary
+		quotas.ManifestCount = req.Manifests.Quota
+		if isUpdate {
+			_, err = tx.Update(quotas)
+		} else {
+			err = tx.Insert(quotas)
+		}
+		if err != nil {
+			return nil, err
+		}
+		err = tx.Commit()
+		if err != nil {
+			return nil, err
+		}
+
+		// record audit event when quotas have changed
+		if userInfo != nil {
+			p.auditor.Record(audittools.EventParameters{
+				Time:       time.Now(),
+				Request:    r,
+				User:       userInfo,
+				ReasonCode: http.StatusOK,
+				Action:     cadf.UpdateAction,
+				Target:     AuditQuotas{QuotasBefore: quotasBefore, QuotasAfter: *quotas},
+			})
+		}
+	}
+
+	return &QuotaResponse{
+		Manifests: SingleQuotaResponse{
+			Quota: req.Manifests.Quota,
+			Usage: manifestCount,
+		},
+	}, nil
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/availability_zone.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/availability_zone.go
@@ -1,0 +1,37 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// AvailabilityZone is the name of an availability zone.
+// Some special values are enumerated below.
+type AvailabilityZone string
+
+const (
+	// AvailabilityZoneAny marks values that are not bound to a specific AZ.
+	AvailabilityZoneAny AvailabilityZone = "any"
+	// AvailabilityZoneUnknown marks values that are bound to an unknown AZ.
+	AvailabilityZoneUnknown AvailabilityZone = "unknown"
+)
+
+// InAnyAZ is a convenience constructor for the PerAZ fields of ResourceCapacityReport and ResourceUsageReport.
+// It can be used for non-AZ-aware resources. The provided report will be placed under the AvailabilityZoneAny key.
+func InAnyAZ[T any](value T) map[AvailabilityZone]*T {
+	return map[AvailabilityZone]*T{AvailabilityZoneAny: &value}
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/doc.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/doc.go
@@ -1,0 +1,120 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// Package liquid contains the API specification for LIQUID (the [Limes] Interface for Quota and Usage Interrogation and Discovery).
+//
+// [Limes] expects OpenStack services to expose this interface either natively or through an adapter.
+// The interface allows Limes to retrieve quota and usage data, and optionally capacity data, from the respective OpenStack service.
+// Limes will also use the interface to set quota within the service.
+//
+// # Naming conventions
+//
+// Throughout this document:
+//   - "LIQUID" (upper case) refers to the REST interface defined by this document.
+//   - "A liquid" (lower case) refers to a server implementing LIQUID.
+//   - "The liquid's service" refers to the OpenStack service that the liquid is a part of or connected to.
+//
+// Each liquid provides access to one or more resources.
+// A resource is any countable or measurable kind of entity managed by the liquid's service.
+//
+// Limes discovers liquids through the Keystone service catalog.
+// Each liquid should be registered there with a service type that has the prefix "liquid-".
+// If a liquid uses vendor-specific APIs to interact with its service, its service type should include the vendor name.
+//
+// # Inside a resource: Usage, quota, capacity, overcommit
+//
+// All resources report a usage value for each Keystone project.
+// This describes how much of the resource is used by objects created within the project.
+// For example, the usage for the compute resource "cores" is the sum of all vCPUs allocated to each VM in that project.
+//
+// Some resources maintain a quota value for each Keystone project.
+// If so, the usage value must be meaningfully connected to the quota value:
+// Provisioning of new assets shall be rejected with "quota exceeded" if and only if usage would exceed quota afterwards.
+//
+// Some resources report a capacity value that applies to the entire OpenStack deployment.
+// For example, the capacity for the compute resource "cores" would be the total amount of CPU cores available across all hypervisors.
+//
+// This capacity value, as it is reported by the liquid, is also called "raw capacity".
+// Limes may be configured to apply an "overcommit factor" to obtain an "effective capacity".
+// For example, the compute resource "cores" is often overcommitted because most users do not put 100% load on their VMs all the time.
+// In this case, quota and usage values are in terms of effective capacity, even though the capacity value is in terms of raw capacity.
+//
+// Capacity and usage may be AZ-aware, in which case one value will be reported per availability zone (AZ).
+// Quota is not modelled as AZ-aware since there are no OpenStack services that support AZ-aware quota at this time.
+//
+// # Structure
+//
+// LIQUID is structured as a REST-like HTTP API akin to those of the various OpenStack services.
+// Like with any other OpenStack API, the client (i.e. Limes) authenticates to the liquid by providing its Keystone token in the HTTP header "X-Auth-Token".
+//
+// Each individual endpoint is documented in a section of this docstring whose title starts with "Endpoint:".
+// Unless noted otherwise, a liquid must implement all documented endpoints.
+// The full URL of the endpoint is obtained by appending the subpath from the section header to the liquid's base URL from the Keystone service catalog.
+//
+// The documentation for an endpoint may refer to a request body being expected or a response body being generated on success.
+// In all such cases, the request or response body will be encoded as "Content-Type: application/json".
+// The structure of the payload must conform to the referenced Go type.
+//
+// When producing a successful response, the status code shall be 200 (OK) unless noted otherwise.
+// When producing an error response (with a status code between 400 and 599), the liquid shall include a response body of "Content-Type: text/plain" to indicate the error.
+//
+// # Metrics
+//
+// While measuring quota, usage and capacity on behalf of Limes, liquids may obtain other metrics that may be useful to report to the OpenStack operator.
+// LIQUID offers a facility to report metrics like this to Limes as part of the regular quota/usage and capacity reports.
+// These metrics will be stored in the Limes database and then collectively forwarded to a metrics database like [Prometheus].
+// This delivery method is designed to ensure that liquids can be operated without their own persistent storage.
+//
+// LIQUID structures metrics in the same way as the [OpenMetrics format] used by Prometheus:
+//   - A "metric" is a floating-point-valued measurement with an optional set of labels. A label set is a map of string keys to string values.
+//   - A "metric family" is a named set of metrics where the labelset of each metric must have the same keys, but a distinct set of values.
+//
+// # Endpoint: GET /v1/info
+//
+// Returns information about the OpenStack service and the resources available within it.
+//   - On success, the response body payload must be of type ServiceInfo.
+//
+// # Endpoint: POST /v1/report-capacity
+//
+// Reports available capacity across all resources of this service.
+//   - The request body payload must be of type ServiceCapacityRequest.
+//   - On success, the response body payload must be of type ServiceCapacityReport.
+//
+// # Endpoint: POST /v1/projects/:uuid/report-usage
+//
+// Reports usage data (as well as applicable quotas) within a project across all resources of this service.
+//   - The ":uuid" parameter in the request path must refer to a project ID known to Keystone.
+//   - The request body payload must be of type ServiceUsageRequest.
+//   - On success, the response body payload must be of type ServiceUsageReport.
+//
+// # Endpoint: PUT /v1/projects/:uuid/quota
+//
+// Updates quota within a project across all resources of this service.
+//   - The ":uuid" parameter in the request path must refer to a project ID known to Keystone.
+//   - The request body payload must be of type ServiceQuotaRequest.
+//   - On success, the response body shall be empty and status 204 (No Content) shall be returned.
+//
+// [Limes]: https://github.com/sapcc/limes
+// [OpenMetrics format]: https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md
+// [Prometheus]: https://prometheus.io/
+package liquid
+
+// ResourceName identifies a resource within a service. This type is used to distinguish
+// resource names from other types of string values in function signatures.
+type ResourceName string

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/info.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/info.go
@@ -1,0 +1,65 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// ServiceInfo is the response payload format for GET /v1/info.
+type ServiceInfo struct {
+	// This version number shall be increased whenever any part of the ServiceInfo changes.
+	//
+	// The metadata version is also reported on most other API responses.
+	// Limes uses this version number to discover when the metadata has changed and needs to be queried again.
+	//
+	// There is no prescribed semantics to the value of the version number, except that:
+	//   - Changes in ServiceInfo must lead to a monotonic increase of the Version.
+	//   - If the contents of ServiceInfo do not change, the Version too shall not change.
+	//
+	// Our recommendation is to use the UNIX timestamp of the most recent change.
+	// If you run multiple replicas of the liquid, take care to ensure that they agree on the Version value.
+	Version int64 `json:"version"`
+
+	// Info for each resource that this service provides.
+	Resources map[ResourceName]ResourceInfo `json:"resources"`
+
+	// Info for each metric family that is included in a response to a query for cluster capacity.
+	CapacityMetricFamilies map[MetricName]MetricFamilyInfo `json:"capacityMetricFamilies"`
+
+	// Info for each metric family that is included in a response to a query for project quota and usage.
+	UsageMetricFamilies map[MetricName]MetricFamilyInfo `json:"usageMetricFamilies"`
+}
+
+// ResourceInfo describes a resource that a liquid's service provides.
+// This type appears in type ServiceInfo.
+type ResourceInfo struct {
+	// If omitted or empty, the resource is "countable" and any quota or usage values describe a number of objects.
+	// If non-empty, the resource is "measured" and quota or usage values are measured in the given unit.
+	// For example, the compute resource "cores" is countable, but the compute resource "ram" is measured, usually in MiB.
+	Unit Unit `json:"unit,omitempty"`
+
+	// Whether the liquid reports capacity for this resource on the cluster level.
+	HasCapacity bool `json:"hasCapacity"`
+
+	// Whether Limes needs to include demand statistics for this resource in its requests for a capacity report.
+	NeedsResourceDemand bool `json:"needsResourceDemand"`
+
+	// Whether the liquid reports quota for this resource on the project level.
+	// If false, only usage is reported on the project level.
+	// Limes will abstain from maintaining quota on such resources.
+	HasQuota bool `json:"hasQuota"`
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/metrics.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/metrics.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// MetricName is the name of a metric family.
+// For more information, please refer to the "Metrics" section of the package documentation.
+type MetricName string
+
+// MetricType is an enum.
+// For more information, please refer to the "Metrics" section of the package documentation.
+type MetricType string
+
+const (
+	MetricTypeUnknown        MetricType = "unknown"
+	MetricTypeGauge          MetricType = "gauge"
+	MetricTypeCounter        MetricType = "counter"
+	MetricTypeStateset       MetricType = "stateset"
+	MetricTypeInfo           MetricType = "info"
+	MetricTypeHistogram      MetricType = "histogram"
+	MetricTypeGaugeHistogram MetricType = "gaugehistogram"
+	MetricTypeSummary        MetricType = "summary"
+)
+
+// MetricFamilyInfo describes a metric family.
+// This type appears in type ServiceInfo.
+// For more information, please refer to the "Metrics" section of the package documentation.
+type MetricFamilyInfo struct {
+	// The metric type.
+	// The most common values are MetricTypeGauge and MetricTypeCounter.
+	Type MetricType `json:"type"`
+
+	// A brief description of the metric family for human consumption.
+	// Should be short enough to be used as a tooltip.
+	Help string `json:"help"`
+
+	// All labels that will be present on each metric in this family.
+	LabelKeys []string `json:"labelKeys"`
+}
+
+// Metric is a metric.
+// This type appears in type ServiceCapacityReport.
+// For more information, please refer to the "Metrics" section of the package documentation.
+//
+// Because reports can include very large numbers of Metric instances, this type uses a compact serialization to improve efficiency.
+type Metric struct {
+	Value float64 `json:"v"`
+
+	// This label set does not include keys to avoid redundant encoding.
+	// The slice must be of the same length as the LabelKeys slice in the respective MetricFamilyInfo instance in type ServiceInfo.
+	// Each label value is implied to belong to the label key with the same slice index.
+	// For example, LabelKeys = ["name","location"] and LabelValues = ["author","work"] represents the label set {name="author",location="work"}.
+	LabelValues []string `json:"l"`
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/overcommit_factor.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/overcommit_factor.go
@@ -1,0 +1,59 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// OvercommitFactor is the ratio between raw and effective capacity of a resource.
+// It appears in type ResourceDemand.
+//
+// In its methods, the zero value behaves as 1, meaning that no overcommit is taking place.
+type OvercommitFactor float64
+
+// ApplyTo converts a raw capacity into an effective capacity.
+func (f OvercommitFactor) ApplyTo(rawCapacity uint64) uint64 {
+	if f == 0 {
+		// if no overcommit was configured, assume an overcommit factor of 1
+		return rawCapacity
+	}
+	return uint64(float64(rawCapacity) * float64(f))
+}
+
+// ApplyInReverseTo turns the given effective capacity back into a raw capacity.
+func (f OvercommitFactor) ApplyInReverseTo(capacity uint64) uint64 {
+	if f == 0 {
+		// if no overcommit was configured, assume an overcommit factor of 1
+		return capacity
+	}
+	rawCapacity := uint64(float64(capacity) / float64(f))
+	for f.ApplyTo(rawCapacity) < capacity {
+		// fix errors from rounding down float64 -> uint64 above
+		rawCapacity++
+	}
+	return rawCapacity
+}
+
+// ApplyInReverseToDemand is a shorthand for calling ApplyInReverseTo() on all fields of a ResourceDemand,
+// thus turning all values initially given in terms of effective capacity into the corresponding raw capacity.
+func (f OvercommitFactor) ApplyInReverseToDemand(demand ResourceDemandInAZ) ResourceDemandInAZ {
+	return ResourceDemandInAZ{
+		Usage:              f.ApplyInReverseTo(demand.Usage),
+		UnusedCommitments:  f.ApplyInReverseTo(demand.UnusedCommitments),
+		PendingCommitments: f.ApplyInReverseTo(demand.PendingCommitments),
+	}
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/quota.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/quota.go
@@ -1,0 +1,35 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// ServiceQuotaRequest is the request payload format for PUT /v1/projects/:uuid/quota.
+type ServiceQuotaRequest struct {
+	Resources map[ResourceName]ResourceQuotaRequest `json:"resources"`
+}
+
+// ResourceQuotaRequest contains the new quota value for a single resource.
+// It appears in type ServiceQuotaRequest.
+type ResourceQuotaRequest struct {
+	Quota uint64 `json:"quota"`
+
+	// This struct looks superfluous (why not just have a bare uint64?), but in
+	// the unlikely event that AZ-aware quota may be added in the future, having
+	// this struct allows for that to be a backwards-compatible change.
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/report_capacity.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/report_capacity.go
@@ -1,0 +1,103 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package liquid
+
+// ServiceCapacityRequest is the request payload format for POST /v1/report-capacity.
+type ServiceCapacityRequest struct {
+	// All AZs known to Limes.
+	// Many liquids need this information to ensure that:
+	//   - AZ-aware capacity is reported for all known AZs, and
+	//   - capacity belonging to an invalid AZ is grouped into AvailabilityZoneUnknown.
+	// Limes provides this list here to reduce the number of places where this information needs to be maintained manually.
+	AllAZs []AvailabilityZone `json:"allAZs"`
+
+	// Must contain an entry for each resource that was declared in type ServiceInfo with "NeedsResourceDemand = true".
+	DemandByResource map[ResourceName]ResourceDemand `json:"demandByResource"`
+}
+
+// ResourceDemand contains demand statistics for a resource.
+// It appears in type ServiceCapacityRequest.
+//
+// This is used when a liquid needs to be able to reshuffle capacity between different resources based on actual user demand.
+type ResourceDemand struct {
+	// Demand values are provided in terms of effective capacity.
+	// This factor can be applied to them in reverse to obtain values in terms of raw capacity.
+	OvercommitFactor OvercommitFactor `json:"overcommitFactor,omitempty"`
+
+	// The actual demand values are AZ-aware.
+	// For non-AZ-aware resources, the only entry will be for AvailabilityZoneAny.
+	PerAZ map[AvailabilityZone]ResourceDemandInAZ `json:"perAZ"`
+}
+
+// ResourceDemandInAZ contains demand statistics for a resource in a single AZ.
+// It appears in type ResourceDemand.
+//
+// The fields are ordered in descending priority.
+// All values are in terms of effective capacity, and are sums over all OpenStack projects.
+type ResourceDemandInAZ struct {
+	// Usage counts all existing usage.
+	Usage uint64 `json:"usage"`
+
+	// UnusedCommitments counts all commitments that are confirmed but not covered by existing usage.
+	UnusedCommitments uint64 `json:"unusedCommitments"`
+
+	// PendingCommitments counts all commitments that should be confirmed by now, but are not.
+	PendingCommitments uint64 `json:"pendingCommitments"`
+}
+
+// ServiceCapacityReport is the response payload format for POST /v1/report-capacity.
+type ServiceCapacityReport struct {
+	// The same version number that is reported in the Version field of a GET /v1/info response.
+	// This is used to signal to Limes to refetch GET /v1/info after configuration changes.
+	InfoVersion int64 `json:"infoVersion"`
+
+	// Must contain an entry for each resource that was declared in type ServiceInfo with "HasCapacity = true".
+	Resources map[ResourceName]*ResourceCapacityReport `json:"resources"`
+
+	// Must contain an entry for each metric family that was declared for capacity metrics in type ServiceInfo.
+	Metrics map[MetricName][]Metric `json:"metrics"`
+}
+
+// ResourceCapacityReport contains capacity data for a resource.
+// It appears in type ServiceCapacityReport.
+type ResourceCapacityReport struct {
+	// For non-AZ-aware resources, the only entry shall be for AvailabilityZoneAny.
+	// Use func InAnyAZ to quickly construct a suitable structure.
+	//
+	// For AZ-aware resources, there shall be an entry for each AZ mentioned in ServiceCapacityRequest.AllAZs.
+	// Reports for AZ-aware resources may also include an entry for AvailabilityZoneUnknown as needed.
+	PerAZ map[AvailabilityZone]*AZResourceCapacityReport `json:"perAZ"`
+}
+
+// AZResourceCapacityReport contains capacity data for a resource in a single AZ.
+// It appears in type ResourceCapacityReport.
+type AZResourceCapacityReport struct {
+	Capacity uint64 `json:"capacity"`
+
+	// How much of the Capacity is used, or null if no usage data is available.
+	//
+	// This should only be reported if the service has an efficient way to obtain this number from the backend.
+	// If you can only fill this by summing up usage across all projects, don't; Limes can already do that.
+	// This is intended for consistency checks and to estimate how much usage cannot be attributed to OpenStack projects.
+	// For example, for compute, this would allow estimating how many VMs are not managed by Nova.
+	Usage *uint64 `json:"usage,omitempty"`
+
+	// Only filled if the resource is able to report subcapacities in a useful way.
+	Subcapacities []Subcapacity `json:"subcapacities,omitempty"`
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/report_usage.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/report_usage.go
@@ -1,0 +1,120 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+// ServiceUsageRequest is the request payload format for POST /v1/projects/:uuid/report-usage.
+type ServiceUsageRequest struct {
+	// All AZs known to Limes.
+	// Many liquids need this information to ensure that:
+	//   - AZ-aware usage is reported for all known AZs, and
+	//   - usage belonging to an invalid AZ is grouped into AvailabilityZoneUnknown.
+	// Limes provides this list here to reduce the number of places where this information needs to be maintained manually.
+	AllAZs []AvailabilityZone `json:"allAZs"`
+}
+
+// ServiceUsageReport is the response payload format for POST /v1/projects/:uuid/report-usage.
+type ServiceUsageReport struct {
+	// The same version number that is reported in the Version field of a GET /v1/info response.
+	// This is used to signal to Limes to refetch GET /v1/info after configuration changes.
+	InfoVersion int64 `json:"infoVersion"`
+
+	// Must contain an entry for each resource that was declared in type ServiceInfo.
+	Resources map[ResourceName]*ResourceUsageReport `json:"resources"`
+
+	// Must contain an entry for each metric family that was declared for usage metrics in type ServiceInfo.
+	Metrics map[MetricName][]Metric `json:"metrics"`
+}
+
+// ResourceUsageReport contains usage data for a resource in a single project.
+// It appears in type ServiceUsageReport.
+type ResourceUsageReport struct {
+	// If true, this project is forbidden from accessing this resource.
+	// This has two consequences:
+	//   - If the resource has quota, Limes will never try to assign quota for this resource to this project.
+	//   - If the project has no usage in this resource, Limes will hide this resource from project reports.
+	Forbidden bool `json:"forbidden"`
+
+	// This shall be null if and only if the resource is declared with "HasQuota = false".
+	// A negative value, usually -1, indicates "infinite quota" (i.e., the absence of a quota).
+	Quota *int64 `json:"quota,omitempty"`
+
+	// For non-AZ-aware resources, the only entry shall be for AvailabilityZoneAny.
+	// Use func InAnyAZ to quickly construct a suitable structure.
+	//
+	// For AZ-aware resources, there shall be an entry for each AZ mentioned in ServiceUsageRequest.AllAZs.
+	// Reports for AZ-aware resources may also include an entry for AvailabilityZoneUnknown as needed.
+	// When starting from a non-AZ-aware usage number that is later broken down with AZ-aware data, use func PrepareForBreakdownInto.
+	PerAZ map[AvailabilityZone]*AZResourceUsageReport `json:"perAZ"`
+}
+
+// AZResourceUsageReport contains usage data for a resource in a single project and AZ.
+// It appears in type ResourceUsageReport.
+type AZResourceUsageReport struct {
+	// The amount of usage for this resource.
+	Usage uint64 `json:"usage"`
+
+	// The amount of physical usage for this resource.
+	// Only reported if this notion makes sense for the particular resource.
+	//
+	// For example, consider the Manila resource "share_capacity".
+	// If a project has 5 shares, each with 10 GiB size and each containing 1 GiB data, then Usage = 50 GiB and PhysicalUsage = 5 GiB.
+	// It is not allowed to report 5 GiB as Usage in this situation, since the 50 GiB value is used when judging whether the Quota fits.
+	PhysicalUsage *uint64 `json:"physicalUsage,omitempty"`
+
+	// Only filled if the resource is able to report subresources for this usage in a useful way.
+	Subresources []Subresource `json:"subresources,omitempty"`
+}
+
+// PrepareForBreakdownInto is a convenience constructor for the PerAZ field of ResourceUsageReport.
+// It builds a map with zero-valued entries for all of the named AZs.
+// Furthermore, if the provided AZ report contains nonzero usage, it is placed in the AvailabilityZoneUnknown key.
+//
+// This constructor can be used when the total usage data is reported without AZ awareness.
+// An AZ breakdown can later be added with the AddLocalizedUsage() method of ResourceUsageReport.
+func (r AZResourceUsageReport) PrepareForBreakdownInto(allAZs []AvailabilityZone) map[AvailabilityZone]*AZResourceUsageReport {
+	result := make(map[AvailabilityZone]*AZResourceUsageReport, len(allAZs)+1)
+	for _, az := range allAZs {
+		var empty AZResourceUsageReport
+		result[az] = &empty
+	}
+	if r.Usage > 0 {
+		result[AvailabilityZoneUnknown] = &r
+	}
+	return result
+}
+
+// AddLocalizedUsage subtracts the given `usage from AvailabilityZoneUnknown (if any) and adds it to the given AZ instead.
+//
+// This is used when breaking down a usage total reported by a non-AZ-aware API by iterating over AZ-localized objects.
+// The hope is that the sum of usage of the AZ-localized objects matches the reported usage total.
+// If this is the case, the entry for AvailabilityZoneUnknown will be removed entirely once it reaches zero usage.
+func (r *ResourceUsageReport) AddLocalizedUsage(az AvailabilityZone, usage uint64) {
+	if u := r.PerAZ[AvailabilityZoneUnknown]; u == nil || u.Usage <= usage {
+		delete(r.PerAZ, AvailabilityZoneUnknown)
+	} else {
+		r.PerAZ[AvailabilityZoneUnknown].Usage -= usage
+	}
+
+	if _, exists := r.PerAZ[az]; exists {
+		r.PerAZ[az].Usage += usage
+	} else {
+		r.PerAZ[az] = &AZResourceUsageReport{Usage: usage}
+	}
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/subdivisions.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/subdivisions.go
@@ -1,0 +1,125 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+import "encoding/json"
+
+// Subcapacity describes a distinct chunk of capacity for a resource within an AZ.
+// It appears in type AZResourceCapacityReport.
+//
+// A service will only report subcapacities for such resources where there is a useful substructure to report.
+// For example:
+//   - Nova can report its hypervisors as subcapacities of the "cores" and "ram" resources.
+//   - Cinder can report its storage pools as subcapacities of the "capacity" resource.
+//
+// The required fields are "Capacity" and at least one of "ID" or "Name".
+//
+// There is no guarantee that the Capacity values of all subcapacities sum up to the total capacity of the resource.
+// For example, some subcapacities may be excluded from new provisioning.
+// The capacity calculation could then take this into account and exclude unused capacity from the total.
+type Subcapacity struct {
+	// A machine-readable unique identifier for this subcapacity, if there is one.
+	ID string `json:"id,omitempty"`
+
+	// A human-readable unique identifier for this subcapacity, if there is one.
+	Name string `json:"name,omitempty"`
+
+	// The amount of capacity in this subcapacity.
+	Capacity uint64 `json:"capacity"`
+
+	// How much of the Capacity is used, or null if no usage data is available.
+	Usage *uint64 `json:"usage,omitempty"`
+
+	// Additional resource-specific attributes.
+	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
+	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
+	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// SubcapacityBuilder is a helper type for building Subcapacity values.
+// If the Attributes in a subcapacity are collected over time, it might be more convenient to have them accessible as a structured type.
+// Once assembly is complete, the provided methods can be used to obtain the final Subcapacity value.
+type SubcapacityBuilder[A any] struct {
+	ID         string
+	Name       string
+	Capacity   uint64
+	Usage      *uint64
+	Attributes A
+}
+
+// Finalize converts this SubcapacityBuilder into a Subcapacity by serializing the Attributes field to JSON.
+// If an error is returned, it is from the json.Marshal() step.
+func (b SubcapacityBuilder[A]) Finalize() (Subcapacity, error) {
+	buf, err := json.Marshal(b.Attributes)
+	return Subcapacity{
+		ID:         b.ID,
+		Name:       b.Name,
+		Capacity:   b.Capacity,
+		Usage:      b.Usage,
+		Attributes: json.RawMessage(buf),
+	}, err
+}
+
+// Subresource describes a distinct chunk of usage for a resource within a project and AZ.
+// It appears in type AZResourceUsageReport.
+//
+// A service will only report subresources for such resources where there is a useful substructure to report.
+// For example, in the Nova resource "instances", each instance is a subresource.
+//
+// The required fields are "Size" (only for measured resources) and at least one of "ID" or "Name".
+type Subresource struct {
+	// A machine-readable unique identifier for this subresource, if there is one.
+	ID string `json:"id,omitempty"`
+
+	// A human-readable identifier for this subresource, if there is one.
+	// Must be unique at least within its project.
+	Name string `json:"name,omitempty"`
+
+	// Must be null for counted resources (for which each subresource must be one of the things that is counted).
+	// Must be non-null for measured resources, and contain the subresource's size in terms of the resource's unit.
+	Usage *uint64 `json:"usage,omitempty"`
+
+	// Additional resource-specific attributes.
+	// This must be shaped like a map[string]any, but is typed as a raw JSON message.
+	// Limes does not touch these attributes and will just pass them on into its users without deserializing it at all.
+	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// SubresourceBuilder is a helper type for building Subresource values.
+// If the Attributes in a subresource are collected over time, it might be more convenient to have them accessible as a structured type.
+// Once assembly is complete, the provided methods can be used to obtain the final Subresource value.
+type SubresourceBuilder[A any] struct {
+	ID         string
+	Name       string
+	Usage      *uint64
+	Attributes A
+}
+
+// Finalize converts this SubresourceBuilder into a Subresource by serializing the Attributes field to JSON.
+// If an error is returned, it is from the json.Marshal() step.
+func (b SubresourceBuilder[A]) Finalize() (Subresource, error) {
+	buf, err := json.Marshal(b.Attributes)
+	return Subresource{
+		ID:         b.ID,
+		Name:       b.Name,
+		Usage:      b.Usage,
+		Attributes: json.RawMessage(buf),
+	}, err
+}

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/unit.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/unit.go
@@ -1,0 +1,119 @@
+/*******************************************************************************
+*
+* Copyright 2017-2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquid
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Unit enumerates allowed values for the unit a resource's quota/usage is
+// measured in.
+type Unit string
+
+const (
+	// UnitNone is used for countable (rather than measurable) resources.
+	UnitNone Unit = ""
+	// UnitBytes is exactly that.
+	UnitBytes Unit = "B"
+	// UnitKibibytes is exactly that.
+	UnitKibibytes Unit = "KiB"
+	// UnitMebibytes is exactly that.
+	UnitMebibytes Unit = "MiB"
+	// UnitGibibytes is exactly that.
+	UnitGibibytes Unit = "GiB"
+	// UnitTebibytes is exactly that.
+	UnitTebibytes Unit = "TiB"
+	// UnitPebibytes is exactly that.
+	UnitPebibytes Unit = "PiB"
+	// UnitExbibytes is exactly that.
+	UnitExbibytes Unit = "EiB"
+	// UnitUnspecified is used as a placeholder when the unit is not known.
+	UnitUnspecified Unit = "UNSPECIFIED"
+)
+
+var allValidUnits = []Unit{
+	UnitNone,
+	UnitBytes,
+	UnitKibibytes,
+	UnitMebibytes,
+	UnitGibibytes,
+	UnitTebibytes,
+	UnitPebibytes,
+	UnitExbibytes,
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// This method validates that the named unit actually exists.
+//
+// Deprecated: This provides backwards-compatibility with existing YAML-based config file formats in Limes which will be replaced by JSON eventually.
+func (u *Unit) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	for _, unit := range allValidUnits {
+		if string(unit) == s {
+			*u = unit
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown unit: %q", s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// This method validates that the named unit actually exists.
+func (u *Unit) UnmarshalJSON(buf []byte) error {
+	var s string
+	err := json.Unmarshal(buf, &s)
+	if err != nil {
+		return err
+	}
+	for _, unit := range allValidUnits {
+		if string(unit) == s {
+			*u = unit
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown unit: %q", s)
+}
+
+// Base returns the base unit of this unit. For units defined as a multiple of
+// another unit, that unit is the base unit. Otherwise, the same unit and a
+// multiple of 1 is returned.
+func (u Unit) Base() (Unit, uint64) { //nolint:gocritic // not necessary to name the results
+	switch u {
+	case UnitKibibytes:
+		return UnitBytes, 1 << 10
+	case UnitMebibytes:
+		return UnitBytes, 1 << 20
+	case UnitGibibytes:
+		return UnitBytes, 1 << 30
+	case UnitTebibytes:
+		return UnitBytes, 1 << 40
+	case UnitPebibytes:
+		return UnitBytes, 1 << 50
+	case UnitExbibytes:
+		return UnitBytes, 1 << 60
+	default:
+		return u, 1
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,10 +176,11 @@ github.com/rs/cors/internal
 # github.com/samber/lo v1.39.0
 ## explicit; go 1.18
 github.com/samber/lo
-# github.com/sapcc/go-api-declarations v1.11.3
+# github.com/sapcc/go-api-declarations v1.12.0
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf
+github.com/sapcc/go-api-declarations/liquid
 # github.com/sapcc/go-bits v0.0.0-20240718093810-9d9ecb2e98b2
 ## explicit; go 1.22
 github.com/sapcc/go-bits/assert


### PR DESCRIPTION
There is already a quota/usage API implementation in `internal/api/keppel/` that does roughly the same thing, so this mostly just translates to and from the payload types used by LIQUID. The diff ended up being a bit bigger because I moved some stuff around to avoid code duplication.