### PR TITLE
Persist trivy reports

### DIFF
--- a/internal/api/keppel/manifests.go
+++ b/internal/api/keppel/manifests.go
@@ -348,13 +348,15 @@ func (a *API) handleGetTrivyReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	relevantPolicies, err := keppel.GetSecurityScanPolicies(*account, *repo)
-	if respondwith.ErrorText(w, err) {
-		return
-	}
-	err = relevantPolicies.EnrichReport(&report)
-	if respondwith.ErrorText(w, err) {
-		return
+	if report.Format == "json" {
+		relevantPolicies, err := keppel.GetSecurityScanPolicies(*account, *repo)
+		if respondwith.ErrorText(w, err) {
+			return
+		}
+		_, err = relevantPolicies.EnrichReport(&report)
+		if respondwith.ErrorText(w, err) {
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -343,6 +343,23 @@ var sqlMigrations = map[string]string{
 	"047_add_manifest_subject_digest_index.down.sql": `
 		DROP INDEX manifests_repo_id_subject_digest_idx;
 	`,
+	"048_stored_trivy_reports.up.sql": `
+		ALTER TABLE trivy_security_info
+			ADD COLUMN has_enriched_report BOOLEAN NOT NULL DEFAULT FALSE;
+		CREATE TABLE unknown_trivy_reports (
+			account_name      TEXT        NOT NULL REFERENCES accounts ON DELETE CASCADE,
+			repo_name         TEXT        NOT NULL,
+			digest            TEXT        NOT NULL,
+			format            TEXT        NOT NULL,
+			can_be_deleted_at TIMESTAMPTZ NOT NULL,
+			PRIMARY KEY (account_name, repo_name, digest, format)
+		);
+	`,
+	"048_stored_trivy_reports.down.sql": `
+		ALTER TABLE trivy_security_info
+			DROP COLUMN has_enriched_report;
+		DROP TABLE unknown_trivy_reports;
+	`,
 }
 
 // DB adds convenience functions on top of gorp.DbMap.
@@ -383,6 +400,7 @@ func InitORM(dbConn *sql.DB) *DB {
 	result.DbMap.AddTableWithName(models.PendingBlob{}, "pending_blobs").SetKeys(false, "account_name", "digest")
 	result.DbMap.AddTableWithName(models.UnknownBlob{}, "unknown_blobs").SetKeys(false, "account_name", "storage_id")
 	result.DbMap.AddTableWithName(models.UnknownManifest{}, "unknown_manifests").SetKeys(false, "account_name", "repo_name", "digest")
+	result.DbMap.AddTableWithName(models.UnknownTrivyReport{}, "unknown_trivy_reports").SetKeys(false, "account_name", "repo_name", "digest", "format")
 	result.DbMap.AddTableWithName(models.TrivySecurityInfo{}, "trivy_security_info").SetKeys(false, "repo_id", "digest")
 
 	return result

--- a/internal/models/trivy.go
+++ b/internal/models/trivy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
+// TrivySecurityInfo contains a record from the `trivy_security_info` table.
 type TrivySecurityInfo struct {
 	RepositoryID        int64               `db:"repo_id"`
 	Digest              digest.Digest       `db:"digest"`
@@ -17,4 +18,7 @@ type TrivySecurityInfo struct {
 	NextCheckAt         time.Time           `db:"next_check_at"` // see tasks.CheckTrivySecurityStatusJob
 	CheckedAt           *time.Time          `db:"checked_at"`
 	CheckDurationSecs   *float64            `db:"check_duration_secs"`
+
+	// Whether a report with `--format json` is stored for this manifest.
+	HasEnrichedReport bool `db:"has_enriched_report"`
 }

--- a/internal/models/unknown.go
+++ b/internal/models/unknown.go
@@ -28,3 +28,16 @@ type UnknownManifest struct {
 	Digest         digest.Digest `db:"digest"`
 	CanBeDeletedAt time.Time     `db:"can_be_deleted_at"`
 }
+
+// UnknownTrivyReport contains a record from the `unknown_trivy_reports` table.
+// This is only used by tasks.StorageSweepJob().
+//
+// NOTE: We don't use repository IDs here because unknown Trivy reports may exist in
+// repositories that are also not known to the database.
+type UnknownTrivyReport struct {
+	AccountName    AccountName   `db:"account_name"`
+	RepositoryName string        `db:"repo_name"`
+	Digest         digest.Digest `db:"digest"`
+	Format         string        `db:"format"`
+	CanBeDeletedAt time.Time     `db:"can_be_deleted_at"`
+}

--- a/internal/processor/manifests.go
+++ b/internal/processor/manifests.go
@@ -451,7 +451,7 @@ var upsertManifestQuery = sqlext.SimplifyWhitespace(`
 	ON CONFLICT (repo_id, digest) DO UPDATE
 		SET size_bytes = EXCLUDED.size_bytes, next_validation_at = EXCLUDED.next_validation_at, labels_json = EXCLUDED.labels_json,
 		min_layer_created_at = EXCLUDED.min_layer_created_at, max_layer_created_at = EXCLUDED.max_layer_created_at,
-    annotations_json = EXCLUDED.annotations_json, artifact_type = EXCLUDED.artifact_type, subject_digest = EXCLUDED.subject_digest
+		annotations_json = EXCLUDED.annotations_json, artifact_type = EXCLUDED.artifact_type, subject_digest = EXCLUDED.subject_digest
 `)
 
 var upsertManifestContentQuery = sqlext.SimplifyWhitespace(`
@@ -854,6 +854,14 @@ func (p *Processor) DeleteManifest(ctx context.Context, account models.ReducedAc
 		tags = append(tags, tagResult.Name)
 	}
 
+	var securityInfo models.TrivySecurityInfo
+	_, err = p.db.Select(&securityInfo,
+		`SELECT * FROM trivy_security_info WHERE repo_id = $1 AND digest = $2`,
+		repo.ID, manifestDigest)
+	if err != nil {
+		return err
+	}
+
 	result, err := p.db.Exec(
 		// this also deletes tags referencing this manifest because of "ON DELETE CASCADE"
 		`DELETE FROM manifests WHERE repo_id = $1 AND digest = $2`,
@@ -893,6 +901,12 @@ func (p *Processor) DeleteManifest(ctx context.Context, account models.ReducedAc
 	err = p.sd.DeleteManifest(ctx, account, repo.Name, manifestDigest)
 	if err != nil {
 		return err
+	}
+	if securityInfo.HasEnrichedReport {
+		err = p.sd.DeleteTrivyReport(ctx, account, repo.Name, manifestDigest, "json")
+		if err != nil {
+			return err
+		}
 	}
 
 	if userInfo := actx.UserIdentity.UserInfo(); userInfo != nil {

--- a/internal/tasks/manifests.go
+++ b/internal/tasks/manifests.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sapcc/keppel/internal/keppel"
 	"github.com/sapcc/keppel/internal/models"
 	"github.com/sapcc/keppel/internal/processor"
-	"github.com/sapcc/keppel/internal/trivy"
 )
 
 // query that finds the next manifest to be validated
@@ -689,28 +688,20 @@ func (j *Janitor) doSecurityCheck(ctx context.Context, securityInfo *models.Triv
 	var securityStatuses []models.VulnerabilityStatus
 
 	if len(layerBlobs) > 0 {
-		parsedTrivyReport, err := j.cfg.Trivy.ScanManifestAndParse(ctx, tokenResp.Token, imageRef)
+		payload, err := j.cfg.Trivy.ScanManifest(ctx, tokenResp.Token, imageRef, "json")
 		if err != nil {
 			return fmt.Errorf("scan error: %w", err)
 		}
-
-		if parsedTrivyReport.Metadata.IsRotten() {
-			securityStatuses = append(securityStatuses, models.RottenVulnerabilityStatus)
+		status, err := relevantPolicies.EnrichReport(&payload)
+		if err != nil {
+			return fmt.Errorf("could not process report: %w", err)
 		}
-		for _, result := range parsedTrivyReport.Results {
-			for _, vuln := range result.Vulnerabilities {
-				securityStatus, ok := trivy.MapToTrivySeverity[vuln.Severity]
-				if !ok {
-					return fmt.Errorf("vulnerability severity with name %s returned from trivy is unknown and cannot be mapped", securityStatus)
-				}
-
-				policy := relevantPolicies.PolicyForVulnerability(vuln)
-				if policy != nil {
-					securityStatus = policy.VulnerabilityStatus()
-				}
-				securityStatuses = append(securityStatuses, securityStatus)
-			}
+		securityStatuses = append(securityStatuses, status)
+		err = j.sd.WriteTrivyReport(ctx, account.Reduced(), repo.Name, securityInfo.Digest, payload)
+		if err != nil {
+			return fmt.Errorf("could not store report: %w", err)
 		}
+		securityInfo.HasEnrichedReport = true
 	}
 
 	// could the image have constituent images?

--- a/internal/tasks/manifests_test.go
+++ b/internal/tasks/manifests_test.go
@@ -835,9 +835,10 @@ func TestManifestValidationJobWithoutPlatform(t *testing.T) {
 	expectSuccess(t, validateManifestJob.ProcessOne(s.Ctx))
 	expectError(t, sql.ErrNoRows.Error(), validateManifestJob.ProcessOne(s.Ctx))
 	tr.DBChanges().AssertEqualf(`
-      UPDATE manifests SET next_validation_at = %d WHERE repo_id = 1 AND digest = '%s';
-      UPDATE manifests SET next_validation_at = %d WHERE repo_id = 1 AND digest = '%s';
-    `, s.Clock.Now().Add(models.ManifestValidationInterval).Unix(), imageList.Manifest.Digest,
+			UPDATE manifests SET next_validation_at = %d WHERE repo_id = 1 AND digest = '%s';
+			UPDATE manifests SET next_validation_at = %d WHERE repo_id = 1 AND digest = '%s';
+		`,
+		s.Clock.Now().Add(models.ManifestValidationInterval).Unix(), imageList.Manifest.Digest,
 		s.Clock.Now().Add(models.ManifestValidationInterval).Unix(), image.Manifest.Digest,
 	)
 }

--- a/internal/test/helper_validate.go
+++ b/internal/test/helper_validate.go
@@ -4,8 +4,12 @@
 package test
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"testing"
+
+	"github.com/sapcc/go-bits/assert"
 
 	"github.com/sapcc/keppel/internal/keppel"
 	"github.com/sapcc/keppel/internal/models"
@@ -101,5 +105,30 @@ func (s Setup) ExpectManifestsMissingInStorage(t *testing.T, manifests ...models
 			t.Errorf("expected manifest %s to be missing in the storage, but could read it", manifest.Digest)
 			continue
 		}
+	}
+}
+
+// ExpectTrivyReportExistsInStorage is a test assertion.
+func (s Setup) ExpectTrivyReportExistsInStorage(t *testing.T, manifest models.Manifest, format string, contents assert.HTTPResponseBody) {
+	t.Helper()
+	repo, err := keppel.FindRepositoryByID(s.DB, manifest.RepositoryID)
+	mustDo(t, err)
+	account := models.ReducedAccount{Name: repo.AccountName}
+	buf, err := s.SD.ReadTrivyReport(s.Ctx, account, repo.Name, manifest.Digest, format)
+	if err != nil {
+		t.Errorf("expected Trivy report %s/%s to exist in the storage, but got: %s", manifest.Digest, format, err.Error())
+	}
+	contents.AssertResponseBody(t, fmt.Sprintf("Trivy report %s/%s", manifest.Digest, format), bytes.TrimSpace(buf))
+}
+
+// ExpectTrivyReportMissingInStorage is a test assertion.
+func (s Setup) ExpectTrivyReportMissingInStorage(t *testing.T, manifest models.Manifest, format string) {
+	t.Helper()
+	repo, err := keppel.FindRepositoryByID(s.DB, manifest.RepositoryID)
+	mustDo(t, err)
+	account := models.ReducedAccount{Name: repo.AccountName}
+	_, err = s.SD.ReadTrivyReport(s.Ctx, account, repo.Name, manifest.Digest, format)
+	if err == nil {
+		t.Errorf("expected Trivy report %s/%s to be missing in the storage, but could read it", manifest.Digest, format)
 	}
 }

--- a/internal/trivy/trivy.go
+++ b/internal/trivy/trivy.go
@@ -87,15 +87,3 @@ var ansiColorCodeRx = regexp.MustCompile("\x1B" + `\[[0-9;]*m`)
 func stripColor(in string) string {
 	return ansiColorCodeRx.ReplaceAllString(in, "")
 }
-
-// ScanManifest is like ScanManifestAndParse, except that the result is parsed
-// instead of being returned as a bytestring. The report format "json" is
-// implied in order to match the return type.
-func (tc *Config) ScanManifestAndParse(ctx context.Context, keppelToken string, manifestRef models.ImageReference) (Report, error) {
-	report, err := tc.ScanManifest(ctx, keppelToken, manifestRef, "json")
-	if err != nil {
-		return Report{}, err
-	}
-
-	return UnmarshalReportFromJSON(report.Contents)
-}


### PR DESCRIPTION
The final intent here is that, when a user asks for a Trivy report on the API, we can skip calling out to Trivy if we already have a report cached from a recent security status check.

The API change is not in here because the PR is already quite big as it is: What this commit does is to

- extend StorageDriver methods to read/write/list Trivy reports,
- adjust the storage sweep job to cleanup unexpected Trivy reports (in the same way as it already does for blobs and manifests),
- extend the security status check job to store Trivy reports, and
- extend Processor.DeleteManifest() to cleanup stored Trivy reports.

Note that the StorageDriver interface is written in a way that allows Trivy reports of any format to be stored, but this PR only uses this for `format = "json"` because that's what the security status check job has at hand. If, in the future, it turns out that we want to store other formats, this setup will allow extending the caching to additional formats without having to touch the StorageDriver implementations again (and with only minimal changes to the storage sweep job as well).

The DB schema is extended to track Trivy reports in storage, as well as unexpected Trivy reports that are in the process of being GC'd by the storage sweep.