### PR TITLE
fix new lints as of golangci-lint 2.1.2

### DIFF
--- a/internal/client/validate.go
+++ b/internal/client/validate.go
@@ -104,14 +104,14 @@ func (c *RepoClient) doValidateManifest(ctx context.Context, reference models.Ma
 		return err
 	}
 
-	digest := digest.FromBytes(manifestBytes)
+	manifestDigest := digest.FromBytes(manifestBytes)
 
-	if reference.Digest != "" && digest != reference.Digest {
-		return keppel.ErrDigestInvalid.With("actual manifest digest is " + digest.String())
+	if reference.Digest != "" && manifestDigest != reference.Digest {
+		return keppel.ErrDigestInvalid.With("actual manifest digest is " + manifestDigest.String())
 	}
 
 	// the manifest itself looks good...
-	session.Logger.LogManifest(models.ManifestReference{Digest: digest}, level, nil, false)
+	session.Logger.LogManifest(models.ManifestReference{Digest: manifestDigest}, level, nil, false)
 	logged = true
 
 	// ...now recurse into the manifests and blobs that it references
@@ -129,7 +129,7 @@ func (c *RepoClient) doValidateManifest(ctx context.Context, reference models.Ma
 	}
 
 	// write validity into cache only after all references have been validated as well
-	session.isValid[c.validationCacheKey(digest.String())] = true
+	session.isValid[c.validationCacheKey(manifestDigest.String())] = true
 	session.isValid[c.validationCacheKey(reference.String())] = true
 	return nil
 }

--- a/internal/drivers/trivial/account_management.go
+++ b/internal/drivers/trivial/account_management.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 // PluginTypeID implements the keppel.AccountManagementDriver interface.
-func (a *AccountManagementDriver) PluginTypeID() string { return "trivial" } //nolint:goconst
+func (a *AccountManagementDriver) PluginTypeID() string { return driverName }
 
 // Init implements the keppel.AccountManagementDriver interface.
 func (a *AccountManagementDriver) Init() error {

--- a/internal/drivers/trivial/auth.go
+++ b/internal/drivers/trivial/auth.go
@@ -35,6 +35,8 @@ func init() {
 	keppel.UserIdentityRegistry.Add(func() keppel.UserIdentity { return &userIdentity{} })
 }
 
+const driverName = "trivial"
+
 ////////////////////////////////////////////////////////////////////////////////
 // type userIdentity
 
@@ -43,7 +45,7 @@ type userIdentity struct {
 }
 
 func (uid *userIdentity) PluginTypeID() string {
-	return "trivial"
+	return driverName
 }
 
 func (uid *userIdentity) HasPermission(perm keppel.Permission, tenantID string) bool {
@@ -79,7 +81,7 @@ type AuthDriver struct {
 }
 
 func (d *AuthDriver) PluginTypeID() string {
-	return "trivial"
+	return driverName
 }
 
 func (d *AuthDriver) Init(ctx context.Context, rc *redis.Client) error {

--- a/internal/drivers/trivial/federation.go
+++ b/internal/drivers/trivial/federation.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 // PluginTypeID implements the keppel.FederationDriver interface.
-func (federationDriver) PluginTypeID() string { return "trivial" }
+func (federationDriver) PluginTypeID() string { return driverName }
 
 // Init implements the keppel.FederationDriver interface.
 func (federationDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) error {

--- a/internal/drivers/trivial/inbound_cache.go
+++ b/internal/drivers/trivial/inbound_cache.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 // PluginTypeID implements the keppel.InboundCacheDriver interface.
-func (inboundCacheDriver) PluginTypeID() string { return "trivial" }
+func (inboundCacheDriver) PluginTypeID() string { return driverName }
 
 // Init implements the keppel.InboundCacheDriver interface.
 func (inboundCacheDriver) Init(ctx context.Context, cfg keppel.Configuration) error {

--- a/internal/test/content.go
+++ b/internal/test/content.go
@@ -350,7 +350,7 @@ func GenerateOCIImage(ociArgs OCIArgs, layers ...Bytes) Image {
 		})
 	}
 
-	manifest := manifest.OCI1{
+	ociManifest := manifest.OCI1{
 		Manifest: imgspecv1.Manifest{
 			Versioned: specs.Versioned{SchemaVersion: 2},
 			MediaType: imgspecv1.MediaTypeImageManifest,
@@ -365,19 +365,19 @@ func GenerateOCIImage(ociArgs OCIArgs, layers ...Bytes) Image {
 	}
 
 	if ociArgs.SubjectDigest != "" {
-		manifest.Subject = &imgspecv1.Descriptor{
+		ociManifest.Subject = &imgspecv1.Descriptor{
 			MediaType: imgspecv1.MediaTypeImageManifest,
 			Digest:    ociArgs.SubjectDigest,
 		}
 	}
 
 	if ociArgs.ArtifactType != "" {
-		manifest.ArtifactType = ociArgs.ArtifactType
+		ociManifest.ArtifactType = ociArgs.ArtifactType
 	}
 
 	return Image{
 		Layers:   layers,
 		Config:   newBytesWithMediaType(must.Return(json.Marshal(ociArgs.Config)), ociArgs.ConfigMediaType),
-		Manifest: newBytesWithMediaType(must.Return(json.Marshal(manifest)), manifest.MediaType),
+		Manifest: newBytesWithMediaType(must.Return(json.Marshal(ociManifest)), ociManifest.MediaType),
 	}
 }


### PR DESCRIPTION
```
$ golangci-lint run --fix
internal/drivers/trivial/inbound_cache.go:38:58: string `trivial` has 5 occurrences, make it a constant (goconst)
internal/client/validate.go:107:2: importShadow: shadow of imported from 'github.com/opencontainers/go-digest' package 'digest' (gocritic)
internal/test/content.go:353:2: importShadow: shadow of imported from 'github.com/containers/image/v5/manifest' package 'manifest' (gocritic)
```