### PR TITLE
fix DB migration

### DIFF
--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -416,11 +416,13 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE accounts DROP COLUMN rule_for_manifest;
 	`,
 	"053_change_vulnerability_report_to_allow_never_scanning_again.up.sql": `
+		UPDATE trivy_security_info SET vuln_status = 'Pending', next_check_at = NOW() WHERE vuln_status = 'Rotten';
 		ALTER TABLE trivy_security_info
 			ALTER COLUMN next_check_at DROP NOT NULL,
 			ADD CONSTRAINT next_check_at_only_null_when_rotten CHECK ((vuln_status = 'Rotten') = (next_check_at IS NULL));
 	`,
 	"053_change_vulnerability_report_to_allow_never_scanning_again.down.sql": `
+		UPDATE trivy_security_info SET next_check_at = NOW() WHERE vuln_status = 'Rotten';
 		ALTER TABLE trivy_security_info
 			ALTER COLUMN next_check_at SET NOT NULL,
 			DROP CONSTRAINT next_check_at_only_null_when_rotten;


### PR DESCRIPTION
This migration does not work as-is. In real deployments, we have plenty of images in "Rotten" that have `next_check_at` because that field is NOT NULL before this migration, so the CHECK constraint will fail on these columns.

In order to allow the constraint to be added, we need to change those to a different vuln_status. "Pending" is a sensible choice.

The alternative of setting `next_check_at = NULL` is not feasible. We _want_ to re-run vulnerability checking on all rotten images exactly once to generate the synthetic report that #579 defines.