### PR TITLE
api/liquid: add topology declaration

### DIFF
--- a/internal/api/keppel/liquid.go
+++ b/internal/api/keppel/liquid.go
@@ -42,6 +42,7 @@ func (a *API) handleLiquidGetInfo(w http.ResponseWriter, r *http.Request) {
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"images": {
 				Unit:        liquid.UnitNone,
+				Topology:    liquid.FlatResourceTopology,
 				HasCapacity: false,
 				HasQuota:    true,
 			},


### PR DESCRIPTION
This is a new capability added in go-api-declarations 1.13.0 which will eventually become mandatory in Limes.