### PR TITLE
cmd/trivyproxy: disable Trivy telemetry

### DIFF
--- a/cmd/trivyproxy/main.go
+++ b/cmd/trivyproxy/main.go
@@ -124,6 +124,7 @@ func (a *API) runTrivy(ctx context.Context, imageURL, format, keppelToken string
 		"trivy", "image",
 		"--scanners", "vuln",
 		"--skip-db-update",
+		"--disable-telemetry",
 		// remove when https://github.com/aquasecurity/trivy/issues/3560 is resolved
 		"--java-db-repository", a.dbMirrorPrefix+"/aquasecurity/trivy-java-db",
 		"--server", a.trivyURL,


### PR DESCRIPTION
@SuperSandro2000 pointed out that this flag exists, so we should probably use it to avoid unexpected dataflows out of the datacenter:

```
$ trivy version | head -n1
Version: 0.63.0
$  trivy image --help | grep telemetry
      --disable-telemetry           disable sending anonymous usage data to Aqua
```