### PR TITLE
switch password hash for peer credentials from BCrypt to SHA-256

### DIFF
--- a/internal/models/peer.go
+++ b/internal/models/peer.go
@@ -31,7 +31,7 @@ type Peer struct {
 	OurPassword string `db:"our_password"`
 
 	// TheirCurrentPasswordHash and TheirPreviousPasswordHash is what the peer
-	// uses to log in with us. Passwords are rotated hourly. We allow access with
+	// uses to log in with us. Passwords are rotated every 10min. We allow access with
 	// the current *and* the previous password to avoid a race where we enter the
 	// new password in the database and then reject authentication attempts from
 	// the peer before we told them about the new password.

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"github.com/sapcc/go-bits/audittools"
@@ -35,7 +36,6 @@ import (
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/mock"
 	"github.com/sapcc/go-bits/osext"
-	"golang.org/x/crypto/bcrypt"
 
 	authapi "github.com/sapcc/keppel/internal/api/auth"
 	keppelv1 "github.com/sapcc/keppel/internal/api/keppel"
@@ -183,9 +183,7 @@ func GetReplicationPassword() string {
 	if replicationPassword == "" {
 		// this password needs to be constant because it appears in some fixtures/*.sql
 		replicationPassword = "a4cb6fae5b8bb91b0b993486937103dab05eca93" //nolint:gosec // hardcoded password for test fixtures
-
-		hashBytes, _ := bcrypt.GenerateFromPassword([]byte(replicationPassword), 8) //nolint:errcheck
-		replicationPasswordHash = string(hashBytes)
+		replicationPasswordHash = digest.SHA256.FromString(replicationPassword).String()
 	}
 	return replicationPassword
 }


### PR DESCRIPTION
As explained in the code commit, I find the security tradeoff acceptable here. This change speeds up the test suite by 40%, and I anticipate similar, if not better performance gains in production.

Note that BCrypt is still accepted for existing passwords, to ensure a smooth migration. Once this is deployed and running for more than 20 minutes, I will remove the BCrypt codepath.