### PR TITLE
support "tag_policies" field in managed accounts

### DIFF
--- a/internal/drivers/basic/account_management.go
+++ b/internal/drivers/basic/account_management.go
@@ -36,6 +36,7 @@ type Account struct {
 	RBACPolicies         []keppel.RBACPolicy         `json:"rbac_policies"`
 	ReplicationPolicy    *keppel.ReplicationPolicy   `json:"replication"`
 	SecurityScanPolicies []keppel.SecurityScanPolicy `json:"security_scan_policies"`
+	TagPolicies          []keppel.TagPolicy          `json:"tag_policies,omitempty"`
 	ValidationPolicy     *keppel.ValidationPolicy    `json:"validation"`
 	PlatformFilter       models.PlatformFilter       `json:"platform_filter"`
 }
@@ -76,6 +77,7 @@ func (a *AccountManagementDriver) ConfigureAccount(accountName models.AccountNam
 			Name:              cfgAccount.Name,
 			RBACPolicies:      cfgAccount.RBACPolicies,
 			ReplicationPolicy: cfgAccount.ReplicationPolicy,
+			TagPolicies:       cfgAccount.TagPolicies,
 			ValidationPolicy:  cfgAccount.ValidationPolicy,
 			PlatformFilter:    cfgAccount.PlatformFilter,
 		}

--- a/internal/keppel/account.go
+++ b/internal/keppel/account.go
@@ -19,6 +19,8 @@ type Account struct {
 	ValidationPolicy  *ValidationPolicy     `json:"validation,omitempty"`
 	PlatformFilter    models.PlatformFilter `json:"platform_filter,omitempty"`
 	Metadata          *map[string]string    `json:"metadata"`
+
+	// NOTE: When changing fields, please also adjust type Account in `internal/drivers/basic` as necessary.
 }
 
 // RenderAccount converts an account model from the DB into the API representation.


### PR DESCRIPTION
We forgot about this in #538. The config file for managed accounts uses a slightly different format from what the API uses, and thus has to use a different type declaration that needs to be updated separately. I made a note to ensure we don't forget this when changing the API in the future.