### PR TITLE
fix new lints

### DIFF
--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -80,7 +80,7 @@ func TestManifestsAPI(t *testing.T) {
 
 		// insert some dummy manifests and tags into each repo
 		for repoID := 1; repoID <= 3; repoID++ {
-			repo := repos[repoID-1]
+			repo := repos[repoID-1] //nolint:gosec // subtraction cannot overflow below 0 because iteration starts at 1
 
 			for idx := 1; idx <= 10; idx++ {
 				dummyDigest := test.DeterministicDummyDigest(repoID*10 + idx)

--- a/internal/auth/challenge.go
+++ b/internal/auth/challenge.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sapcc/keppel/internal/keppel"
 )
@@ -28,14 +29,15 @@ func (c Challenge) WithErrorMessage(msg string) Challenge {
 
 // AddTo adds a Www-Authenticate header to the given error.
 func (c Challenge) AddTo(err *keppel.RegistryV2Error) *keppel.RegistryV2Error {
-	fields := fmt.Sprintf(`realm="%s",service="%s"`, c.AuthEndpointURL, c.AudienceHostname)
+	var fields strings.Builder
+	fmt.Fprintf(&fields, `realm="%s",service="%s"`, c.AuthEndpointURL, c.AudienceHostname)
 	for _, scope := range c.Scopes {
 		if !scope.Contains(InfoAPIScope) {
-			fields += fmt.Sprintf(`,scope="%s"`, scope)
+			fmt.Fprintf(&fields, `,scope="%s"`, scope)
 		}
 	}
 	if c.ErrorMessage != "" {
-		fields += fmt.Sprintf(`,error="%s"`, c.ErrorMessage)
+		fmt.Fprintf(&fields, `,error="%s"`, c.ErrorMessage)
 	}
-	return err.WithHeader("Www-Authenticate", "Bearer "+fields)
+	return err.WithHeader("Www-Authenticate", "Bearer "+fields.String())
 }

--- a/internal/processor/blobs.go
+++ b/internal/processor/blobs.go
@@ -340,7 +340,7 @@ func (r *chunkingTrackingReader) IsEOF() bool {
 		return true
 	}
 	if n == 1 {
-		r.peeked = &buf[0]
+		r.peeked = &buf[0] //nolint:gosec // "index out of range" error is a clear false positive
 	}
 	return false
 	//NOTE: Non-EOF errors are discarded here, but the next Read() should surface them.


### PR DESCRIPTION
Mostly, perfsprint was complaining about repeated string concatenation in a loop.