### PR TITLE
bring back accounts.in_maintenance temporarily

### DIFF
--- a/internal/api/keppel/accounts.go
+++ b/internal/api/keppel/accounts.go
@@ -117,11 +117,6 @@ func (a *API) handlePutAccount(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `malformed attribute "account.state" in request body is not allowed here`, http.StatusUnprocessableEntity)
 		return
 	}
-	// ... or in_maintenance ...
-	if req.Account.InMaintenance {
-		http.Error(w, `malformed attribute "account.in_maintenance" in request body is not allowed here`, http.StatusUnprocessableEntity)
-		return
-	}
 	// ... or metadata ...
 	if req.Account.Metadata != nil && len(*req.Account.Metadata) > 0 {
 		http.Error(w, `malformed attribute "account.metadata" in request body is not allowed here`, http.StatusUnprocessableEntity)

--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -419,6 +419,36 @@ func TestAccountsAPI(t *testing.T) {
 	`)
 }
 
+func TestPutAccountInMaintenanceFlag(t *testing.T) {
+	s := test.NewSetup(t, test.WithKeppelAPI)
+	h := s.Handler
+
+	// TODO: remove the writing capability for accounts.in_maintenance once the Elektra UI does not depend on it anymore
+	for _, inMaintenance := range []bool{false, true, false} {
+		assert.HTTPRequest{
+			Method: "PUT",
+			Path:   "/keppel/v1/accounts/first",
+			Header: map[string]string{"X-Test-Perms": "change:tenant1"},
+			Body: assert.JSONObject{
+				"account": assert.JSONObject{
+					"auth_tenant_id": "tenant1",
+					"in_maintenance": inMaintenance,
+				},
+			},
+			ExpectStatus: http.StatusOK,
+			ExpectBody: assert.JSONObject{
+				"account": assert.JSONObject{
+					"name":           "first",
+					"auth_tenant_id": "tenant1",
+					"in_maintenance": inMaintenance,
+					"metadata":       nil,
+					"rbac_policies":  []assert.JSONObject{},
+				},
+			},
+		}.Check(t, h)
+	}
+}
+
 func TestGetAccountsErrorCases(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
 	h := s.Handler
@@ -1131,19 +1161,20 @@ func TestPutAccountErrorCases(t *testing.T) {
 		ExpectBody:   assert.StringData("no permission for keppel_account:unknown:change\n"),
 	}.Check(t, h)
 
-	assert.HTTPRequest{
-		Method: "PUT",
-		Path:   "/keppel/v1/accounts/first",
-		Header: map[string]string{"X-Test-Perms": "change:tenant1"},
-		Body: assert.JSONObject{
-			"account": assert.JSONObject{
-				"auth_tenant_id": "tenant1",
-				"in_maintenance": true,
-			},
-		},
-		ExpectStatus: http.StatusUnprocessableEntity,
-		ExpectBody:   assert.StringData("malformed attribute \"account.in_maintenance\" in request body is not allowed here\n"),
-	}.Check(t, h)
+	// TODO: reenable once we completely remove support for the accounts.in_maintenance flag
+	// assert.HTTPRequest{
+	// 	Method: "PUT",
+	// 	Path:   "/keppel/v1/accounts/first",
+	// 	Header: map[string]string{"X-Test-Perms": "change:tenant1"},
+	// 	Body: assert.JSONObject{
+	// 		"account": assert.JSONObject{
+	// 			"auth_tenant_id": "tenant1",
+	// 			"in_maintenance": true,
+	// 		},
+	// 	},
+	// 	ExpectStatus: http.StatusUnprocessableEntity,
+	// 	ExpectBody:   assert.StringData("malformed attribute \"account.in_maintenance\" in request body is not allowed here\n"),
+	// }.Check(t, h)
 
 	assert.HTTPRequest{
 		Method: "PUT",

--- a/internal/keppel/account.go
+++ b/internal/keppel/account.go
@@ -66,5 +66,6 @@ func RenderAccount(dbAccount models.Account) (Account, error) {
 		ReplicationPolicy: RenderReplicationPolicy(dbAccount),
 		ValidationPolicy:  RenderValidationPolicy(dbAccount.Reduced()),
 		PlatformFilter:    dbAccount.PlatformFilter,
+		InMaintenance:     dbAccount.InMaintenance,
 	}, nil
 }

--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -326,6 +326,14 @@ var sqlMigrations = map[string]string{
 			DROP COLUMN is_deleting,
 			DROP COLUMN next_deletion_attempt_at;
 	`,
+	"044_bring_back_accounts_in_maintenance_as_dummy.up.sql": `
+		ALTER TABLE accounts
+			ADD COLUMN in_maintenance BOOLEAN NOT NULL DEFAULT FALSE;
+	`,
+	"044_bring_back_accounts_in_maintenance_as_dummy.down.sql": `
+		ALTER TABLE accounts
+			DROP COLUMN in_maintenance;
+	`,
 }
 
 // DB adds convenience functions on top of gorp.DbMap.

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -63,6 +63,9 @@ type Account struct {
 	NextEnforcementAt            *time.Time `db:"next_enforcement_at"`             // see tasks.CreateManagedAccountsJob
 	NextStorageSweepedAt         *time.Time `db:"next_storage_sweep_at"`           // see tasks.StorageSweepJob
 	NextFederationAnnouncementAt *time.Time `db:"next_federation_announcement_at"` // see tasks.AnnounceAccountToFederationJob
+
+	// TODO: remove once the Elektra UI has been updated to not require this flag to proceed with account deletion
+	InMaintenance bool `db:"in_maintenance"`
 }
 
 // Reduced converts an Account into a ReducedAccount.

--- a/internal/processor/accounts.go
+++ b/internal/processor/accounts.go
@@ -105,6 +105,7 @@ func (p *Processor) CreateOrUpdateAccount(ctx context.Context, account keppel.Ac
 
 	// validate and update fields as requested
 	targetAccount.IsDeleting = account.State == "deleting"
+	targetAccount.InMaintenance = account.InMaintenance
 
 	// validate GC policies
 	if len(account.GCPolicies) == 0 {


### PR DESCRIPTION
In order to not break the account deletion workflow in the Elektra UI.