### PR TITLE
add AccountName type, change several methods to take AccountName instead of Account

### DIFF
--- a/cmd/api/gui_redirect.go
+++ b/cmd/api/gui_redirect.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/sapcc/keppel/internal/auth"
 	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // guiRedirecter is an api.API that implements the GUI redirect.
@@ -56,7 +57,8 @@ func (g *guiRedirecter) tryRedirectToGUI(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 
 	// do we have this account/repo?
-	account, err := keppel.FindAccount(g.db, vars["account"])
+	accountName := models.AccountName(vars["account"])
+	account, err := keppel.FindAccount(g.db, accountName)
 	if err != nil || account == nil {
 		respondNotFound(w, r)
 		return
@@ -83,7 +85,7 @@ func (g *guiRedirecter) tryRedirectToGUI(w http.ResponseWriter, r *http.Request)
 			// do the redirect
 			s := g.urlStr
 			s = strings.ReplaceAll(s, "%AUTH_TENANT_ID%", account.AuthTenantID)
-			s = strings.ReplaceAll(s, "%ACCOUNT_NAME%", account.Name)
+			s = strings.ReplaceAll(s, "%ACCOUNT_NAME%", string(account.Name))
 			s = strings.ReplaceAll(s, "%REPO_NAME%", repo.Name)
 			w.Header().Set("Location", s)
 			w.WriteHeader(http.StatusFound)

--- a/cmd/api/gui_redirect.go
+++ b/cmd/api/gui_redirect.go
@@ -64,7 +64,7 @@ func (g *guiRedirecter) tryRedirectToGUI(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	repoName := stripTagAndDigest(vars["repository"])
-	repo, err := keppel.FindRepository(g.db, repoName, *account)
+	repo, err := keppel.FindRepository(g.db, repoName, accountName)
 	if err != nil || repo == nil {
 		respondNotFound(w, r)
 		return

--- a/cmd/healthmonitor/main.go
+++ b/cmd/healthmonitor/main.go
@@ -73,7 +73,7 @@ func AddCommandTo(parent *cobra.Command) {
 
 type healthMonitorJob struct {
 	AuthDriver  client.AuthDriver
-	AccountName string
+	AccountName models.AccountName
 	RepoClient  *client.RepoClient
 
 	LastResultLock *sync.RWMutex
@@ -93,7 +93,7 @@ func run(cmd *cobra.Command, args []string) {
 	apiUser, apiPassword := ad.CredentialsForRegistryAPI()
 	job := &healthMonitorJob{
 		AuthDriver:  ad,
-		AccountName: args[0],
+		AccountName: models.AccountName(args[0]),
 		RepoClient: &client.RepoClient{
 			Scheme:   ad.ServerScheme(),
 			Host:     ad.ServerHost(),
@@ -149,7 +149,7 @@ func (j *healthMonitorJob) PrepareKeppelAccount(ctx context.Context) error {
 	}
 	reqBodyBytes, _ := json.Marshal(reqBody)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "/keppel/v1/accounts/"+j.AccountName, bytes.NewReader(reqBodyBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "/keppel/v1/accounts/"+string(j.AccountName), bytes.NewReader(reqBodyBytes))
 	if err != nil {
 		return err
 	}

--- a/internal/api/auth/api.go
+++ b/internal/api/auth/api.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/sapcc/keppel/internal/auth"
 	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // API contains state variables used by the Auth API endpoint.
@@ -129,7 +130,7 @@ func (a *API) handleGetAuth(w http.ResponseWriter, r *http.Request) {
 	respondwith.JSON(w, http.StatusOK, tokenResponse)
 }
 
-func (a *API) reverseProxyTokenReqToUpstream(w http.ResponseWriter, r *http.Request, audience auth.Audience, accountName string) error {
+func (a *API) reverseProxyTokenReqToUpstream(w http.ResponseWriter, r *http.Request, audience auth.Audience, accountName models.AccountName) error {
 	primaryHostName, err := a.fd.FindPrimaryAccount(r.Context(), accountName)
 	if err != nil {
 		return err

--- a/internal/api/auth/api_test.go
+++ b/internal/api/auth/api_test.go
@@ -681,7 +681,7 @@ func TestInvalidCredentials(t *testing.T) {
 
 type anycastTestCase struct {
 	// request
-	AccountName string
+	AccountName models.AccountName
 	Service     string
 	Handler     http.Handler
 	// result
@@ -760,11 +760,11 @@ func TestAnycastAndDomainRemappedTokens(t *testing.T) {
 					scopeRepoName string
 				)
 				if withDomainRemapping {
-					domainPrefix = c.AccountName + "."
+					domainPrefix = string(c.AccountName) + "."
 					scopeRepoName = "foo"
 				} else {
 					domainPrefix = ""
-					scopeRepoName = c.AccountName + "/foo"
+					scopeRepoName = string(c.AccountName) + "/foo"
 				}
 
 				req := assert.HTTPRequest{

--- a/internal/api/keppel/accounts.go
+++ b/internal/api/keppel/accounts.go
@@ -111,7 +111,7 @@ func (a *API) handlePutAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// ... transfer it here into the struct, to make the below code simpler
-	req.Account.Name = mux.Vars(r)["account"]
+	req.Account.Name = models.AccountName(mux.Vars(r)["account"])
 
 	// check permission to create account
 	authz := a.authenticateRequest(w, r, authTenantScope(keppel.CanChangeAccount, req.Account.AuthTenantID))

--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -2119,10 +2119,10 @@ func TestReplicaAccountsInheritPlatformFilter(t *testing.T) {
 		}
 
 		// create some primary accounts to play with
-		for _, name := range []string{"first", "second", "third"} {
+		for _, name := range []models.AccountName{"first", "second", "third"} {
 			assert.HTTPRequest{
 				Method: "PUT",
-				Path:   "/keppel/v1/accounts/" + name,
+				Path:   "/keppel/v1/accounts/" + string(name),
 				Header: map[string]string{"X-Test-Perms": "change:tenant1"},
 				Body: assert.JSONObject{
 					"account": assert.JSONObject{

--- a/internal/api/keppel/api.go
+++ b/internal/api/keppel/api.go
@@ -132,7 +132,7 @@ func accountScopes(perm keppel.Permission, accounts ...models.Account) auth.Scop
 	for idx, account := range accounts {
 		scopes[idx] = auth.Scope{
 			ResourceType: "keppel_account",
-			ResourceName: account.Name,
+			ResourceName: string(account.Name),
 			Actions:      []string{string(perm)},
 		}
 	}
@@ -166,7 +166,7 @@ func (a *API) authenticateRequest(w http.ResponseWriter, r *http.Request, ss aut
 // first. This is important because this function may otherwise leak information about whether
 // accounts exist or not to unauthorized users.
 func (a *API) findAccountFromRequest(w http.ResponseWriter, r *http.Request, _ *auth.Authorization) *models.Account {
-	accountName := mux.Vars(r)["account"]
+	accountName := models.AccountName(mux.Vars(r)["account"])
 	account, err := keppel.FindAccount(a.db, accountName)
 	if respondwith.ErrorText(w, err) {
 		return nil

--- a/internal/api/keppel/api.go
+++ b/internal/api/keppel/api.go
@@ -178,14 +178,14 @@ func (a *API) findAccountFromRequest(w http.ResponseWriter, r *http.Request, _ *
 	return account
 }
 
-func (a *API) findRepositoryFromRequest(w http.ResponseWriter, r *http.Request, account models.Account) *models.Repository {
+func (a *API) findRepositoryFromRequest(w http.ResponseWriter, r *http.Request, accountName models.AccountName) *models.Repository {
 	repoName := mux.Vars(r)["repo_name"]
 	if !isValidRepoName(repoName) {
 		http.Error(w, "repo name invalid", http.StatusUnprocessableEntity)
 		return nil
 	}
 
-	repo, err := keppel.FindRepository(a.db, repoName, account)
+	repo, err := keppel.FindRepository(a.db, repoName, accountName)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "repo not found", http.StatusNotFound)
 		return nil

--- a/internal/api/keppel/audit.go
+++ b/internal/api/keppel/audit.go
@@ -38,7 +38,7 @@ func (a AuditSecurityScanPolicy) Render() cadf.Resource {
 	content, _ := json.Marshal(a.Policy)
 	return cadf.Resource{
 		TypeURI:   "docker-registry/account",
-		ID:        a.Account.Name,
+		ID:        string(a.Account.Name),
 		ProjectID: a.Account.AuthTenantID,
 		Attachments: []cadf.Attachment{{
 			Name:    "payload",

--- a/internal/api/keppel/manifests.go
+++ b/internal/api/keppel/manifests.go
@@ -94,7 +94,7 @@ func (a *API) handleGetManifests(w http.ResponseWriter, r *http.Request) {
 	if account == nil {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, *account)
+	repo := a.findRepositoryFromRequest(w, r, account.Name)
 	if repo == nil {
 		return
 	}
@@ -216,7 +216,7 @@ func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request) {
 	if account == nil {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, *account)
+	repo := a.findRepositoryFromRequest(w, r, account.Name)
 	if repo == nil {
 		return
 	}
@@ -251,7 +251,7 @@ func (a *API) handleDeleteTag(w http.ResponseWriter, r *http.Request) {
 	if account == nil {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, *account)
+	repo := a.findRepositoryFromRequest(w, r, account.Name)
 	if repo == nil {
 		return
 	}
@@ -293,7 +293,7 @@ func (a *API) handleGetTrivyReport(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	repo := a.findRepositoryFromRequest(w, r, *account)
+	repo := a.findRepositoryFromRequest(w, r, account.Name)
 	if repo == nil {
 		return
 	}

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -494,7 +494,7 @@ func TestRateLimitsTrivyReport(t *testing.T) {
 		)
 		h := s.Handler
 
-		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.Account{Name: "test1"})
+		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/keppel/repos.go
+++ b/internal/api/keppel/repos.go
@@ -168,7 +168,7 @@ func (a *API) handleDeleteRepository(w http.ResponseWriter, r *http.Request) {
 	if account == nil {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, *account)
+	repo := a.findRepositoryFromRequest(w, r, account.Name)
 	if repo == nil {
 		return
 	}

--- a/internal/api/keppel/sublease.go
+++ b/internal/api/keppel/sublease.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/sapcc/keppel/internal/models"
 )
 
 const SubleaseHeader = "X-Keppel-Sublease-Token"
@@ -32,9 +34,9 @@ const SubleaseHeader = "X-Keppel-Sublease-Token"
 // informational. GUIs/CLIs can display these data to the user for confirmation
 // when the token is entered.
 type SubleaseToken struct {
-	AccountName     string `json:"account"`
-	PrimaryHostname string `json:"primary"`
-	Secret          string `json:"secret"`
+	AccountName     models.AccountName `json:"account"`
+	PrimaryHostname string             `json:"primary"`
+	Secret          string             `json:"secret"`
 }
 
 // Serialize returns the Base64-encoded JSON of this token. This is the format

--- a/internal/api/peer/replica_sync.go
+++ b/internal/api/peer/replica_sync.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sapcc/go-bits/sqlext"
 
 	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // Implementation for the POST /peer/v1/sync-replica/:account/:repo endpoint.
@@ -54,7 +55,8 @@ func (a *API) handleSyncReplica(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// find account
-	account, err := keppel.FindAccount(a.db, mux.Vars(r)["account"])
+	accountName := models.AccountName(mux.Vars(r)["account"])
+	account, err := keppel.FindAccount(a.db, accountName)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/internal/api/peer/replica_sync.go
+++ b/internal/api/peer/replica_sync.go
@@ -66,7 +66,7 @@ func (a *API) handleSyncReplica(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// find repository
-	repo, err := keppel.FindRepository(a.db, mux.Vars(r)["repo"], *account)
+	repo, err := keppel.FindRepository(a.db, mux.Vars(r)["repo"], accountName)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "repo not found", http.StatusNotFound)
 		return

--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -173,7 +173,7 @@ const (
 )
 
 type anycastRequestInfo struct {
-	AccountName     string
+	AccountName     models.AccountName
 	RepoName        string
 	PrimaryHostName string // the peer who has this account
 }
@@ -184,7 +184,7 @@ func (info anycastRequestInfo) AsPrometheusLabels() prometheus.Labels {
 	// this field for tracking the fact that we were redirecting an anycast
 	// request, and where we redirected it
 	return prometheus.Labels{
-		"account":        info.AccountName,
+		"account":        string(info.AccountName),
 		"auth_tenant_id": "anycast-" + info.PrimaryHostName,
 		"method":         "registry-api",
 	}

--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -284,9 +284,9 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 
 	var repo *models.Repository
 	if canCreateRepoIfMissing {
-		repo, err = keppel.FindOrCreateRepository(a.db, repoScope.RepositoryName, *account)
+		repo, err = keppel.FindOrCreateRepository(a.db, repoScope.RepositoryName, account.Name)
 	} else {
-		repo, err = keppel.FindRepository(a.db, repoScope.RepositoryName, *account)
+		repo, err = keppel.FindRepository(a.db, repoScope.RepositoryName, account.Name)
 	}
 	if errors.Is(err, sql.ErrNoRows) || repo == nil {
 		if canFirstPull {

--- a/internal/api/registry/blobs.go
+++ b/internal/api/registry/blobs.go
@@ -128,7 +128,7 @@ func (a *API) handleGetOrHeadBlob(w http.ResponseWriter, r *http.Request) {
 
 	// before we branch into different code paths, count the pull
 	if r.Method == http.MethodGet {
-		l := prometheus.Labels{"account": account.Name, "auth_tenant_id": account.AuthTenantID, "method": "registry-api"}
+		l := prometheus.Labels{"account": string(account.Name), "auth_tenant_id": account.AuthTenantID, "method": "registry-api"}
 		if authz.UserIdentity.UserType() == keppel.PeerUser {
 			l["method"] = "replication"
 		} else if isAnycast {

--- a/internal/api/registry/blobs_test.go
+++ b/internal/api/registry/blobs_test.go
@@ -232,7 +232,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 
 			// create the "test1/foo" repository to ensure that we don't just always hit
 			// NAME_UNKNOWN errors
-			_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.Account{Name: "test1"})
+			_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1"))
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -544,7 +544,7 @@ func TestGetBlobUpload(t *testing.T) {
 
 		// create the "test1/foo" repository to ensure that we don't just always hit
 		// NAME_UNKNOWN errors
-		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.Account{Name: "test1"})
+		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -671,7 +671,7 @@ func TestDeleteBlobUpload(t *testing.T) {
 
 		// create the "test1/foo" repository to ensure that we don't just always hit
 		// NAME_UNKNOWN errors
-		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.Account{Name: "test1"})
+		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/registry/catalog_test.go
+++ b/internal/api/registry/catalog_test.go
@@ -36,8 +36,9 @@ func TestCatalogEndpoint(t *testing.T) {
 
 	// set up dummy accounts for testing
 	for idx := 1; idx <= 3; idx++ {
+		accountName := models.AccountName(fmt.Sprintf("test%d", idx))
 		err := s.DB.Insert(&models.Account{
-			Name:                     fmt.Sprintf("test%d", idx),
+			Name:                     accountName,
 			AuthTenantID:             authTenantID,
 			GCPoliciesJSON:           "[]",
 			SecurityScanPoliciesJSON: "[]",
@@ -49,7 +50,7 @@ func TestCatalogEndpoint(t *testing.T) {
 		for _, repoName := range []string{"foo", "bar", "qux"} {
 			err := s.DB.Insert(&models.Repository{
 				Name:        repoName,
-				AccountName: fmt.Sprintf("test%d", idx),
+				AccountName: accountName,
 			})
 			if err != nil {
 				t.Fatal(err.Error())

--- a/internal/api/registry/manifests.go
+++ b/internal/api/registry/manifests.go
@@ -194,7 +194,7 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 
 	// count the pull unless a special header is set or the pull is performed by Trivy as part of our security scanning
 	if r.Method == http.MethodGet && r.Header.Get("X-Keppel-No-Count-Towards-Last-Pulled") != "1" && authz.UserIdentity.UserType() != keppel.TrivyUser {
-		l := prometheus.Labels{"account": account.Name, "auth_tenant_id": account.AuthTenantID, "method": "registry-api"}
+		l := prometheus.Labels{"account": string(account.Name), "auth_tenant_id": account.AuthTenantID, "method": "registry-api"}
 		api.ManifestsPulledCounter.With(l).Inc()
 
 		// update manifests.last_pulled_at
@@ -362,7 +362,7 @@ func (a *API) handlePutManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// count the push
-	l := prometheus.Labels{"account": account.Name, "auth_tenant_id": account.AuthTenantID, "method": "registry-api"}
+	l := prometheus.Labels{"account": string(account.Name), "auth_tenant_id": account.AuthTenantID, "method": "registry-api"}
 	api.ManifestsPushedCounter.With(l).Inc()
 
 	w.Header().Set("Content-Length", "0")

--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -67,7 +67,7 @@ func TestImageManifestLifecycle(t *testing.T) {
 			}
 
 			// and even if it does...
-			_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.Account{Name: "test1"})
+			_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1"))
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/internal/api/registry/ratelimit_test.go
+++ b/internal/api/registry/ratelimit_test.go
@@ -51,7 +51,7 @@ func TestRateLimits(t *testing.T) {
 	testWithPrimary(t, setupOptions, func(s test.Setup) {
 		// create the "test1/foo" repository to ensure that we don't just always hit
 		// NAME_UNKNOWN errors
-		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.Account{Name: "test1"})
+		_, err := keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -133,7 +133,7 @@ func TestReplicationMissingEntities(t *testing.T) {
 	testWithPrimary(t, nil, func(s1 test.Setup) {
 		// ensure that the `test1/foo` repo exists upstream; otherwise we'll just get
 		// NAME_UNKNOWN
-		_, err := keppel.FindOrCreateRepository(s1.DB, "foo", models.Account{Name: "test1"})
+		_, err := keppel.FindOrCreateRepository(s1.DB, "foo", models.AccountName("test1"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/internal/api/registry/shared_test.go
+++ b/internal/api/registry/shared_test.go
@@ -270,7 +270,7 @@ func expectStorageEmpty(t *testing.T, sd *trivial.StorageDriver, db *keppel.DB) 
 }
 
 //nolint:unparam
-func testWithAccountInMaintenance(t *testing.T, db *keppel.DB, accountName string, action func()) {
+func testWithAccountInMaintenance(t *testing.T, db *keppel.DB, accountName models.AccountName, action func()) {
 	_, err := db.Exec("UPDATE accounts SET in_maintenance = TRUE WHERE name = $1", accountName)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/internal/api/registry/uploads.go
+++ b/internal/api/registry/uploads.go
@@ -160,7 +160,7 @@ func (a *API) performCrossRepositoryBlobMount(w http.ResponseWriter, r *http.Req
 		keppel.ErrNameInvalid.With("source repository is invalid").WriteAsRegistryV2ResponseTo(w, r)
 		return
 	}
-	sourceRepo, err := keppel.FindRepository(a.db, sourceRepoName, account)
+	sourceRepo, err := keppel.FindRepository(a.db, sourceRepoName, account.Name)
 	if errors.Is(err, sql.ErrNoRows) {
 		keppel.ErrNameUnknown.With("source repository does not exist").WriteAsRegistryV2ResponseTo(w, r)
 		return
@@ -728,7 +728,7 @@ func (a *API) createOrUpdateBlobObject(ctx context.Context, tx *gorp.Transaction
 	if err != nil {
 		return nil, err
 	}
-	blob, err := keppel.FindBlobByAccountName(tx, blobDigest, account)
+	blob, err := keppel.FindBlobByAccountName(tx, blobDigest, account.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/audience.go
+++ b/internal/auth/audience.go
@@ -36,7 +36,7 @@ type Audience struct {
 	IsAnycast bool
 	// When using a domain-remapped API, contains the account name specified in the domain name.
 	// Otherwise, contains the empty string.
-	AccountName string
+	AccountName models.AccountName
 }
 
 // IdentifyAudience returns the Audience corresponding to the given domain name.
@@ -64,9 +64,9 @@ func IdentifyAudience(hostname string, cfg keppel.Configuration) Audience {
 			// ...and tail must be one of the well-known hostnames
 			switch hostnameParts[1] {
 			case cfg.APIPublicHostname:
-				return Audience{IsAnycast: false, AccountName: hostnameParts[0]}
+				return Audience{IsAnycast: false, AccountName: models.AccountName(hostnameParts[0])}
 			case cfg.AnycastAPIPublicHostname:
-				return Audience{IsAnycast: true, AccountName: hostnameParts[0]}
+				return Audience{IsAnycast: true, AccountName: models.AccountName(hostnameParts[0])}
 			default:
 				// try the other options
 			}

--- a/internal/auth/filter.go
+++ b/internal/auth/filter.go
@@ -116,7 +116,7 @@ func addCatalogAccess(ss *ScopeSet, uid keppel.UserIdentity, audience Audience, 
 		if uid.HasPermission(keppel.CanViewAccount, account.AuthTenantID) {
 			ss.Add(Scope{
 				ResourceType: "keppel_account",
-				ResourceName: account.Name,
+				ResourceName: string(account.Name),
 				Actions:      []string{"view"},
 			})
 		}
@@ -227,7 +227,7 @@ func filterRepoActions(ip string, scope Scope, uid keppel.UserIdentity, audience
 }
 
 func filterKeppelAccountActions(uid keppel.UserIdentity, audience Audience, db *keppel.DB, scope *Scope) ([]string, error) {
-	if audience.AccountName != "" && scope.ResourceName != audience.AccountName {
+	if audience.AccountName != "" && scope.ResourceName != string(audience.AccountName) {
 		// domain-remapped APIs only allow access to that API's account
 		return nil, nil
 	}
@@ -237,7 +237,7 @@ func filterKeppelAccountActions(uid keppel.UserIdentity, audience Audience, db *
 		return nil, nil
 	}
 
-	account, err := keppel.FindAccount(db, scope.ResourceName)
+	account, err := keppel.FindAccount(db, models.AccountName(scope.ResourceName))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -21,6 +21,8 @@ package auth
 import (
 	"fmt"
 	"strings"
+
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // Scope contains the fields of the "scope" query parameter in a token request.
@@ -32,7 +34,7 @@ type Scope struct {
 
 // ParsedRepositoryScope is returned by Scope.ParseRepositoryScope().
 type ParsedRepositoryScope struct {
-	AccountName        string
+	AccountName        models.AccountName
 	RepositoryName     string
 	FullRepositoryName string
 }
@@ -71,13 +73,13 @@ func (s Scope) ParseRepositoryScope(audience Audience) ParsedRepositoryScope {
 		// repository name which is not allowed; generate a ParsedRepositoryScope
 		// that will never have any permissions given out for it
 		return ParsedRepositoryScope{
-			AccountName:        s.ResourceName,
+			AccountName:        models.AccountName(s.ResourceName),
 			RepositoryName:     "",
 			FullRepositoryName: s.ResourceName,
 		}
 	}
 	return ParsedRepositoryScope{
-		AccountName:        parts[0],
+		AccountName:        models.AccountName(parts[0]),
 		RepositoryName:     parts[1],
 		FullRepositoryName: s.ResourceName,
 	}

--- a/internal/auth/scopeset.go
+++ b/internal/auth/scopeset.go
@@ -19,6 +19,8 @@
 
 package auth
 
+import "github.com/sapcc/keppel/internal/models"
+
 // ScopeSet is a set of scopes.
 type ScopeSet []*Scope
 
@@ -84,8 +86,8 @@ func (ss ScopeSet) Flatten() []Scope {
 // is not empty, only accounts with `name > markerAccountName` will be returned.
 //
 // For use with the /v2/_catalog endpoint.
-func (ss ScopeSet) AccountsWithCatalogAccess(markerAccountName string) []string {
-	var result []string
+func (ss ScopeSet) AccountsWithCatalogAccess(markerAccountName models.AccountName) []models.AccountName {
+	var result []models.AccountName
 	for _, scope := range ss {
 		accountName, ok := isKeppelAccountViewScope(*scope)
 		if !ok {
@@ -99,13 +101,13 @@ func (ss ScopeSet) AccountsWithCatalogAccess(markerAccountName string) []string 
 	return result
 }
 
-func isKeppelAccountViewScope(s Scope) (string, bool) {
+func isKeppelAccountViewScope(s Scope) (models.AccountName, bool) {
 	if s.ResourceType != "keppel_account" {
 		return "", false
 	}
 	for _, action := range s.Actions {
 		if action == "view" {
-			return s.ResourceName, true
+			return models.AccountName(s.ResourceName), true
 		}
 	}
 	return "", false

--- a/internal/client/peer/requests.go
+++ b/internal/client/peer/requests.go
@@ -60,8 +60,8 @@ func (c Client) DownloadManifestViaPullDelegation(ctx context.Context, imageRef 
 // The configuration is deserialized into `target`, which must have the type
 // `*keppelv1.Account`. We cannot return this type explicitly because that
 // would create an import cycle between this package and package keppelv1.
-func (c Client) GetForeignAccountConfigurationInto(ctx context.Context, target any, accountName string) error {
-	reqURL := c.buildRequestURL("keppel/v1/accounts/" + accountName)
+func (c Client) GetForeignAccountConfigurationInto(ctx context.Context, target any, accountName models.AccountName) error {
+	reqURL := c.buildRequestURL("keppel/v1/accounts/" + string(accountName))
 
 	respBodyBytes, respStatusCode, _, err := c.doRequest(ctx, http.MethodGet, reqURL, http.NoBody, nil)
 	if err != nil {
@@ -84,8 +84,8 @@ func (c Client) GetForeignAccountConfigurationInto(ctx context.Context, target a
 
 // GetSubleaseToken asks the peer for a sublease token for this account to replicate it on another Keppel instance.
 // Only the primary instance of an account can be asked for a sublease token.
-func (c Client) GetSubleaseToken(ctx context.Context, accountName string) (string, error) {
-	reqURL := c.buildRequestURL("keppel/v1/accounts/" + accountName + "/sublease")
+func (c Client) GetSubleaseToken(ctx context.Context, accountName models.AccountName) (string, error) {
+	reqURL := c.buildRequestURL("keppel/v1/accounts/" + string(accountName) + "/sublease")
 
 	respBodyBytes, respStatusCode, _, err := c.doRequest(ctx, http.MethodPost, reqURL, http.NoBody, nil)
 	if err != nil {

--- a/internal/drivers/basic/account_management.go
+++ b/internal/drivers/basic/account_management.go
@@ -45,7 +45,7 @@ type AccountConfig struct {
 }
 
 type Account struct {
-	Name                 string                      `json:"name"`
+	Name                 models.AccountName          `json:"name"`
 	AuthTenantID         string                      `json:"auth_tenant_id"`
 	GCPolicies           []keppel.GCPolicy           `json:"gc_policies"`
 	RBACPolicies         []keppel.RBACPolicy         `json:"rbac_policies"`
@@ -76,7 +76,7 @@ func (a *AccountManagementDriver) Init() error {
 }
 
 // ConfigureAccount implements the keppel.AccountManagementDriver interface.
-func (a *AccountManagementDriver) ConfigureAccount(accountName string) (*keppel.Account, []keppel.SecurityScanPolicy, error) {
+func (a *AccountManagementDriver) ConfigureAccount(accountName models.AccountName) (*keppel.Account, []keppel.SecurityScanPolicy, error) {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
 
@@ -99,14 +99,14 @@ func (a *AccountManagementDriver) ConfigureAccount(accountName string) (*keppel.
 	}
 
 	// we didn't find the account, delete it
-	if slices.Contains(a.ProtectedAccountNames, accountName) {
+	if slices.Contains(a.ProtectedAccountNames, string(accountName)) {
 		return nil, nil, errors.New("refusing to delete this account because of explicit protection")
 	}
 	return nil, nil, nil
 }
 
 // ManagedAccountNames implements the keppel.AccountManagementDriver interface.
-func (a *AccountManagementDriver) ManagedAccountNames() ([]string, error) {
+func (a *AccountManagementDriver) ManagedAccountNames() ([]models.AccountName, error) {
 	err := a.LoadConfig()
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (a *AccountManagementDriver) ManagedAccountNames() ([]string, error) {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
 
-	var accounts []string
+	var accounts []models.AccountName
 	for _, account := range a.config.Accounts {
 		accounts = append(accounts, account.Name)
 	}

--- a/internal/drivers/basic/account_management_test.go
+++ b/internal/drivers/basic/account_management_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sapcc/keppel/internal/keppel"
-
 	"github.com/sapcc/go-bits/assert"
+
+	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
 )
 
 func TestConfigureAccount(t *testing.T) {
@@ -36,7 +37,7 @@ func TestConfigureAccount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	assert.DeepEqual(t, "account", listOfAccounts, []string{"abcde"})
+	assert.DeepEqual(t, "account", listOfAccounts, []models.AccountName{"abcde"})
 
 	newAccount, newSecurityScanPolicy, err := driver.ConfigureAccount("abcde")
 	if err != nil {

--- a/internal/drivers/multi/federation.go
+++ b/internal/drivers/multi/federation.go
@@ -107,6 +107,6 @@ func (fd *federationDriver) RecordExistingAccount(ctx context.Context, account m
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (fd *federationDriver) FindPrimaryAccount(ctx context.Context, accountName string) (peerHostName string, err error) {
+func (fd *federationDriver) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (peerHostName string, err error) {
 	return fd.Drivers[0].FindPrimaryAccount(ctx, accountName)
 }

--- a/internal/drivers/openstack/federation_basic.go
+++ b/internal/drivers/openstack/federation_basic.go
@@ -97,7 +97,7 @@ func (d *federationDriverBasic) ClaimAccountName(ctx context.Context, account mo
 
 	for _, entry := range d.Whitelist {
 		projectMatches := entry.ProjectName.MatchString(projectName)
-		accountMatches := entry.AccountName.MatchString(account.Name)
+		accountMatches := entry.AccountName.MatchString(string(account.Name))
 		if projectMatches && accountMatches {
 			return keppel.ClaimSucceeded, nil
 		}
@@ -124,6 +124,6 @@ func (d *federationDriverBasic) RecordExistingAccount(ctx context.Context, accou
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (d *federationDriverBasic) FindPrimaryAccount(ctx context.Context, accountName string) (string, error) {
+func (d *federationDriverBasic) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (string, error) {
 	return "", keppel.ErrNoSuchPrimaryAccount
 }

--- a/internal/drivers/openstack/federation_swift.go
+++ b/internal/drivers/openstack/federation_swift.go
@@ -101,18 +101,18 @@ func initSwiftContainerConnection(ctx context.Context, envPrefix string) (*schwi
 }
 
 type accountFile struct {
-	AccountName         string   `json:"-"`
-	PrimaryHostName     string   `json:"primary_hostname"`
-	ReplicaHostNames    []string `json:"replica_hostnames"`
-	SubleaseTokenSecret string   `json:"sublease_token_secret"`
+	AccountName         models.AccountName `json:"-"`
+	PrimaryHostName     string             `json:"primary_hostname"`
+	ReplicaHostNames    []string           `json:"replica_hostnames"`
+	SubleaseTokenSecret string             `json:"sublease_token_secret"`
 }
 
-func (fd *federationDriverSwift) accountFileObj(accountName string) *schwift.Object {
+func (fd *federationDriverSwift) accountFileObj(accountName models.AccountName) *schwift.Object {
 	return fd.Container.Object(fmt.Sprintf("accounts/%s.json", accountName))
 }
 
 // Downloads and parses an account file from the Swift container.
-func (fd *federationDriverSwift) readAccountFile(ctx context.Context, accountName string) (accountFile, error) {
+func (fd *federationDriverSwift) readAccountFile(ctx context.Context, accountName models.AccountName) (accountFile, error) {
 	buf, err := fd.accountFileObj(accountName).Download(ctx, nil).AsByteSlice()
 	if err != nil {
 		if schwift.Is(err, http.StatusNotFound) {
@@ -132,7 +132,7 @@ func (fd *federationDriverSwift) readAccountFile(ctx context.Context, accountNam
 // does not have strong consistency, so we reduce the likelihood of accidental
 // inconsistencies by performing a write once, then reading the result back
 // after a short wait and checking whether our write was persisted.
-func (fd *federationDriverSwift) modifyAccountFile(ctx context.Context, accountName string, modify func(file *accountFile, firstPass bool) error) error {
+func (fd *federationDriverSwift) modifyAccountFile(ctx context.Context, accountName models.AccountName, modify func(file *accountFile, firstPass bool) error) error {
 	fileOld, err := fd.readAccountFile(ctx, accountName)
 	if err != nil {
 		return err
@@ -354,7 +354,7 @@ func (fd *federationDriverSwift) verifyAccountOwnership(file accountFile, expect
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (fd *federationDriverSwift) FindPrimaryAccount(ctx context.Context, accountName string) (peerHostName string, err error) {
+func (fd *federationDriverSwift) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (peerHostName string, err error) {
 	file, err := fd.readAccountFile(ctx, accountName)
 	if err != nil {
 		return "", err

--- a/internal/drivers/openstack/swift.go
+++ b/internal/drivers/openstack/swift.go
@@ -53,7 +53,7 @@ type swiftContainerInfo struct {
 
 type swiftDriver struct {
 	mainAccount         *schwift.Account
-	containerInfos      map[string]*swiftContainerInfo
+	containerInfos      map[models.AccountName]*swiftContainerInfo
 	containerInfosMutex sync.RWMutex
 }
 
@@ -85,7 +85,7 @@ func (d *swiftDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) error
 	if err != nil {
 		return err
 	}
-	d.containerInfos = make(map[string]*swiftContainerInfo)
+	d.containerInfos = make(map[models.AccountName]*swiftContainerInfo)
 	return nil
 }
 

--- a/internal/drivers/redis/federation.go
+++ b/internal/drivers/redis/federation.go
@@ -59,13 +59,13 @@ func (d *federationDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg k
 	return nil
 }
 
-func (d *federationDriver) primaryKey(accountName string) string {
+func (d *federationDriver) primaryKey(accountName models.AccountName) string {
 	return fmt.Sprintf("%s-primary-%s", d.prefix, accountName)
 }
-func (d *federationDriver) replicasKey(accountName string) string {
+func (d *federationDriver) replicasKey(accountName models.AccountName) string {
 	return fmt.Sprintf("%s-replicas-%s", d.prefix, accountName)
 }
-func (d *federationDriver) tokenKey(accountName string) string {
+func (d *federationDriver) tokenKey(accountName models.AccountName) string {
 	return fmt.Sprintf("%s-token-%s", d.prefix, accountName)
 }
 
@@ -256,7 +256,7 @@ func (d *federationDriver) validatePrimaryHostname(ctx context.Context, account 
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (d *federationDriver) FindPrimaryAccount(ctx context.Context, accountName string) (string, error) {
+func (d *federationDriver) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (string, error) {
 	primaryHostname, err := d.rc.Get(ctx, d.primaryKey(accountName)).Result()
 	if errors.Is(err, redis.Nil) {
 		return "", keppel.ErrNoSuchPrimaryAccount

--- a/internal/drivers/trivial/account_management.go
+++ b/internal/drivers/trivial/account_management.go
@@ -21,6 +21,7 @@ package trivial
 
 import (
 	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // AccountManagementDriver is the account management driver "trivial".
@@ -41,13 +42,13 @@ func (a *AccountManagementDriver) Init() error {
 }
 
 // ConfigureAccount implements the keppel.AccountManagementDriver interface.
-func (a *AccountManagementDriver) ConfigureAccount(accountName string) (*keppel.Account, []keppel.SecurityScanPolicy, error) {
+func (a *AccountManagementDriver) ConfigureAccount(accountName models.AccountName) (*keppel.Account, []keppel.SecurityScanPolicy, error) {
 	// if there are any managed accounts, delete them
 	return nil, nil, nil
 }
 
 // ManagedAccountNames implements the keppel.AccountManagementDriver interface.
-func (a *AccountManagementDriver) ManagedAccountNames() ([]string, error) {
+func (a *AccountManagementDriver) ManagedAccountNames() ([]models.AccountName, error) {
 	// there should be no managed accounts
 	return nil, nil
 }

--- a/internal/drivers/trivial/federation.go
+++ b/internal/drivers/trivial/federation.go
@@ -61,6 +61,6 @@ func (federationDriver) RecordExistingAccount(ctx context.Context, account model
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (federationDriver) FindPrimaryAccount(ctx context.Context, accountName string) (string, error) {
+func (federationDriver) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (string, error) {
 	return "", keppel.ErrNoSuchPrimaryAccount
 }

--- a/internal/keppel/account.go
+++ b/internal/keppel/account.go
@@ -27,7 +27,7 @@ import (
 
 // Account represents an account in the API.
 type Account struct {
-	Name              string                `json:"name"`
+	Name              models.AccountName    `json:"name"`
 	AuthTenantID      string                `json:"auth_tenant_id"`
 	GCPolicies        []GCPolicy            `json:"gc_policies,omitempty"`
 	InMaintenance     bool                  `json:"in_maintenance"`

--- a/internal/keppel/account_management_driver.go
+++ b/internal/keppel/account_management_driver.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/pluggable"
+
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // AccountManagementDriver is a pluggable interface for receiving account
@@ -41,13 +43,13 @@ type AccountManagementDriver interface {
 	//
 	// Returns nil if the account was managed, and now shall be deleted.
 	// The jobloop will clean up the manifests, blobs, repos and the account.
-	ConfigureAccount(accountName string) (*Account, []SecurityScanPolicy, error)
+	ConfigureAccount(accountName models.AccountName) (*Account, []SecurityScanPolicy, error)
 
 	// Called by a jobloop every once in a while (e.g. every hour).
 	//
 	// If new names appear in the list, the jobloop will create the
 	// respective accounts as configured by ConfigureAccount().
-	ManagedAccountNames() ([]string, error)
+	ManagedAccountNames() ([]models.AccountName, error)
 }
 
 // AccountManagementDriverRegistry is a pluggable.Registry for AccountManagementDriver implementations.

--- a/internal/keppel/database_helpers.go
+++ b/internal/keppel/database_helpers.go
@@ -63,9 +63,9 @@ var blobGetQueryByAccountName = sqlext.SimplifyWhitespace(`
 
 // FindBlobByRepositoryName is a convenience wrapper around db.SelectOne(). If
 // the blob in question does not exist, sql.ErrNoRows is returned.
-func FindBlobByRepositoryName(db gorp.SqlExecutor, blobDigest digest.Digest, repoName string, account models.Account) (*models.Blob, error) {
+func FindBlobByRepositoryName(db gorp.SqlExecutor, blobDigest digest.Digest, repoName string, accountName models.AccountName) (*models.Blob, error) {
 	var blob models.Blob
-	err := db.SelectOne(&blob, blobGetQueryByRepoName, account.Name, blobDigest.String(), repoName)
+	err := db.SelectOne(&blob, blobGetQueryByRepoName, accountName, blobDigest.String(), repoName)
 	return &blob, err
 }
 
@@ -79,9 +79,9 @@ func FindBlobByRepository(db gorp.SqlExecutor, blobDigest digest.Digest, repo mo
 
 // FindBlobByAccountName is a convenience wrapper around db.SelectOne(). If the
 // blob in question does not exist, sql.ErrNoRows is returned.
-func FindBlobByAccountName(db gorp.SqlExecutor, blobDigest digest.Digest, account models.Account) (*models.Blob, error) {
+func FindBlobByAccountName(db gorp.SqlExecutor, blobDigest digest.Digest, accountName models.AccountName) (*models.Blob, error) {
 	var blob models.Blob
-	err := db.SelectOne(&blob, blobGetQueryByAccountName, account.Name, blobDigest.String())
+	err := db.SelectOne(&blob, blobGetQueryByAccountName, accountName, blobDigest.String())
 	return &blob, err
 }
 
@@ -124,9 +124,9 @@ var manifestGetQueryByRepoName = sqlext.SimplifyWhitespace(`
 
 // FindManifestByRepositoryName is a convenience wrapper around db.SelectOne().
 // If the manifest in question does not exist, sql.ErrNoRows is returned.
-func FindManifestByRepositoryName(db gorp.SqlExecutor, repoName string, account models.Account, manifestDigest digest.Digest) (*models.Manifest, error) {
+func FindManifestByRepositoryName(db gorp.SqlExecutor, repoName string, accountName models.AccountName, manifestDigest digest.Digest) (*models.Manifest, error) {
 	var manifest models.Manifest
-	err := db.SelectOne(&manifest, manifestGetQueryByRepoName, account.Name, repoName, manifestDigest.String())
+	err := db.SelectOne(&manifest, manifestGetQueryByRepoName, accountName, repoName, manifestDigest.String())
 	return &manifest, err
 }
 
@@ -168,12 +168,12 @@ func AtLeastZero[I interface{ int | int64 }](x I) uint64 {
 
 // FindOrCreateRepository works similar to db.SelectOne(), but autovivifies a
 // Repository record when none exists yet.
-func FindOrCreateRepository(db gorp.SqlExecutor, name string, account models.Account) (*models.Repository, error) {
-	repo, err := FindRepository(db, name, account)
+func FindOrCreateRepository(db gorp.SqlExecutor, name string, accountName models.AccountName) (*models.Repository, error) {
+	repo, err := FindRepository(db, name, accountName)
 	if errors.Is(err, sql.ErrNoRows) {
 		repo = &models.Repository{
 			Name:        name,
-			AccountName: account.Name,
+			AccountName: accountName,
 		}
 		err = db.Insert(repo)
 	}
@@ -182,10 +182,10 @@ func FindOrCreateRepository(db gorp.SqlExecutor, name string, account models.Acc
 
 // FindRepository is a convenience wrapper around db.SelectOne(). If the
 // repository in question does not exist, sql.ErrNoRows is returned.
-func FindRepository(db gorp.SqlExecutor, name string, account models.Account) (*models.Repository, error) {
+func FindRepository(db gorp.SqlExecutor, name string, accountName models.AccountName) (*models.Repository, error) {
 	var repo models.Repository
 	err := db.SelectOne(&repo,
-		"SELECT * FROM repos WHERE account_name = $1 AND name = $2", account.Name, name)
+		"SELECT * FROM repos WHERE account_name = $1 AND name = $2", accountName, name)
 	return &repo, err
 }
 

--- a/internal/keppel/database_helpers.go
+++ b/internal/keppel/database_helpers.go
@@ -32,7 +32,7 @@ import (
 
 // FindAccount works similar to db.SelectOne(), but returns nil instead of
 // sql.ErrNoRows if no account exists with this name.
-func FindAccount(db gorp.SqlExecutor, name string) (*models.Account, error) {
+func FindAccount(db gorp.SqlExecutor, name models.AccountName) (*models.Account, error) {
 	var account models.Account
 	err := db.SelectOne(&account, "SELECT * FROM accounts WHERE name = $1", name)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/keppel/federation_driver.go
+++ b/internal/keppel/federation_driver.go
@@ -101,7 +101,7 @@ type FederationDriver interface {
 	// do not exist locally. It shell return the hostname of the peer that hosts
 	// the primary account. If no account with this name exists anywhere,
 	// ErrNoSuchPrimaryAccount shall be returned.
-	FindPrimaryAccount(ctx context.Context, accountName string) (peerHostName string, err error)
+	FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (peerHostName string, err error)
 }
 
 // FederationDriverRegistry is a pluggable.Registry for FederationDriver implementations.

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -24,10 +24,14 @@ import (
 	"time"
 )
 
+// AccountName identifies an account. This typedef is used to distinguish these
+// names from other string values.
+type AccountName string
+
 // Account contains a record from the `accounts` table.
 type Account struct {
-	Name         string `db:"name"`
-	AuthTenantID string `db:"auth_tenant_id"`
+	Name         AccountName `db:"name"`
+	AuthTenantID string      `db:"auth_tenant_id"`
 
 	// UpstreamPeerHostName is set if and only if the "on_first_use" replication strategy is used.
 	UpstreamPeerHostName string `db:"upstream_peer_hostname"`
@@ -65,7 +69,7 @@ type Account struct {
 // SwiftContainerName returns the name of the Swift container backing this
 // Keppel account.
 func (a Account) SwiftContainerName() string {
-	return "keppel-" + a.Name
+	return "keppel-" + string(a.Name)
 }
 
 // SplitRequiredLabels parses the RequiredLabels field.

--- a/internal/models/blob.go
+++ b/internal/models/blob.go
@@ -37,7 +37,7 @@ import (
 // known yet.
 type Blob struct {
 	ID                     int64         `db:"id"`
-	AccountName            string        `db:"account_name"`
+	AccountName            AccountName   `db:"account_name"`
 	Digest                 digest.Digest `db:"digest"`
 	SizeBytes              uint64        `db:"size_bytes"`
 	StorageID              string        `db:"storage_id"`

--- a/internal/models/pending_blob.go
+++ b/internal/models/pending_blob.go
@@ -27,7 +27,7 @@ import (
 
 // PendingBlob contains a record from the `pending_blobs` table.
 type PendingBlob struct {
-	AccountName  string        `db:"account_name"`
+	AccountName  AccountName   `db:"account_name"`
 	Digest       digest.Digest `db:"digest"`
 	Reason       PendingReason `db:"reason"`
 	PendingSince time.Time     `db:"since"`

--- a/internal/models/repository.go
+++ b/internal/models/repository.go
@@ -25,15 +25,15 @@ import (
 
 // Repository contains a record from the `repos` table.
 type Repository struct {
-	ID                      int64      `db:"id"`
-	AccountName             string     `db:"account_name"`
-	Name                    string     `db:"name"`
-	NextBlobMountSweepAt    *time.Time `db:"next_blob_mount_sweep_at"` // see tasks.BlobMountSweepJob
-	NextManifestSyncAt      *time.Time `db:"next_manifest_sync_at"`    // see tasks.ManifestSyncJob (only set for replica accounts)
-	NextGarbageCollectionAt *time.Time `db:"next_gc_at"`               // see tasks.GarbageCollectManifestsJob
+	ID                      int64       `db:"id"`
+	AccountName             AccountName `db:"account_name"`
+	Name                    string      `db:"name"`
+	NextBlobMountSweepAt    *time.Time  `db:"next_blob_mount_sweep_at"` // see tasks.BlobMountSweepJob
+	NextManifestSyncAt      *time.Time  `db:"next_manifest_sync_at"`    // see tasks.ManifestSyncJob (only set for replica accounts)
+	NextGarbageCollectionAt *time.Time  `db:"next_gc_at"`               // see tasks.GarbageCollectManifestsJob
 }
 
 // FullName prepends the account name to the repository name.
 func (r Repository) FullName() string {
-	return r.AccountName + `/` + r.Name
+	return string(r.AccountName) + `/` + r.Name
 }

--- a/internal/models/unknown_blob.go
+++ b/internal/models/unknown_blob.go
@@ -28,9 +28,9 @@ import (
 // UnknownBlob contains a record from the `unknown_blobs` table.
 // This is only used by tasks.StorageSweepJob().
 type UnknownBlob struct {
-	AccountName    string    `db:"account_name"`
-	StorageID      string    `db:"storage_id"`
-	CanBeDeletedAt time.Time `db:"can_be_deleted_at"`
+	AccountName    AccountName `db:"account_name"`
+	StorageID      string      `db:"storage_id"`
+	CanBeDeletedAt time.Time   `db:"can_be_deleted_at"`
 }
 
 // UnknownManifest contains a record from the `unknown_manifests` table.
@@ -39,7 +39,7 @@ type UnknownBlob struct {
 // NOTE: We don't use repository IDs here because unknown manifests may exist in
 // repositories that are also not known to the database.
 type UnknownManifest struct {
-	AccountName    string        `db:"account_name"`
+	AccountName    AccountName   `db:"account_name"`
 	RepositoryName string        `db:"repo_name"`
 	Digest         digest.Digest `db:"digest"`
 	CanBeDeletedAt time.Time     `db:"can_be_deleted_at"`

--- a/internal/processor/accounts.go
+++ b/internal/processor/accounts.go
@@ -44,7 +44,7 @@ import (
 func (p *Processor) GetPlatformFilterFromPrimaryAccount(ctx context.Context, peer models.Peer, replicaAccount models.Account) (models.PlatformFilter, error) {
 	viewScope := auth.Scope{
 		ResourceType: "keppel_account",
-		ResourceName: replicaAccount.Name,
+		ResourceName: string(replicaAccount.Name),
 		Actions:      []string{"view"},
 	}
 	client, err := peerclient.New(ctx, p.cfg, peer, viewScope)
@@ -73,10 +73,10 @@ func (p *Processor) CreateOrUpdateAccount(ctx context.Context, account keppel.Ac
 	// APIs (we will soon start recognizing image-like URLs such as
 	// keppel.example.org/account/repo and offer redirection to a suitable UI;
 	// this requires the account name to not overlap with API endpoint paths)
-	if strings.HasPrefix(account.Name, "keppel") {
+	if strings.HasPrefix(string(account.Name), "keppel") {
 		return models.Account{}, keppel.AsRegistryV2Error(errors.New(`account names with the prefix "keppel" are reserved for internal use`)).WithStatus(http.StatusUnprocessableEntity)
 	}
-	if looksLikeAPIVersionRx.MatchString(account.Name) {
+	if looksLikeAPIVersionRx.MatchString(string(account.Name)) {
 		return models.Account{}, keppel.AsRegistryV2Error(errors.New(`account names that look like API versions (e.g. v1) are reserved for internal use`)).WithStatus(http.StatusUnprocessableEntity)
 	}
 

--- a/internal/processor/audit.go
+++ b/internal/processor/audit.go
@@ -36,7 +36,7 @@ type AuditAccount struct {
 func (a AuditAccount) Render() cadf.Resource {
 	res := cadf.Resource{
 		TypeURI:   "docker-registry/account",
-		ID:        a.Account.Name,
+		ID:        string(a.Account.Name),
 		ProjectID: a.Account.AuthTenantID,
 	}
 

--- a/internal/processor/blobs.go
+++ b/internal/processor/blobs.go
@@ -193,7 +193,7 @@ func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account
 	}
 
 	// count the successful push
-	l := prometheus.Labels{"account": account.Name, "auth_tenant_id": account.AuthTenantID, "method": "replication"}
+	l := prometheus.Labels{"account": string(account.Name), "auth_tenant_id": account.AuthTenantID, "method": "replication"}
 	api.BlobsPushedCounter.With(l).Inc()
 	return true, nil
 }
@@ -202,7 +202,7 @@ func (p *Processor) uploadBlobToLocal(ctx context.Context, blob models.Blob, acc
 	defer func() {
 		// if blob upload fails, count an aborted upload
 		if returnErr != nil {
-			l := prometheus.Labels{"account": account.Name, "auth_tenant_id": account.AuthTenantID, "method": "replication"}
+			l := prometheus.Labels{"account": string(account.Name), "auth_tenant_id": account.AuthTenantID, "method": "replication"}
 			api.UploadsAbortedCounter.With(l).Inc()
 		}
 	}()

--- a/internal/processor/blobs.go
+++ b/internal/processor/blobs.go
@@ -96,17 +96,17 @@ func (w *byteCountingWriter) Write(buf []byte) (int, error) {
 // requested blob does not exist, a blob record with an empty storage ID will be
 // inserted into the DB. This indicates to the registry API handler that this
 // blob shall be replicated when it is first pulled.
-func (p *Processor) FindBlobOrInsertUnbackedBlob(ctx context.Context, desc distribution.Descriptor, account models.Account) (*models.Blob, error) {
+func (p *Processor) FindBlobOrInsertUnbackedBlob(ctx context.Context, desc distribution.Descriptor, accountName models.AccountName) (*models.Blob, error) {
 	var blob *models.Blob
 	err := p.insideTransaction(ctx, func(ctx context.Context, tx *gorp.Transaction) error {
 		var err error
-		blob, err = keppel.FindBlobByAccountName(tx, desc.Digest, account)
+		blob, err = keppel.FindBlobByAccountName(tx, desc.Digest, accountName)
 		if !errors.Is(err, sql.ErrNoRows) { // either success or unexpected error
 			return err
 		}
 
 		blob = &models.Blob{
-			AccountName:      account.Name,
+			AccountName:      accountName,
 			Digest:           desc.Digest,
 			MediaType:        desc.MediaType,
 			SizeBytes:        keppel.AtLeastZero(desc.Size),

--- a/internal/processor/manifests.go
+++ b/internal/processor/manifests.go
@@ -683,7 +683,7 @@ func (p *Processor) ReplicateManifest(ctx context.Context, account models.Accoun
 	// mark all missing blobs as pending replication
 	for _, desc := range manifestParsed.BlobReferences() {
 		// mark referenced blobs as pending replication if not replicated yet
-		blob, err := p.FindBlobOrInsertUnbackedBlob(ctx, desc, account)
+		blob, err := p.FindBlobOrInsertUnbackedBlob(ctx, desc, account.Name)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -701,7 +701,7 @@ func (p *Processor) ReplicateManifest(ctx context.Context, account models.Accoun
 	// purposes
 	configBlobDesc := manifestParsed.FindImageConfigBlob()
 	if configBlobDesc != nil {
-		configBlob, err := keppel.FindBlobByAccountName(p.db, configBlobDesc.Digest, account)
+		configBlob, err := keppel.FindBlobByAccountName(p.db, configBlobDesc.Digest, account.Name)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/tasks/account_management.go
+++ b/internal/tasks/account_management.go
@@ -174,7 +174,7 @@ func (j *Janitor) tryDeleteManagedAccount(ctx context.Context, accountName model
 				return false, fmt.Errorf("while deleting manifest %q in repository %q: could not parse digest: %w",
 					rm.Digest, rm.RepositoryName, err)
 			}
-			repo, err := keppel.FindRepository(j.db, rm.RepositoryName, *accountModel)
+			repo, err := keppel.FindRepository(j.db, rm.RepositoryName, accountName)
 			if err != nil {
 				return false, fmt.Errorf("while deleting manifest %q in repository %q: could not find repository in DB: %w",
 					rm.Digest, rm.RepositoryName, err)

--- a/internal/tasks/account_management.go
+++ b/internal/tasks/account_management.go
@@ -41,7 +41,7 @@ import (
 
 // EnforceManagedAccounts is a job. Each task creates newly discovered accounts from the driver.
 func (j *Janitor) EnforceManagedAccountsJob(registerer prometheus.Registerer) jobloop.Job {
-	return (&jobloop.ProducerConsumerJob[string]{
+	return (&jobloop.ProducerConsumerJob[models.AccountName]{
 		Metadata: jobloop.JobMetadata{
 			ReadableName: "create new managed accounts",
 			CounterOpts: prometheus.CounterOpts{
@@ -65,14 +65,14 @@ var (
 	`)
 )
 
-func (j *Janitor) discoverManagedAccount(_ context.Context, _ prometheus.Labels) (accountName string, err error) {
+func (j *Janitor) discoverManagedAccount(_ context.Context, _ prometheus.Labels) (accountName models.AccountName, err error) {
 	managedAccountNames, err := j.amd.ManagedAccountNames()
 	if err != nil {
 		return "", fmt.Errorf("could not get ManagedAccountNames() from account management driver: %w", err)
 	}
 
 	// if there is a managed account that does not exist yet, create it
-	var existingAccountNames []string
+	var existingAccountNames []models.AccountName
 	_, err = j.db.Select(&existingAccountNames, "SELECT name FROM accounts WHERE is_managed")
 	if err != nil {
 		return "", err
@@ -88,7 +88,7 @@ func (j *Janitor) discoverManagedAccount(_ context.Context, _ prometheus.Labels)
 	return accountName, err
 }
 
-func (j *Janitor) enforceManagedAccount(ctx context.Context, accountName string, labels prometheus.Labels) error {
+func (j *Janitor) enforceManagedAccount(ctx context.Context, accountName models.AccountName, labels prometheus.Labels) error {
 	account, securityScanPolicies, err := j.amd.ConfigureAccount(accountName)
 	if err != nil {
 		return fmt.Errorf("could not ConfigureAccount(%q) in account management driver: %w", accountName, err)
@@ -130,7 +130,7 @@ func (j *Janitor) enforceManagedAccount(ctx context.Context, accountName string,
 	}
 }
 
-func (j *Janitor) tryDeleteManagedAccount(ctx context.Context, accountName string) (done bool, err error) {
+func (j *Janitor) tryDeleteManagedAccount(ctx context.Context, accountName models.AccountName) (done bool, err error) {
 	accountModel, err := keppel.FindAccount(j.db, accountName)
 	if err != nil {
 		return false, err
@@ -201,7 +201,7 @@ func (j *Janitor) createOrUpdateManagedAccount(ctx context.Context, account kepp
 	getSubleaseToken := func(peer models.Peer) (string, *keppel.RegistryV2Error) {
 		viewScope := auth.Scope{
 			ResourceType: "keppel_account",
-			ResourceName: account.Name,
+			ResourceName: string(account.Name),
 			Actions:      []string{"view"},
 		}
 

--- a/internal/test/driver_federation.go
+++ b/internal/test/driver_federation.go
@@ -39,7 +39,7 @@ type FederationDriver struct {
 	ClaimFailsBecauseOfServerError bool
 	ForfeitFails                   bool
 	NextSubleaseTokenSecretToIssue string
-	ValidSubleaseTokenSecrets      map[string]string // maps accountName => subleaseTokenSecret
+	ValidSubleaseTokenSecrets      map[models.AccountName]string
 	RecordedAccounts               []AccountRecordedByFederationDriver
 }
 
@@ -59,7 +59,7 @@ func (d *FederationDriver) PluginTypeID() string { return "unittest" }
 // Init implements the keppel.FederationDriver interface.
 func (d *FederationDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) error {
 	d.APIPublicHostName = cfg.APIPublicHostname
-	d.ValidSubleaseTokenSecrets = make(map[string]string)
+	d.ValidSubleaseTokenSecrets = make(map[models.AccountName]string)
 	federationDriversForThisUnitTest = append(federationDriversForThisUnitTest, d)
 	return nil
 }
@@ -115,7 +115,7 @@ func (d *FederationDriver) RecordExistingAccount(ctx context.Context, account mo
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (d *FederationDriver) FindPrimaryAccount(ctx context.Context, accountName string) (string, error) {
+func (d *FederationDriver) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (string, error) {
 	for _, fd := range federationDriversForThisUnitTest {
 		for _, a := range fd.RecordedAccounts {
 			if a.Account.Name == accountName && a.Account.UpstreamPeerHostName == "" {

--- a/internal/test/helper_auth.go
+++ b/internal/test/helper_auth.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sapcc/keppel/internal/auth"
 	"github.com/sapcc/keppel/internal/keppel"
+	"github.com/sapcc/keppel/internal/models"
 )
 
 // GetToken obtains a token for use with the Registry V2 API.
@@ -47,7 +48,7 @@ func (s Setup) GetAnycastToken(t *testing.T, scopes ...string) string {
 
 // GetDomainRemappedToken is like GetToken, but instead returns a token for a
 // domain-remapped API.
-func (s Setup) GetDomainRemappedToken(t *testing.T, accountName string, scopes ...string) string {
+func (s Setup) GetDomainRemappedToken(t *testing.T, accountName models.AccountName, scopes ...string) string {
 	t.Helper()
 	return s.getToken(t, auth.Audience{IsAnycast: false, AccountName: accountName}, scopes...)
 }
@@ -111,7 +112,7 @@ func (s Setup) getToken(t *testing.T, audience auth.Audience, scopes ...string) 
 			if strings.Join(scope.Actions, ",") != "view" {
 				t.Fatalf("do not know how to handle scope %q", scope.String())
 			}
-			authTenantID, err := s.findAuthTenantIDForAccountName(scope.ResourceName)
+			authTenantID, err := s.findAuthTenantIDForAccountName(models.AccountName(scope.ResourceName))
 			mustDo(t, err)
 			perms[string(keppel.CanViewAccount)][authTenantID] = true
 		}
@@ -132,7 +133,7 @@ func (s Setup) getToken(t *testing.T, audience auth.Audience, scopes ...string) 
 	return tokenResp.Token
 }
 
-func (s Setup) findAuthTenantIDForAccountName(accountName string) (string, error) {
+func (s Setup) findAuthTenantIDForAccountName(accountName models.AccountName) (string, error) {
 	//optimization: if we can find this specific account in the list of
 	// pre-provisioned accounts, we can skip the DB lookup
 	for _, a := range s.Accounts {

--- a/internal/test/helper_upload.go
+++ b/internal/test/helper_upload.go
@@ -70,8 +70,7 @@ func (b Bytes) MustUpload(t *testing.T, s Setup, repo models.Repository) models.
 	// validate uploaded blob (FindBlobByRepository does not work here because we
 	// are usually given a Repository instance that does not have the ID field
 	// filled)
-	account := models.Account{Name: repo.AccountName}
-	blob, err := keppel.FindBlobByRepositoryName(s.DB, b.Digest, repo.Name, account)
+	blob, err := keppel.FindBlobByRepositoryName(s.DB, b.Digest, repo.Name, repo.AccountName)
 	mustDo(t, err)
 	s.ExpectBlobsExistInStorage(t, *blob)
 	if t.Failed() {
@@ -125,8 +124,7 @@ func (i Image) MustUpload(t *testing.T, s Setup, repo models.Repository, tagName
 	}
 
 	// validate uploaded manifest
-	account := models.Account{Name: repo.AccountName}
-	manifest, err := keppel.FindManifestByRepositoryName(s.DB, repo.Name, account, i.Manifest.Digest)
+	manifest, err := keppel.FindManifestByRepositoryName(s.DB, repo.Name, repo.AccountName, i.Manifest.Digest)
 	mustDo(t, err)
 	s.ExpectManifestsExistInStorage(t, repo.Name, *manifest)
 	if t.Failed() {
@@ -182,8 +180,7 @@ func (l ImageList) MustUpload(t *testing.T, s Setup, repo models.Repository, tag
 	}
 
 	// validate uploaded manifest
-	account := models.Account{Name: repo.AccountName}
-	manifest, err := keppel.FindManifestByRepositoryName(s.DB, repo.Name, account, l.Manifest.Digest)
+	manifest, err := keppel.FindManifestByRepositoryName(s.DB, repo.Name, repo.AccountName, l.Manifest.Digest)
 	mustDo(t, err)
 	s.ExpectManifestsExistInStorage(t, repo.Name, *manifest)
 	if t.Failed() {


### PR DESCRIPTION
I want to introduce a `type ReducedAccount` that only carries the most common fields of `type Account` and omits the expensive fields (esp. `..._policies_json`) to reduce DB read load. To make this transition easier, this introduces a typedef for `AccountName` and makes several core methods take just an `AccountName` instead of a full `Account`.