### PR TITLE
bump all dependencies to their latest versions

### DIFF
--- a/.github/workflows/oci-distribution-conformance.yml
+++ b/.github/workflows/oci-distribution-conformance.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Start keppel
         run: |
           sudo apt-get update

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-redis/redis_rate/v10 v10.0.1
 	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/golang-jwt/jwt/v5 v5.3.0
-	github.com/google/cel-go v0.26.0
+	github.com/google/cel-go v0.26.1
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.23.0
-	github.com/redis/go-redis/v9 v9.12.0
+	github.com/redis/go-redis/v9 v9.12.1
 	github.com/rs/cors v1.11.1
 	github.com/sapcc/go-api-declarations v1.17.4
 	github.com/sapcc/go-bits v0.0.0-20250828142518-d29beaf1bcca

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/golang-migrate/migrate/v4 v4.18.3/go.mod h1:99BKpIi6ruaaXRM1A77eqZ+FW
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/cel-go v0.26.0 h1:DPGjXackMpJWH680oGY4lZhYjIameYmR+/6RBdDGmaI=
-github.com/google/cel-go v0.26.0/go.mod h1:A9O8OU9rdvrK5MQyrqfIxo1a0u4g3sF8KB6PUIaryMM=
+github.com/google/cel-go v0.26.1 h1:iPbVVEdkhTX++hpe3lzSk7D3G3QSYqLGoHOcEio+UXQ=
+github.com/google/cel-go v0.26.1/go.mod h1:A9O8OU9rdvrK5MQyrqfIxo1a0u4g3sF8KB6PUIaryMM=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -194,8 +194,8 @@ github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7D
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
 github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
-github.com/redis/go-redis/v9 v9.12.0 h1:XlVPGlflh4nxfhsNXPA8Qp6EmEfTo0rp8oaBzPipXnU=
-github.com/redis/go-redis/v9 v9.12.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/vendor/github.com/google/cel-go/cel/env.go
+++ b/vendor/github.com/google/cel-go/cel/env.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/env"
+	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -141,6 +142,9 @@ type Env struct {
 	libraries       map[string]SingletonLibrary
 	validators      []ASTValidator
 	costOptions     []checker.CostOption
+
+	funcBindOnce     sync.Once
+	functionBindings []*functions.Overload
 
 	// Internal parser representation
 	prsr     *parser.Parser
@@ -320,18 +324,19 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		return nil, err
 	}
 	return (&Env{
-		variables:       []*decls.VariableDecl{},
-		functions:       map[string]*decls.FunctionDecl{},
-		macros:          []parser.Macro{},
-		Container:       containers.DefaultContainer,
-		adapter:         registry,
-		provider:        registry,
-		features:        map[int]bool{},
-		appliedFeatures: map[int]bool{},
-		libraries:       map[string]SingletonLibrary{},
-		validators:      []ASTValidator{},
-		progOpts:        []ProgramOption{},
-		costOptions:     []checker.CostOption{},
+		variables:        []*decls.VariableDecl{},
+		functions:        map[string]*decls.FunctionDecl{},
+		functionBindings: []*functions.Overload{},
+		macros:           []parser.Macro{},
+		Container:        containers.DefaultContainer,
+		adapter:          registry,
+		provider:         registry,
+		features:         map[int]bool{},
+		appliedFeatures:  map[int]bool{},
+		libraries:        map[string]SingletonLibrary{},
+		validators:       []ASTValidator{},
+		progOpts:         []ProgramOption{},
+		costOptions:      []checker.CostOption{},
 	}).configure(opts)
 }
 

--- a/vendor/github.com/google/cel-go/cel/folding.go
+++ b/vendor/github.com/google/cel-go/cel/folding.go
@@ -38,7 +38,7 @@ func MaxConstantFoldIterations(limit int) ConstantFoldingOption {
 	}
 }
 
-// Adds an Activation which provides known values for the folding evaluator
+// FoldKnownValues adds an Activation which provides known values for the folding evaluator
 //
 // Any values the activation provides will be used by the constant folder and turned into
 // literals in the AST.

--- a/vendor/github.com/google/cel-go/cel/program.go
+++ b/vendor/github.com/google/cel-go/cel/program.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -191,16 +192,25 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 		}
 	}
 
+	e.funcBindOnce.Do(func() {
+		var bindings []*functions.Overload
+		e.functionBindings = []*functions.Overload{}
+		for _, fn := range e.functions {
+			bindings, err = fn.Bindings()
+			if err != nil {
+				return
+			}
+			e.functionBindings = append(e.functionBindings, bindings...)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	// Add the function bindings created via Function() options.
-	for _, fn := range e.functions {
-		bindings, err := fn.Bindings()
-		if err != nil {
-			return nil, err
-		}
-		err = disp.Add(bindings...)
-		if err != nil {
-			return nil, err
-		}
+	err = disp.Add(e.functionBindings...)
+	if err != nil {
+		return nil, err
 	}
 
 	// Set the attribute factory after the options have been set.

--- a/vendor/github.com/google/cel-go/cel/templates/authoring.tmpl
+++ b/vendor/github.com/google/cel-go/cel/templates/authoring.tmpl
@@ -1,4 +1,8 @@
-{{define "variable"}}{{.Name}} is a {{.Type}}
+{{define "variable"}}{{.Name}} is a {{.Type}}{{if .Description}}
+
+{{range split .Description}}      {{.}}
+{{end}}
+{{- end -}}
 {{- end -}}
 
 {{define "macro" -}}

--- a/vendor/github.com/google/cel-go/cel/validator.go
+++ b/vendor/github.com/google/cel-go/cel/validator.go
@@ -45,6 +45,14 @@ var (
 	astValidatorFactories = map[string]ASTValidatorFactory{
 		nestingLimitValidatorName: func(val *env.Validator) (ASTValidator, error) {
 			if limit, found := val.ConfigValue("limit"); found {
+				// In case of protos, config value is of type by google.protobuf.Value, which numeric values are always a double.
+				if val, isDouble := limit.(float64); isDouble {
+					if val != float64(int64(val)) {
+						return nil, fmt.Errorf("invalid validator: %s, limit value is not a whole number: %v", nestingLimitValidatorName, limit)
+					}
+					return ValidateComprehensionNestingLimit(int(val)), nil
+				}
+
 				if val, isInt := limit.(int); isInt {
 					return ValidateComprehensionNestingLimit(val), nil
 				}

--- a/vendor/github.com/google/cel-go/common/types/pb/type.go
+++ b/vendor/github.com/google/cel-go/common/types/pb/type.go
@@ -472,7 +472,7 @@ func unwrap(desc description, msg proto.Message) (any, bool, error) {
 		}
 		return v.GetValue(), true, nil
 	}
-	return msg, false, nil
+	return unwrapDynamic(desc, msg.ProtoReflect())
 }
 
 // unwrapDynamic unwraps a reflected protobuf Message value.

--- a/vendor/github.com/redis/go-redis/v9/README.md
+++ b/vendor/github.com/redis/go-redis/v9/README.md
@@ -20,6 +20,7 @@ In `go-redis` we are aiming to support the last three releases of Redis. Current
 - [Redis 7.2](https://raw.githubusercontent.com/redis/redis/7.2/00-RELEASENOTES) - using Redis Stack 7.2 for modules support
 - [Redis 7.4](https://raw.githubusercontent.com/redis/redis/7.4/00-RELEASENOTES) - using Redis Stack 7.4 for modules support
 - [Redis 8.0](https://raw.githubusercontent.com/redis/redis/8.0/00-RELEASENOTES) - using Redis CE 8.0 where modules are included
+- [Redis 8.2](https://raw.githubusercontent.com/redis/redis/8.2/00-RELEASENOTES) - using Redis CE 8.2 where modules are included
 
 Although the `go.mod` states it requires at minimum `go 1.18`, our CI is configured to run the tests against all three
 versions of Redis and latest two versions of Go ([1.23](https://go.dev/doc/devel/release#go1.23.0),
@@ -77,6 +78,7 @@ key value NoSQL database that uses RocksDB as storage engine and is compatible w
 - [Redis Ring](https://redis.uptrace.dev/guide/ring.html).
 - [Redis Performance Monitoring](https://redis.uptrace.dev/guide/redis-performance-monitoring.html).
 - [Redis Probabilistic [RedisStack]](https://redis.io/docs/data-types/probabilistic/)
+- [Customizable read and write buffers size.](#custom-buffer-sizes)
 
 ## Installation
 
@@ -372,6 +374,21 @@ For example:
 ```
 You can find further details in the [query dialect documentation](https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/dialects/).
 
+#### Custom buffer sizes
+Prior to v9.12, the buffer size was the default go value of 4096 bytes. Starting from v9.12, 
+go-redis uses 256KiB read and write buffers by default for optimal performance.
+For high-throughput applications or large pipelines, you can customize buffer sizes:
+
+```go
+rdb := redis.NewClient(&redis.Options{
+    Addr:            "localhost:6379",
+    ReadBufferSize:  1024 * 1024, // 1MiB read buffer
+    WriteBufferSize: 1024 * 1024, // 1MiB write buffer
+})
+```
+
+**Important**: If you experience any issues with the default buffer sizes, please try setting them to the go default of 4096 bytes.
+
 ## Contributing
 We welcome contributions to the go-redis library! If you have a bug fix, feature request, or improvement, please open an issue or pull request on GitHub.
 We appreciate your help in making go-redis better for everyone.
@@ -411,6 +428,7 @@ vals, err := rdb.Eval(ctx, "return {KEYS[1],ARGV[1]}", []string{"key"}, "hello")
 // custom command
 res, err := rdb.Do(ctx, "set", "key", "value").Result()
 ```
+
 
 ## Run the test
 

--- a/vendor/github.com/redis/go-redis/v9/RELEASE-NOTES.md
+++ b/vendor/github.com/redis/go-redis/v9/RELEASE-NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+# 9.12.1 (2025-08-11)
+## 🚀 Highlights
+In the last version (9.12.0) the client introduced bigger write and read buffer sized. The default value we set was 512KiB.
+However, users reported that this is too big for most use cases and can lead to high memory usage.
+In this version the default value is changed to 256KiB. The `README.md` was updated to reflect the
+correct default value and include a note that the default value can be changed.
+
+## 🐛 Bug Fixes
+
+- fix(options): Add buffer sizes to failover. Update README ([#3468](https://github.com/redis/go-redis/pull/3468))
+
+## 🧰 Maintenance
+
+- fix(options): Add buffer sizes to failover. Update README ([#3468](https://github.com/redis/go-redis/pull/3468))
+- chore: update & fix otel example ([#3466](https://github.com/redis/go-redis/pull/3466))
+
+## Contributors
+We'd like to thank all the contributors who worked on this release!
+
+[@ndyakov](https://github.com/ndyakov) and [@vmihailenco](https://github.com/vmihailenco)
+
 # 9.12.0 (2025-08-05)
 
 ## 🚀 Highlights

--- a/vendor/github.com/redis/go-redis/v9/internal/proto/reader.go
+++ b/vendor/github.com/redis/go-redis/v9/internal/proto/reader.go
@@ -12,8 +12,8 @@ import (
 	"github.com/redis/go-redis/v9/internal/util"
 )
 
-// DefaultBufferSize is the default size for read/write buffers (0.5MiB)
-const DefaultBufferSize = 512 * 1024
+// DefaultBufferSize is the default size for read/write buffers (256 KiB).
+const DefaultBufferSize = 256 * 1024
 
 // redis resp protocol data type.
 const (

--- a/vendor/github.com/redis/go-redis/v9/options.go
+++ b/vendor/github.com/redis/go-redis/v9/options.go
@@ -135,14 +135,14 @@ type Options struct {
 	// Larger buffers can improve performance for commands that return large responses.
 	// Smaller buffers can improve memory usage for larger pools.
 	//
-	// default: 0.5MiB (524288 bytes)
+	// default: 256KiB (262144 bytes)
 	ReadBufferSize int
 
 	// WriteBufferSize is the size of the bufio.Writer buffer for each connection.
 	// Larger buffers can improve performance for large pipelines and commands with many arguments.
 	// Smaller buffers can improve memory usage for larger pools.
 	//
-	// default: 0.5MiB (524288 bytes)
+	// default: 256KiB (262144 bytes)
 	WriteBufferSize int
 
 	// PoolFIFO type of connection pool.

--- a/vendor/github.com/redis/go-redis/v9/osscluster.go
+++ b/vendor/github.com/redis/go-redis/v9/osscluster.go
@@ -96,14 +96,14 @@ type ClusterOptions struct {
 	// Larger buffers can improve performance for commands that return large responses.
 	// Smaller buffers can improve memory usage for larger pools.
 	//
-	// default: 0.5MiB (524288 bytes)
+	// default: 256KiB (262144 bytes)
 	ReadBufferSize int
 
 	// WriteBufferSize is the size of the bufio.Writer buffer for each connection.
 	// Larger buffers can improve performance for large pipelines and commands with many arguments.
 	// Smaller buffers can improve memory usage for larger pools.
 	//
-	// default: 0.5MiB (524288 bytes)
+	// default: 256KiB (262144 bytes)
 	WriteBufferSize int
 
 	TLSConfig *tls.Config

--- a/vendor/github.com/redis/go-redis/v9/ring.go
+++ b/vendor/github.com/redis/go-redis/v9/ring.go
@@ -128,14 +128,14 @@ type RingOptions struct {
 	// Larger buffers can improve performance for commands that return large responses.
 	// Smaller buffers can improve memory usage for larger pools.
 	//
-	// default: 0.5MiB (524288 bytes)
+	// default: 256KiB (262144 bytes)
 	ReadBufferSize int
 
 	// WriteBufferSize is the size of the bufio.Writer buffer for each connection.
 	// Larger buffers can improve performance for large pipelines and commands with many arguments.
 	// Smaller buffers can improve memory usage for larger pools.
 	//
-	// default: 0.5MiB (524288 bytes)
+	// default: 256KiB (262144 bytes)
 	WriteBufferSize int
 
 	TLSConfig *tls.Config

--- a/vendor/github.com/redis/go-redis/v9/sentinel.go
+++ b/vendor/github.com/redis/go-redis/v9/sentinel.go
@@ -90,6 +90,20 @@ type FailoverOptions struct {
 	WriteTimeout          time.Duration
 	ContextTimeoutEnabled bool
 
+	// ReadBufferSize is the size of the bufio.Reader buffer for each connection.
+	// Larger buffers can improve performance for commands that return large responses.
+	// Smaller buffers can improve memory usage for larger pools.
+	//
+	// default: 256KiB (262144 bytes)
+	ReadBufferSize int
+
+	// WriteBufferSize is the size of the bufio.Writer buffer for each connection.
+	// Larger buffers can improve performance for large pipelines and commands with many arguments.
+	// Smaller buffers can improve memory usage for larger pools.
+	//
+	// default: 256KiB (262144 bytes)
+	WriteBufferSize int
+
 	PoolFIFO bool
 
 	PoolSize        int
@@ -138,6 +152,9 @@ func (opt *FailoverOptions) clientOptions() *Options {
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
 
+		ReadBufferSize:  opt.ReadBufferSize,
+		WriteBufferSize: opt.WriteBufferSize,
+
 		DialTimeout:           opt.DialTimeout,
 		ReadTimeout:           opt.ReadTimeout,
 		WriteTimeout:          opt.WriteTimeout,
@@ -177,6 +194,9 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		MaxRetries:      opt.MaxRetries,
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
+
+		ReadBufferSize:  opt.ReadBufferSize,
+		WriteBufferSize: opt.WriteBufferSize,
 
 		DialTimeout:           opt.DialTimeout,
 		ReadTimeout:           opt.ReadTimeout,
@@ -223,6 +243,9 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
+
+		ReadBufferSize:  opt.ReadBufferSize,
+		WriteBufferSize: opt.WriteBufferSize,
 
 		DialTimeout:           opt.DialTimeout,
 		ReadTimeout:           opt.ReadTimeout,

--- a/vendor/github.com/redis/go-redis/v9/version.go
+++ b/vendor/github.com/redis/go-redis/v9/version.go
@@ -2,5 +2,5 @@ package redis
 
 // Version is the current release version.
 func Version() string {
-	return "9.12.0"
+	return "9.12.1"
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/golang-migrate/migrate/v4/database/postgres
 github.com/golang-migrate/migrate/v4/internal/url
 github.com/golang-migrate/migrate/v4/source
 github.com/golang-migrate/migrate/v4/source/go_bindata
-# github.com/google/cel-go v0.26.0
+# github.com/google/cel-go v0.26.1
 ## explicit; go 1.22.0
 github.com/google/cel-go/cel
 github.com/google/cel-go/checker
@@ -180,7 +180,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/rabbitmq/amqp091-go v1.10.0
 ## explicit; go 1.20
 github.com/rabbitmq/amqp091-go
-# github.com/redis/go-redis/v9 v9.12.0
+# github.com/redis/go-redis/v9 v9.12.1
 ## explicit; go 1.18
 github.com/redis/go-redis/v9
 github.com/redis/go-redis/v9/auth


### PR DESCRIPTION
This is the same as <https://github.com/sapcc/keppel/pull/582>, except for the changes that we want to ignore because go-makefile-maker is supposed to make them.