### PR TITLE
Optimize for maia query in pgmetrics

### DIFF
--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -376,6 +376,12 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE trivy_security_info
 			DROP COLUMN vuln_status_changed_at;
 	`,
+	"051_add_vuln_status_index_over_not_clean.up.sql": `
+		CREATE INDEX ON trivy_security_info (repo_id, digest) WHERE vuln_status <> 'Clean';
+	`,
+	"051_add_vuln_status_index_over_not_clean.down.sql": `
+		DROP INDEX trivy_security_info_repo_id_digest_idx;
+	`,
 }
 
 // DB adds convenience functions on top of gorp.DbMap.


### PR DESCRIPTION
This reduces overhaul cost by 7k points and execution time slightly by 20 to 30ms.

Before:
```
------------------------------------------+
| QUERY PLAN                                                                                                                                                                                           |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| HashAggregate  (cost=24298.74..27654.96 rows=100373 width=80) (actual time=389.562..390.842 rows=3874 loops=1)                                                                                       |
|   Group Key: a.name, r.name, t.vuln_status                                                                                                                                                           |
|   Planned Partitions: 4  Batches: 1  Memory Usage: 2321kB                                                                                                                                            |
|   ->  Hash Join  (cost=151.38..18699.80 rows=100373 width=72) (actual time=1.568..338.989 rows=100264 loops=1)                                                                                       |
|         Hash Cond: (r.account_name = a.name)                                                                                                                                                         |
|         ->  Hash Join  (cost=129.59..18407.90 rows=100373 width=39) (actual time=1.430..311.364 rows=100264 loops=1)                                                                                 |
|               Hash Cond: (t.repo_id = r.id)                                                                                                                                                          |
|               ->  Merge Join  (cost=0.83..18015.34 rows=100373 width=23) (actual time=0.043..283.743 rows=100264 loops=1)                                                                            |
|                     Merge Cond: ((m.repo_id = t.repo_id) AND (m.digest = t.digest))                                                                                                                  |
|                     ->  Index Only Scan using manifests_pkey on manifests m  (cost=0.42..10342.03 rows=102062 width=80) (actual time=0.006..76.326 rows=102062 loops=1)                              |
|                           Heap Fetches: 41008                                                                                                                                                        |
|                     ->  Index Scan using trivy_security_info_repo_id_digest_key on trivy_security_info t  (cost=0.42..6654.96 rows=100373 width=87) (actual time=0.007..136.154 rows=100264 loops=1) |
|                           Filter: (vuln_status <> 'Clean'::text)                                                                                                                                     |
|                           Rows Removed by Filter: 1798                                                                                                                                               |
|               ->  Hash  (cost=85.56..85.56 rows=3456 width=40) (actual time=1.377..1.378 rows=3456 loops=1)                                                                                          |
|                     Buckets: 4096  Batches: 1  Memory Usage: 292kB                                                                                                                                   |
|                     ->  Seq Scan on repos r  (cost=0.00..85.56 rows=3456 width=40) (actual time=0.010..0.651 rows=3456 loops=1)                                                                      |
|         ->  Hash  (cost=19.68..19.68 rows=168 width=46) (actual time=0.131..0.132 rows=168 loops=1)                                                                                                  |
|               Buckets: 1024  Batches: 1  Memory Usage: 21kB                                                                                                                                          |
|               ->  Seq Scan on accounts a  (cost=0.00..19.68 rows=168 width=46) (actual time=0.015..0.087 rows=168 loops=1)                                                                           |
| Planning Time: 2.293 ms                                                                                                                                                                              |
| Execution Time: 391.284 ms                                                                                                                                                                           |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 22
```

After:
```
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                           |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| HashAggregate  (cost=17322.95..20674.52 rows=100234 width=80) (actual time=361.182..362.439 rows=3873 loops=1)                                                                                       |
|   Group Key: a.name, r.name, t.vuln_status                                                                                                                                                           |
|   Planned Partitions: 4  Batches: 1  Memory Usage: 2321kB                                                                                                                                            |
|   ->  Hash Join  (cost=151.38..11731.77 rows=100234 width=72) (actual time=1.586..311.802 rows=100253 loops=1)                                                                                       |
|         Hash Cond: (r.account_name = a.name)                                                                                                                                                         |
|         ->  Hash Join  (cost=129.59..11440.24 rows=100234 width=39) (actual time=1.456..285.500 rows=100253 loops=1)                                                                                 |
|               Hash Cond: (t.repo_id = r.id)                                                                                                                                                          |
|               ->  Merge Join  (cost=0.83..11048.04 rows=100234 width=23) (actual time=0.039..258.924 rows=100253 loops=1)                                                                            |
|                     Merge Cond: ((m.repo_id = t.repo_id) AND (m.digest = t.digest))                                                                                                                  |
|                     ->  Index Only Scan using manifests_pkey on manifests m  (cost=0.42..4364.64 rows=102049 width=80) (actual time=0.009..57.822 rows=102050 loops=1)                               |
|                           Heap Fetches: 23397                                                                                                                                                        |
|                     ->  Index Scan using trivy_security_info_repo_id_digest_idx on trivy_security_info t  (cost=0.42..5663.93 rows=100234 width=87) (actual time=0.025..132.645 rows=100253 loops=1) |
|               ->  Hash  (cost=85.56..85.56 rows=3456 width=40) (actual time=1.406..1.407 rows=3456 loops=1)                                                                                          |
|                     Buckets: 4096  Batches: 1  Memory Usage: 292kB                                                                                                                                   |
|                     ->  Seq Scan on repos r  (cost=0.00..85.56 rows=3456 width=40) (actual time=0.009..0.681 rows=3456 loops=1)                                                                      |
|         ->  Hash  (cost=19.68..19.68 rows=168 width=46) (actual time=0.123..0.123 rows=168 loops=1)                                                                                                  |
|               Buckets: 1024  Batches: 1  Memory Usage: 21kB                                                                                                                                          |
|               ->  Seq Scan on accounts a  (cost=0.00..19.68 rows=168 width=46) (actual time=0.016..0.069 rows=168 loops=1)                                                                           |
| Planning Time: 1.281 ms                                                                                                                                                                              |
| Execution Time: 362.892 ms                                                                                                                                                                           |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 20
```