### PR TITLE
Fix types of trivial drivers

### DIFF
--- a/internal/drivers/basic/ratelimit.go
+++ b/internal/drivers/basic/ratelimit.go
@@ -29,7 +29,7 @@ type RateLimitDriver struct {
 }
 
 func init() {
-	keppel.RateLimitDriverRegistry.Add(func() keppel.RateLimitDriver { return RateLimitDriver{} })
+	keppel.RateLimitDriverRegistry.Add(func() keppel.RateLimitDriver { return &RateLimitDriver{} })
 }
 
 // PluginTypeID implements the keppel.RateLimitDriver interface.

--- a/internal/drivers/trivial/federation.go
+++ b/internal/drivers/trivial/federation.go
@@ -14,7 +14,7 @@ import (
 type federationDriver struct{}
 
 func init() {
-	keppel.FederationDriverRegistry.Add(func() keppel.FederationDriver { return federationDriver{} })
+	keppel.FederationDriverRegistry.Add(func() keppel.FederationDriver { return &federationDriver{} })
 }
 
 // PluginTypeID implements the keppel.FederationDriver interface.

--- a/internal/drivers/trivial/inbound_cache.go
+++ b/internal/drivers/trivial/inbound_cache.go
@@ -15,7 +15,7 @@ import (
 type inboundCacheDriver struct{}
 
 func init() {
-	keppel.InboundCacheDriverRegistry.Add(func() keppel.InboundCacheDriver { return inboundCacheDriver{} })
+	keppel.InboundCacheDriverRegistry.Add(func() keppel.InboundCacheDriver { return &inboundCacheDriver{} })
 }
 
 // PluginTypeID implements the keppel.InboundCacheDriver interface.

--- a/internal/keppel/config.go
+++ b/internal/keppel/config.go
@@ -192,7 +192,7 @@ func newDriver[P pluggable.Plugin](driverType string, registry pluggable.Registr
 	if !ok {
 		return zero, fmt.Errorf("no such %s: %q", driverType, cfg.PluginTypeID)
 	}
-	err = json.Unmarshal([]byte(cfg.Params), driver)
+	err = json.Unmarshal(cfg.Params, driver)
 	if err != nil {
 		return zero, fmt.Errorf("cannot unmarshal params for %s %q: %w", driverType, cfg.PluginTypeID, err)
 	}


### PR DESCRIPTION
cannot unmarshal params for KEPPEL_DRIVER_FEDERATION "trivial": json: Unmarshal(non-pointer trivial.federationDriver)