### PR TITLE
add models.ReducedAccount

### DIFF
--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -1825,7 +1825,7 @@ func uploadManifest(t *testing.T, s test.Setup, account *models.Account, repo *m
 		Digest:       manifest.Digest.String(),
 		Content:      manifest.Contents,
 	}))
-	mustDo(t, s.SD.WriteManifest(s.Ctx, *account, repo.Name, manifest.Digest, manifest.Contents))
+	mustDo(t, s.SD.WriteManifest(s.Ctx, account.Reduced(), repo.Name, manifest.Digest, manifest.Contents))
 	return dbManifest
 }
 
@@ -1872,11 +1872,11 @@ func TestDeleteAccount(t *testing.T) {
 		mustInsert(t, s.DB, &blob)
 		blobs = append(blobs, blob)
 
-		err := s.SD.AppendToBlob(s.Ctx, *accounts[0], storageID, 1, &blob.SizeBytes, bytes.NewReader(testBlob.Contents))
+		err := s.SD.AppendToBlob(s.Ctx, accounts[0].Reduced(), storageID, 1, &blob.SizeBytes, bytes.NewReader(testBlob.Contents))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		err = s.SD.FinalizeBlob(s.Ctx, *accounts[0], storageID, 1)
+		err = s.SD.FinalizeBlob(s.Ctx, accounts[0].Reduced(), storageID, 1)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -1900,7 +1900,7 @@ func TestDeleteAccount(t *testing.T) {
 		NextCheckAt:         time.Unix(0, 0),
 		VulnerabilityStatus: models.PendingVulnerabilityStatus,
 	})
-	err := s.SD.WriteManifest(s.Ctx, *accounts[0], repos[0].Name, image.Manifest.Digest, image.Manifest.Contents)
+	err := s.SD.WriteManifest(s.Ctx, accounts[0].Reduced(), repos[0].Name, image.Manifest.Digest, image.Manifest.Contents)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/internal/api/keppel/manifests.go
+++ b/internal/api/keppel/manifests.go
@@ -226,7 +226,7 @@ func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = a.processor().DeleteManifest(r.Context(), *account, *repo, parsedDigest, keppel.AuditContext{
+	err = a.processor().DeleteManifest(r.Context(), account.Reduced(), *repo, parsedDigest, keppel.AuditContext{
 		UserIdentity: authz.UserIdentity,
 		Request:      r,
 	})
@@ -257,7 +257,7 @@ func (a *API) handleDeleteTag(w http.ResponseWriter, r *http.Request) {
 	}
 	tagName := mux.Vars(r)["tag_name"]
 
-	err := a.processor().DeleteTag(*account, *repo, tagName, keppel.AuditContext{
+	err := a.processor().DeleteTag(account.Reduced(), *repo, tagName, keppel.AuditContext{
 		UserIdentity: authz.UserIdentity,
 		Request:      r,
 	})
@@ -283,7 +283,7 @@ func (a *API) handleGetTrivyReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := api.CheckRateLimit(r, a.rle, *account, authz, keppel.TrivyReportRetrieveAction, 1)
+	err := api.CheckRateLimit(r, a.rle, account.Reduced(), authz, keppel.TrivyReportRetrieveAction, 1)
 	if err != nil {
 		if rerr, ok := errext.As[*keppel.RegistryV2Error](err); ok && rerr != nil {
 			rerr.WriteAsRegistryV2ResponseTo(w, r)

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -132,7 +132,7 @@ func TestManifestsAPI(t *testing.T) {
 
 				err := s.SD.WriteManifest(
 					s.Ctx,
-					models.Account{Name: repo.AccountName},
+					models.ReducedAccount{Name: repo.AccountName},
 					repo.Name, dummyDigest, []byte(strings.Repeat("x", sizeBytes)),
 				)
 				if err != nil {

--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -197,7 +197,7 @@ func (info anycastRequestInfo) AsPrometheusLabels() prometheus.Labels {
 // If the account does not exist locally, but the request is for the anycast API
 // and the account exists elsewhere, the `anycastHandler` is invoked if given
 // instead of giving a 404 response.
-func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strategy repoAccessStrategy, anycastHandler func(http.ResponseWriter, *http.Request, anycastRequestInfo)) (*models.Account, *models.Repository, *auth.Authorization) {
+func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strategy repoAccessStrategy, anycastHandler func(http.ResponseWriter, *http.Request, anycastRequestInfo)) (*models.ReducedAccount, *models.Repository, *auth.Authorization) {
 	// must be set even for 401 responses!
 	w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
 
@@ -211,7 +211,7 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 		return nil, nil, nil
 	}
 
-	// check authorization before FindAccount(); otherwise we might leak
+	// check authorization before FindReducedAccount(); otherwise we might leak
 	// information about account existence to unauthorized users
 	switch r.Method {
 	case http.MethodDelete:
@@ -234,7 +234,7 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 
 	// we need to know the account to select the registry instance for this request
 	repoScope := scope.ParseRepositoryScope(authz.Audience)
-	account, err := keppel.FindAccount(a.db, repoScope.AccountName)
+	account, err := keppel.FindReducedAccount(a.db, repoScope.AccountName)
 	if respondWithError(w, r, err) {
 		return nil, nil, nil
 	}

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -30,7 +30,7 @@ import (
 	"github.com/sapcc/keppel/internal/models"
 )
 
-func CheckRateLimit(r *http.Request, rle *keppel.RateLimitEngine, account models.Account, authz *auth.Authorization, action keppel.RateLimitedAction, amount uint64) error {
+func CheckRateLimit(r *http.Request, rle *keppel.RateLimitEngine, account models.ReducedAccount, authz *auth.Authorization, action keppel.RateLimitedAction, amount uint64) error {
 	// rate-limiting is optional
 	if rle == nil {
 		return nil

--- a/internal/drivers/basic/ratelimit.go
+++ b/internal/drivers/basic/ratelimit.go
@@ -89,7 +89,7 @@ func (d RateLimitDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) er
 }
 
 // GetRateLimit implements the keppel.RateLimitDriver interface.
-func (d RateLimitDriver) GetRateLimit(account models.Account, action keppel.RateLimitedAction) *redis_rate.Limit {
+func (d RateLimitDriver) GetRateLimit(account models.ReducedAccount, action keppel.RateLimitedAction) *redis_rate.Limit {
 	quota, ok := d.Limits[action]
 	if ok {
 		return &quota

--- a/internal/drivers/filesystem/storage.go
+++ b/internal/drivers/filesystem/storage.go
@@ -52,24 +52,24 @@ func (d *StorageDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) (er
 	return err
 }
 
-func (d *StorageDriver) getBlobBasePath(account models.Account) string {
+func (d *StorageDriver) getBlobBasePath(account models.ReducedAccount) string {
 	return fmt.Sprintf("%s/%s/%s/blobs", d.rootPath, account.AuthTenantID, account.Name)
 }
 
-func (d *StorageDriver) getBlobPath(account models.Account, storageID string) string {
+func (d *StorageDriver) getBlobPath(account models.ReducedAccount, storageID string) string {
 	return fmt.Sprintf("%s/%s/%s/blobs/%s", d.rootPath, account.AuthTenantID, account.Name, storageID)
 }
 
-func (d *StorageDriver) getManifestBasePath(account models.Account) string {
+func (d *StorageDriver) getManifestBasePath(account models.ReducedAccount) string {
 	return fmt.Sprintf("%s/%s/%s/manifests", d.rootPath, account.AuthTenantID, account.Name)
 }
 
-func (d *StorageDriver) getManifestPath(account models.Account, repoName string, manifestDigest digest.Digest) string {
+func (d *StorageDriver) getManifestPath(account models.ReducedAccount, repoName string, manifestDigest digest.Digest) string {
 	return fmt.Sprintf("%s/%s/%s/manifests/%s/%s", d.rootPath, account.AuthTenantID, account.Name, repoName, manifestDigest)
 }
 
 // AppendToBlob implements the keppel.StorageDriver interface.
-func (d *StorageDriver) AppendToBlob(ctx context.Context, account models.Account, storageID string, chunkNumber uint32, chunkLength *uint64, chunk io.Reader) error {
+func (d *StorageDriver) AppendToBlob(ctx context.Context, account models.ReducedAccount, storageID string, chunkNumber uint32, chunkLength *uint64, chunk io.Reader) error {
 	path := d.getBlobPath(account, storageID)
 	tmpPath := path + ".tmp"
 	flags := os.O_APPEND | os.O_WRONLY
@@ -90,21 +90,21 @@ func (d *StorageDriver) AppendToBlob(ctx context.Context, account models.Account
 }
 
 // FinalizeBlob implements the keppel.StorageDriver interface.
-func (d *StorageDriver) FinalizeBlob(ctx context.Context, account models.Account, storageID string, chunkCount uint32) error {
+func (d *StorageDriver) FinalizeBlob(ctx context.Context, account models.ReducedAccount, storageID string, chunkCount uint32) error {
 	path := d.getBlobPath(account, storageID)
 	tmpPath := path + ".tmp"
 	return os.Rename(tmpPath, path)
 }
 
 // AbortBlobUpload implements the keppel.StorageDriver interface.
-func (d *StorageDriver) AbortBlobUpload(ctx context.Context, account models.Account, storageID string, chunkCount uint32) error {
+func (d *StorageDriver) AbortBlobUpload(ctx context.Context, account models.ReducedAccount, storageID string, chunkCount uint32) error {
 	path := d.getBlobPath(account, storageID)
 	tmpPath := path + ".tmp"
 	return os.Remove(tmpPath)
 }
 
 // ReadBlob implements the keppel.StorageDriver interface.
-func (d *StorageDriver) ReadBlob(ctx context.Context, account models.Account, storageID string) (io.ReadCloser, uint64, error) {
+func (d *StorageDriver) ReadBlob(ctx context.Context, account models.ReducedAccount, storageID string) (io.ReadCloser, uint64, error) {
 	path := d.getBlobPath(account, storageID)
 	f, err := os.Open(path)
 	if err != nil {
@@ -119,24 +119,24 @@ func (d *StorageDriver) ReadBlob(ctx context.Context, account models.Account, st
 }
 
 // URLForBlob implements the keppel.StorageDriver interface.
-func (d *StorageDriver) URLForBlob(ctx context.Context, account models.Account, storageID string) (string, error) {
+func (d *StorageDriver) URLForBlob(ctx context.Context, account models.ReducedAccount, storageID string) (string, error) {
 	return "", keppel.ErrCannotGenerateURL
 }
 
 // DeleteBlob implements the keppel.StorageDriver interface.
-func (d *StorageDriver) DeleteBlob(ctx context.Context, account models.Account, storageID string) error {
+func (d *StorageDriver) DeleteBlob(ctx context.Context, account models.ReducedAccount, storageID string) error {
 	path := d.getBlobPath(account, storageID)
 	return os.Remove(path)
 }
 
 // ReadManifest implements the keppel.StorageDriver interface.
-func (d *StorageDriver) ReadManifest(ctx context.Context, account models.Account, repoName string, manifestDigest digest.Digest) ([]byte, error) {
+func (d *StorageDriver) ReadManifest(ctx context.Context, account models.ReducedAccount, repoName string, manifestDigest digest.Digest) ([]byte, error) {
 	path := d.getManifestPath(account, repoName, manifestDigest)
 	return os.ReadFile(path)
 }
 
 // WriteManifest implements the keppel.StorageDriver interface.
-func (d *StorageDriver) WriteManifest(ctx context.Context, account models.Account, repoName string, manifestDigest digest.Digest, contents []byte) error {
+func (d *StorageDriver) WriteManifest(ctx context.Context, account models.ReducedAccount, repoName string, manifestDigest digest.Digest, contents []byte) error {
 	path := d.getManifestPath(account, repoName, manifestDigest)
 	tmpPath := path + ".tmp"
 	err := os.MkdirAll(filepath.Dir(tmpPath), 0777)
@@ -151,13 +151,13 @@ func (d *StorageDriver) WriteManifest(ctx context.Context, account models.Accoun
 }
 
 // DeleteManifest implements the keppel.StorageDriver interface.
-func (d *StorageDriver) DeleteManifest(ctx context.Context, account models.Account, repoName string, manifestDigest digest.Digest) error {
+func (d *StorageDriver) DeleteManifest(ctx context.Context, account models.ReducedAccount, repoName string, manifestDigest digest.Digest) error {
 	path := d.getManifestPath(account, repoName, manifestDigest)
 	return os.Remove(path)
 }
 
 // ListStorageContents implements the keppel.StorageDriver interface.
-func (d *StorageDriver) ListStorageContents(ctx context.Context, account models.Account) ([]keppel.StoredBlobInfo, []keppel.StoredManifestInfo, error) {
+func (d *StorageDriver) ListStorageContents(ctx context.Context, account models.ReducedAccount) ([]keppel.StoredBlobInfo, []keppel.StoredManifestInfo, error) {
 	blobs, err := d.getBlobs(account)
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +169,7 @@ func (d *StorageDriver) ListStorageContents(ctx context.Context, account models.
 	return blobs, manifests, nil
 }
 
-func (d *StorageDriver) getBlobs(account models.Account) ([]keppel.StoredBlobInfo, error) {
+func (d *StorageDriver) getBlobs(account models.ReducedAccount) ([]keppel.StoredBlobInfo, error) {
 	var blobs []keppel.StoredBlobInfo
 	directory, err := os.Open(d.getBlobBasePath(account))
 	if err != nil {
@@ -194,7 +194,7 @@ func (d *StorageDriver) getBlobs(account models.Account) ([]keppel.StoredBlobInf
 	return blobs, nil
 }
 
-func (d *StorageDriver) getManifests(account models.Account) ([]keppel.StoredManifestInfo, error) {
+func (d *StorageDriver) getManifests(account models.ReducedAccount) ([]keppel.StoredManifestInfo, error) {
 	var manifests []keppel.StoredManifestInfo
 	directory, err := os.Open(d.getManifestBasePath(account))
 	if err != nil {
@@ -218,7 +218,7 @@ func (d *StorageDriver) getManifests(account models.Account) ([]keppel.StoredMan
 	return manifests, nil
 }
 
-func (d *StorageDriver) getRepoManifests(account models.Account, repo string) ([]keppel.StoredManifestInfo, error) {
+func (d *StorageDriver) getRepoManifests(account models.ReducedAccount, repo string) ([]keppel.StoredManifestInfo, error) {
 	var manifests []keppel.StoredManifestInfo
 	directory, err := os.Open(filepath.Join(d.getManifestBasePath(account), repo))
 	if err != nil {
@@ -251,12 +251,12 @@ func (d *StorageDriver) getRepoManifests(account models.Account, repo string) ([
 }
 
 // CanSetupAccount implements the keppel.StorageDriver interface.
-func (d *StorageDriver) CanSetupAccount(ctx context.Context, account models.Account) error {
+func (d *StorageDriver) CanSetupAccount(ctx context.Context, account models.ReducedAccount) error {
 	return nil // this driver does not perform any preflight checks here
 }
 
 // CleanupAccount implements the keppel.StorageDriver interface.
-func (d *StorageDriver) CleanupAccount(ctx context.Context, account models.Account) error {
+func (d *StorageDriver) CleanupAccount(ctx context.Context, account models.ReducedAccount) error {
 	// double-check that cleanup order is right; when the account gets deleted,
 	// all blobs and manifests must have been deleted from it before
 	storedBlobs, storedManifests, err := d.ListStorageContents(ctx, account)

--- a/internal/keppel/account.go
+++ b/internal/keppel/account.go
@@ -69,7 +69,7 @@ func RenderAccount(dbAccount models.Account) (Account, error) {
 		Metadata:          metadata,
 		RBACPolicies:      rbacPolicies,
 		ReplicationPolicy: RenderReplicationPolicy(dbAccount),
-		ValidationPolicy:  RenderValidationPolicy(dbAccount),
+		ValidationPolicy:  RenderValidationPolicy(dbAccount.Reduced()),
 		PlatformFilter:    dbAccount.PlatformFilter,
 	}, nil
 }

--- a/internal/keppel/ratelimit_driver.go
+++ b/internal/keppel/ratelimit_driver.go
@@ -67,7 +67,7 @@ type RateLimitDriver interface {
 	Init(AuthDriver, Configuration) error
 
 	// GetRateLimit shall return nil if the given action has no rate limit.
-	GetRateLimit(account models.Account, action RateLimitedAction) *redis_rate.Limit
+	GetRateLimit(account models.ReducedAccount, action RateLimitedAction) *redis_rate.Limit
 }
 
 // RateLimitDriverRegistry is a pluggable.Registry for RateLimitDriver implementations.
@@ -96,7 +96,7 @@ type RateLimitEngine struct {
 
 // RateLimitAllows checks whether the given action on the given account is allowed by
 // the account's rate limit.
-func (e RateLimitEngine) RateLimitAllows(ctx context.Context, remoteAddr string, account models.Account, action RateLimitedAction, amount uint64) (bool, *redis_rate.Result, error) {
+func (e RateLimitEngine) RateLimitAllows(ctx context.Context, remoteAddr string, account models.ReducedAccount, action RateLimitedAction, amount uint64) (bool, *redis_rate.Result, error) {
 	rateQuota := e.Driver.GetRateLimit(account, action)
 	if rateQuota == nil {
 		// no rate limit for this account and action

--- a/internal/keppel/storage_driver.go
+++ b/internal/keppel/storage_driver.go
@@ -55,29 +55,29 @@ type StorageDriver interface {
 	// If `chunkLength` is non-nil, the implementation may assume that `chunk`
 	// will yield that many bytes, and return keppel.ErrSizeInvalid when that
 	// turns out not to be true.
-	AppendToBlob(ctx context.Context, account models.Account, storageID string, chunkNumber uint32, chunkLength *uint64, chunk io.Reader) error
+	AppendToBlob(ctx context.Context, account models.ReducedAccount, storageID string, chunkNumber uint32, chunkLength *uint64, chunk io.Reader) error
 	// FinalizeBlob() is called at the end of the upload, after the last
 	// AppendToBlob() call for that blob. `chunkCount` identifies how often
 	// AppendToBlob() was called.
-	FinalizeBlob(ctx context.Context, account models.Account, storageID string, chunkCount uint32) error
+	FinalizeBlob(ctx context.Context, account models.ReducedAccount, storageID string, chunkCount uint32) error
 	// AbortBlobUpload() is used to clean up after an error in AppendToBlob() or
 	// FinalizeBlob(). It is the counterpart of DeleteBlob() for when any part of
 	// the blob upload failed.
-	AbortBlobUpload(ctx context.Context, account models.Account, storageID string, chunkCount uint32) error
+	AbortBlobUpload(ctx context.Context, account models.ReducedAccount, storageID string, chunkCount uint32) error
 
-	ReadBlob(ctx context.Context, account models.Account, storageID string) (contents io.ReadCloser, sizeBytes uint64, err error)
+	ReadBlob(ctx context.Context, account models.ReducedAccount, storageID string) (contents io.ReadCloser, sizeBytes uint64, err error)
 	// If the blob can be retrieved by a publicly accessible URL, URLForBlob shall
 	// return it. Otherwise ErrCannotGenerateURL shall be returned to instruct the
 	// caller fall back to ReadBlob().
-	URLForBlob(ctx context.Context, account models.Account, storageID string) (string, error)
+	URLForBlob(ctx context.Context, account models.ReducedAccount, storageID string) (string, error)
 	// DeleteBlob may assume that FinalizeBlob() has been called. If an error
 	// occurred before or during FinalizeBlob(), AbortBlobUpload() will be called
 	// instead.
-	DeleteBlob(ctx context.Context, account models.Account, storageID string) error
+	DeleteBlob(ctx context.Context, account models.ReducedAccount, storageID string) error
 
-	ReadManifest(ctx context.Context, account models.Account, repoName string, digest digest.Digest) ([]byte, error)
-	WriteManifest(ctx context.Context, account models.Account, repoName string, digest digest.Digest, contents []byte) error
-	DeleteManifest(ctx context.Context, account models.Account, repoName string, digest digest.Digest) error
+	ReadManifest(ctx context.Context, account models.ReducedAccount, repoName string, digest digest.Digest) ([]byte, error)
+	WriteManifest(ctx context.Context, account models.ReducedAccount, repoName string, digest digest.Digest, contents []byte) error
+	DeleteManifest(ctx context.Context, account models.ReducedAccount, repoName string, digest digest.Digest) error
 
 	// This method shall only be used as a positive signal for the existence of a
 	// blob or manifest in the storage, not as a negative signal: If we expect a
@@ -85,17 +85,17 @@ type StorageDriver interface {
 	// lists, that does not necessarily mean it does not exist in the storage.
 	// This is because storage implementations may be backed by object stores with
 	// eventual consistency.
-	ListStorageContents(ctx context.Context, account models.Account) (blobs []StoredBlobInfo, manifests []StoredManifestInfo, err error)
+	ListStorageContents(ctx context.Context, account models.ReducedAccount) (blobs []StoredBlobInfo, manifests []StoredManifestInfo, err error)
 
 	// This method is called before a new account is set up in the DB. The
 	// StorageDriver can use this opportunity to check for any reasons why the
 	// account would not be functional once it is persisted in our DB.
-	CanSetupAccount(ctx context.Context, account models.Account) error
+	CanSetupAccount(ctx context.Context, account models.ReducedAccount) error
 	// This method can be used by the StorageDriver to perform last-minute cleanup
 	// on an account that we are about to delete. This cleanup should be
 	// reversible; we might bail out of the account deletion afterwards if the
 	// deletion in the DB fails.
-	CleanupAccount(ctx context.Context, account models.Account) error
+	CleanupAccount(ctx context.Context, account models.ReducedAccount) error
 }
 
 // StoredBlobInfo is returned by StorageDriver.ListStorageContents().

--- a/internal/keppel/validation.go
+++ b/internal/keppel/validation.go
@@ -33,7 +33,7 @@ type ValidationPolicy struct {
 
 // RenderValidationPolicy builds a ValidationPolicy object out of the
 // information in the given account model.
-func RenderValidationPolicy(account models.Account) *ValidationPolicy {
+func RenderValidationPolicy(account models.ReducedAccount) *ValidationPolicy {
 	if account.RequiredLabels == "" {
 		return nil
 	}

--- a/internal/processor/accounts.go
+++ b/internal/processor/accounts.go
@@ -260,7 +260,7 @@ func (p *Processor) CreateOrUpdateAccount(ctx context.Context, account keppel.Ac
 			return models.Account{}, keppel.AsRegistryV2Error(err).WithStatus(http.StatusInternalServerError)
 		}
 
-		err = p.sd.CanSetupAccount(ctx, targetAccount)
+		err = p.sd.CanSetupAccount(ctx, targetAccount.Reduced())
 		if err != nil {
 			msg := fmt.Errorf("cannot set up backing storage for this account: %w", err)
 			return models.Account{}, keppel.AsRegistryV2Error(msg).WithStatus(http.StatusConflict)
@@ -439,7 +439,7 @@ func (p *Processor) DeleteAccount(ctx context.Context, account models.Account, a
 
 	// before committing the transaction, confirm account deletion with the
 	// storage driver and the federation driver
-	err = p.sd.CleanupAccount(ctx, account)
+	err = p.sd.CleanupAccount(ctx, account.Reduced())
 	if err != nil {
 		return nil, fmt.Errorf("while cleaning up storage for account: %w", err)
 	}
@@ -460,9 +460,7 @@ func (p *Processor) DeleteAccount(ctx context.Context, account models.Account, a
 			User:       userInfo,
 			ReasonCode: http.StatusOK,
 			Action:     cadf.DeleteAction,
-			Target: auditManifest{
-				Account: account,
-			},
+			Target:     AuditAccount{Account: account},
 		})
 	}
 

--- a/internal/processor/blobs.go
+++ b/internal/processor/blobs.go
@@ -42,7 +42,7 @@ import (
 // ValidateExistingBlob validates the given blob that already exists in the DB.
 // Validation includes computing the digest of the blob contents and comparing
 // to the digest in the DB. On success, nil is returned.
-func (p *Processor) ValidateExistingBlob(ctx context.Context, account models.Account, blob models.Blob) (returnErr error) {
+func (p *Processor) ValidateExistingBlob(ctx context.Context, account models.ReducedAccount, blob models.Blob) (returnErr error) {
 	err := blob.Digest.Validate()
 	if err != nil {
 		return fmt.Errorf("cannot parse blob digest: %s", err.Error())
@@ -132,7 +132,7 @@ var (
 // our local registry. The result value `responseWasWritten` indicates whether
 // this happened. It may be false if an error occurred before writing into the
 // ResponseWriter took place.
-func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account models.Account, repo models.Repository, w http.ResponseWriter) (responseWasWritten bool, returnErr error) {
+func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account models.ReducedAccount, repo models.Repository, w http.ResponseWriter) (responseWasWritten bool, returnErr error) {
 	// mark this blob as currently being replicated
 	pendingBlob := models.PendingBlob{
 		AccountName:  account.Name,
@@ -198,7 +198,7 @@ func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account
 	return true, nil
 }
 
-func (p *Processor) uploadBlobToLocal(ctx context.Context, blob models.Blob, account models.Account, blobReader io.Reader, blobLengthBytes uint64) (returnErr error) {
+func (p *Processor) uploadBlobToLocal(ctx context.Context, blob models.Blob, account models.ReducedAccount, blobReader io.Reader, blobLengthBytes uint64) (returnErr error) {
 	defer func() {
 		// if blob upload fails, count an aborted upload
 		if returnErr != nil {
@@ -259,7 +259,7 @@ func (p *Processor) uploadBlobToLocal(ctx context.Context, blob models.Blob, acc
 // Warning: The upload's Digest field is *not* read or written. For chunked
 // uploads, the caller is responsible for performing and validating the digest
 // computation.
-func (p *Processor) AppendToBlob(ctx context.Context, account models.Account, upload *models.Upload, contents io.Reader, lengthBytes *uint64) error {
+func (p *Processor) AppendToBlob(ctx context.Context, account models.ReducedAccount, upload *models.Upload, contents io.Reader, lengthBytes *uint64) error {
 	// case 1: we know the length of the input and don't have to guess when to chunk
 	if lengthBytes != nil {
 		return foreachChunkWithKnownSize(contents, *lengthBytes, func(chunk io.Reader, chunkLengthBytes uint64) error {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -116,7 +116,7 @@ func (p *Processor) insideTransaction(ctx context.Context, action func(context.C
 // helper functions used by multiple Processor methods
 
 // Returns nil if and only if the user can push another manifest.
-func (p *Processor) checkQuotaForManifestPush(account models.Account) error {
+func (p *Processor) checkQuotaForManifestPush(account models.ReducedAccount) error {
 	// check if user has enough quota to push a manifest
 	quotas, err := keppel.FindQuotas(p.db, account.AuthTenantID)
 	if err != nil {
@@ -140,7 +140,7 @@ func (p *Processor) checkQuotaForManifestPush(account models.Account) error {
 
 // Takes a repo in a replica account and returns a RepoClient for accessing its
 // the upstream repo in the corresponding primary account.
-func (p *Processor) getRepoClientForUpstream(account models.Account, repo models.Repository) (*client.RepoClient, error) {
+func (p *Processor) getRepoClientForUpstream(account models.ReducedAccount, repo models.Repository) (*client.RepoClient, error) {
 	// use cached client if possible (this one probably already contains a valid
 	// pull token)
 	if c, ok := p.repoClients[repo.FullName()]; ok {

--- a/internal/tasks/account_management.go
+++ b/internal/tasks/account_management.go
@@ -179,7 +179,7 @@ func (j *Janitor) tryDeleteManagedAccount(ctx context.Context, accountName model
 				return false, fmt.Errorf("while deleting manifest %q in repository %q: could not find repository in DB: %w",
 					rm.Digest, rm.RepositoryName, err)
 			}
-			err = proc.DeleteManifest(ctx, *accountModel, *repo, parsedDigest, actx)
+			err = proc.DeleteManifest(ctx, accountModel.Reduced(), *repo, parsedDigest, actx)
 			if err != nil {
 				return false, fmt.Errorf("while deleting manifest %q in repository %q: %w",
 					rm.Digest, rm.RepositoryName, err)

--- a/internal/tasks/blobs.go
+++ b/internal/tasks/blobs.go
@@ -139,7 +139,7 @@ func (j *Janitor) sweepBlobsInRepo(ctx context.Context, account models.Account, 
 			return err
 		}
 		if blob.StorageID != "" { // ignore unbacked blobs that were never replicated
-			err = j.sd.DeleteBlob(ctx, account, blob.StorageID)
+			err = j.sd.DeleteBlob(ctx, account.Reduced(), blob.StorageID)
 			if err != nil {
 				return err
 			}
@@ -190,7 +190,7 @@ func (j *Janitor) validateBlob(ctx context.Context, blob models.Blob, _ promethe
 	}
 
 	// perform validation
-	err = j.processor().ValidateExistingBlob(ctx, *account, blob)
+	err = j.processor().ValidateExistingBlob(ctx, account.Reduced(), blob)
 	if err == nil {
 		// on success, reset error message and schedule next validation
 		_, err := j.db.Exec(validateBlobFinishQuery,

--- a/internal/tasks/image_gc.go
+++ b/internal/tasks/image_gc.go
@@ -97,7 +97,7 @@ func (j *Janitor) garbageCollectManifestsInRepo(ctx context.Context, repo models
 
 	// execute GC policies
 	if len(policiesForRepo) > 0 {
-		err = j.executeGCPolicies(ctx, *account, repo, policiesForRepo)
+		err = j.executeGCPolicies(ctx, account.Reduced(), repo, policiesForRepo)
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ type manifestData struct {
 	IsDeleted     bool
 }
 
-func (j *Janitor) executeGCPolicies(ctx context.Context, account models.Account, repo models.Repository, policies []keppel.GCPolicy) error {
+func (j *Janitor) executeGCPolicies(ctx context.Context, account models.ReducedAccount, repo models.Repository, policies []keppel.GCPolicy) error {
 	// load manifests in repo
 	var dbManifests []models.Manifest
 	_, err := j.db.Select(&dbManifests, `SELECT * FROM manifests WHERE repo_id = $1`, repo.ID)
@@ -207,7 +207,7 @@ func (j *Janitor) executeGCPolicies(ctx context.Context, account models.Account,
 	return j.persistGCStatus(manifests, repo.ID)
 }
 
-func (j *Janitor) evaluatePolicy(ctx context.Context, proc *processor.Processor, manifests []*manifestData, account models.Account, repo models.Repository, policy keppel.GCPolicy) error {
+func (j *Janitor) evaluatePolicy(ctx context.Context, proc *processor.Processor, manifests []*manifestData, account models.ReducedAccount, repo models.Repository, policy keppel.GCPolicy) error {
 	// for some time constraint matches, we need to know which manifests are
 	// still alive
 	var aliveManifests []models.Manifest

--- a/internal/tasks/manifests_test.go
+++ b/internal/tasks/manifests_test.go
@@ -165,7 +165,7 @@ func TestManifestValidationJobError(t *testing.T) {
 		NextCheckAt:         time.Unix(0, 0),
 		VulnerabilityStatus: models.PendingVulnerabilityStatus,
 	}))
-	mustDo(t, s.SD.WriteManifest(s.Ctx, *s.Accounts[0], "foo", image.Manifest.Digest, image.Manifest.Contents))
+	mustDo(t, s.SD.WriteManifest(s.Ctx, s.Accounts[0].Reduced(), "foo", image.Manifest.Digest, image.Manifest.Contents))
 
 	// validation should yield an error
 	s.Clock.StepBy(36 * time.Hour)

--- a/internal/tasks/storage_test.go
+++ b/internal/tasks/storage_test.go
@@ -75,7 +75,7 @@ func TestSweepStorageBlobs(t *testing.T) {
 	_, healthyBlobs, healthyManifests := setupStorageSweepTest(t, s, sweepStorageJob)
 
 	// put some blobs in the storage without adding them in the DB
-	account := models.Account{Name: "test1"}
+	account := models.ReducedAccount{Name: "test1"}
 	testBlob1 := test.GenerateExampleLayer(30)
 	testBlob2 := test.GenerateExampleLayer(31)
 	for _, blob := range []test.Bytes{testBlob1, testBlob2} {
@@ -163,7 +163,7 @@ func TestSweepStorageManifests(t *testing.T) {
 	images, healthyBlobs, healthyManifests := setupStorageSweepTest(t, s, sweepStorageJob)
 
 	// put some manifests in the storage without adding them in the DB
-	account := models.Account{Name: "test1"}
+	account := models.ReducedAccount{Name: "test1"}
 	testImageList1 := test.GenerateImageList(images[0])
 	testImageList2 := test.GenerateImageList(images[1])
 	for _, manifest := range []test.Bytes{testImageList1.Manifest, testImageList2.Manifest} {

--- a/internal/tasks/uploads.go
+++ b/internal/tasks/uploads.go
@@ -83,7 +83,7 @@ func (j *Janitor) deleteAbandonedUpload(ctx context.Context, tx *gorp.Transactio
 
 	// remove from backing storage if necessary
 	if upload.NumChunks > 0 {
-		err := j.sd.AbortBlobUpload(ctx, account, upload.StorageID, upload.NumChunks)
+		err := j.sd.AbortBlobUpload(ctx, account.Reduced(), upload.StorageID, upload.NumChunks)
 		if err != nil {
 			return fmt.Errorf("cannot AbortBlobUpload for abandoned upload %s: %s", upload.UUID, err.Error())
 		}

--- a/internal/tasks/uploads_test.go
+++ b/internal/tasks/uploads_test.go
@@ -41,7 +41,7 @@ var (
 )
 
 func TestDeleteAbandonedUploadWithZeroChunks(t *testing.T) {
-	testDeleteUpload(t, func(_ context.Context, sd keppel.StorageDriver, account models.Account) models.Upload {
+	testDeleteUpload(t, func(_ context.Context, sd keppel.StorageDriver, account models.ReducedAccount) models.Upload {
 		return models.Upload{
 			SizeBytes: 0,
 			Digest:    "",
@@ -51,7 +51,7 @@ func TestDeleteAbandonedUploadWithZeroChunks(t *testing.T) {
 }
 
 func TestDeleteAbandonedUploadWithOneChunk(t *testing.T) {
-	testDeleteUpload(t, func(ctx context.Context, sd keppel.StorageDriver, account models.Account) models.Upload {
+	testDeleteUpload(t, func(ctx context.Context, sd keppel.StorageDriver, account models.ReducedAccount) models.Upload {
 		data := "just some test data"
 		err := sd.AppendToBlob(ctx, account, testStorageID, 1, p2len(data), strings.NewReader(data))
 		if err != nil {
@@ -67,7 +67,7 @@ func TestDeleteAbandonedUploadWithOneChunk(t *testing.T) {
 }
 
 func TestDeleteAbandonedUploadWithManyChunks(t *testing.T) {
-	testDeleteUpload(t, func(ctx context.Context, sd keppel.StorageDriver, account models.Account) models.Upload {
+	testDeleteUpload(t, func(ctx context.Context, sd keppel.StorageDriver, account models.ReducedAccount) models.Upload {
 		chunks := []string{"just", "some", "test", "data"}
 		for idx, data := range chunks {
 			err := sd.AppendToBlob(ctx, account, testStorageID, uint32(idx+1), p2len(data), strings.NewReader(data)) //nolint:gosec // chunks has a fixed size of 4
@@ -85,9 +85,9 @@ func TestDeleteAbandonedUploadWithManyChunks(t *testing.T) {
 	})
 }
 
-func testDeleteUpload(t *testing.T, setupUploadObject func(context.Context, keppel.StorageDriver, models.Account) models.Upload) {
+func testDeleteUpload(t *testing.T, setupUploadObject func(context.Context, keppel.StorageDriver, models.ReducedAccount) models.Upload) {
 	j, s := setup(t)
-	account := models.Account{Name: "test1"}
+	account := models.ReducedAccount{Name: "test1"}
 	uploadJob := j.AbandonedUploadCleanupJob(s.Registry)
 
 	// right now, there are no upload objects, so DeleteNextAbandonedUpload should indicate that

--- a/internal/test/helper_validate.go
+++ b/internal/test/helper_validate.go
@@ -30,7 +30,7 @@ import (
 func (s Setup) ExpectBlobsExistInStorage(t *testing.T, blobs ...models.Blob) {
 	t.Helper()
 	for _, blob := range blobs {
-		account := models.Account{Name: blob.AccountName}
+		account := models.ReducedAccount{Name: blob.AccountName}
 		readCloser, sizeBytes, err := s.SD.ReadBlob(s.Ctx, account, blob.StorageID)
 		if err != nil {
 			t.Errorf("expected blob %s to exist in the storage, but got: %s", blob.Digest, err.Error())
@@ -70,7 +70,7 @@ func (s Setup) ExpectBlobsExistInStorage(t *testing.T, blobs ...models.Blob) {
 func (s Setup) ExpectBlobsMissingInStorage(t *testing.T, blobs ...models.Blob) {
 	t.Helper()
 	for _, blob := range blobs {
-		account := models.Account{Name: blob.AccountName}
+		account := models.ReducedAccount{Name: blob.AccountName}
 		_, _, err := s.SD.ReadBlob(s.Ctx, account, blob.StorageID)
 		if err == nil {
 			t.Errorf("expected blob %s to be missing in the storage, but could read it", blob.Digest)
@@ -85,7 +85,7 @@ func (s Setup) ExpectManifestsExistInStorage(t *testing.T, repoName string, mani
 	for _, manifest := range manifests {
 		repo, err := keppel.FindRepositoryByID(s.DB, manifest.RepositoryID)
 		mustDo(t, err)
-		account := models.Account{Name: repo.AccountName}
+		account := models.ReducedAccount{Name: repo.AccountName}
 		manifestBytes, err := s.SD.ReadManifest(s.Ctx, account, repoName, manifest.Digest)
 		if err != nil {
 			t.Errorf("expected manifest %s to exist in the storage, but got: %s", manifest.Digest, err.Error())
@@ -110,7 +110,7 @@ func (s Setup) ExpectManifestsMissingInStorage(t *testing.T, manifests ...models
 	for _, manifest := range manifests {
 		repo, err := keppel.FindRepositoryByID(s.DB, manifest.RepositoryID)
 		mustDo(t, err)
-		account := models.Account{Name: repo.AccountName}
+		account := models.ReducedAccount{Name: repo.AccountName}
 		_, err = s.SD.ReadManifest(s.Ctx, account, "foo", manifest.Digest)
 		if err == nil {
 			t.Errorf("expected manifest %s to be missing in the storage, but could read it", manifest.Digest)


### PR DESCRIPTION
The StorageDriver and most Processor methods are changed to only take the models.ReducedAccount instead of the full models.Account type.

This allows the Registry API (which is the most-used one by a wide margin) to only load ReducedAccount. This should reduce the read load on the DB noticeably.