### PR TITLE
use pointer receiver on all drivers

### DIFF
--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -455,7 +455,7 @@ func TestGetTrivyReport(t *testing.T) {
 
 func TestRateLimitsTrivyReport(t *testing.T) {
 	limit := redis_rate.Limit{Rate: 2, Period: time.Minute, Burst: 3}
-	rld := basic.RateLimitDriver{
+	rld := &basic.RateLimitDriver{
 		Limits: map[keppel.RateLimitedAction]redis_rate.Limit{
 			keppel.TrivyReportRetrieveAction: limit,
 		},

--- a/internal/api/registry/ratelimit_test.go
+++ b/internal/api/registry/ratelimit_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRateLimits(t *testing.T) {
 	limit := redis_rate.Limit{Rate: 2, Period: time.Minute, Burst: 3}
-	rld := basic.RateLimitDriver{
+	rld := &basic.RateLimitDriver{
 		Limits: map[keppel.RateLimitedAction]redis_rate.Limit{
 			keppel.BlobPullAction:     limit,
 			keppel.BlobPushAction:     limit,
@@ -122,7 +122,7 @@ func TestAnycastRateLimits(t *testing.T) {
 	// set up rate limit such that we can pull this blob only twice in a row
 	limit := redis_rate.Limit{Rate: len(blob.Contents) * 2, Period: time.Minute, Burst: len(blob.Contents) * 2}
 
-	rld := basic.RateLimitDriver{
+	rld := &basic.RateLimitDriver{
 		Limits: map[keppel.RateLimitedAction]redis_rate.Limit{
 			keppel.AnycastBlobBytePullAction: limit,
 			// all other rate limits are set to "unlimited"

--- a/internal/drivers/basic/ratelimit.go
+++ b/internal/drivers/basic/ratelimit.go
@@ -33,10 +33,10 @@ func init() {
 }
 
 // PluginTypeID implements the keppel.RateLimitDriver interface.
-func (d RateLimitDriver) PluginTypeID() string { return "basic" }
+func (d *RateLimitDriver) PluginTypeID() string { return "basic" }
 
 // Init implements the keppel.RateLimitDriver interface.
-func (d RateLimitDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) error {
+func (d *RateLimitDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) error {
 	inputs := map[keppel.RateLimitedAction]Option[RateLimitSpec]{
 		keppel.AnycastBlobBytePullAction: d.AnycastBlobPullBytes,
 		keppel.BlobPullAction:            d.BlobPulls,
@@ -62,7 +62,7 @@ func (d RateLimitDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) er
 }
 
 // GetRateLimit implements the keppel.RateLimitDriver interface.
-func (d RateLimitDriver) GetRateLimit(account models.ReducedAccount, action keppel.RateLimitedAction) Option[redis_rate.Limit] {
+func (d *RateLimitDriver) GetRateLimit(account models.ReducedAccount, action keppel.RateLimitedAction) Option[redis_rate.Limit] {
 	quota, ok := d.Limits[action]
 	if ok {
 		return Some(quota)

--- a/internal/drivers/trivial/federation.go
+++ b/internal/drivers/trivial/federation.go
@@ -18,34 +18,34 @@ func init() {
 }
 
 // PluginTypeID implements the keppel.FederationDriver interface.
-func (federationDriver) PluginTypeID() string { return driverName }
+func (*federationDriver) PluginTypeID() string { return driverName }
 
 // Init implements the keppel.FederationDriver interface.
-func (federationDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) error {
+func (*federationDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) error {
 	return nil
 }
 
 // ClaimAccountName implements the keppel.FederationDriver interface.
-func (federationDriver) ClaimAccountName(ctx context.Context, account models.Account, subleaseTokenSecret string) (keppel.ClaimResult, error) {
+func (*federationDriver) ClaimAccountName(ctx context.Context, account models.Account, subleaseTokenSecret string) (keppel.ClaimResult, error) {
 	return keppel.ClaimSucceeded, nil
 }
 
 // IssueSubleaseTokenSecret implements the keppel.FederationDriver interface.
-func (federationDriver) IssueSubleaseTokenSecret(ctx context.Context, account models.Account) (string, error) {
+func (*federationDriver) IssueSubleaseTokenSecret(ctx context.Context, account models.Account) (string, error) {
 	return "", nil
 }
 
 // ForfeitAccountName implements the keppel.FederationDriver interface.
-func (federationDriver) ForfeitAccountName(ctx context.Context, account models.Account) error {
+func (*federationDriver) ForfeitAccountName(ctx context.Context, account models.Account) error {
 	return nil
 }
 
 // RecordExistingAccount implements the keppel.FederationDriver interface.
-func (federationDriver) RecordExistingAccount(ctx context.Context, account models.Account, now time.Time) error {
+func (*federationDriver) RecordExistingAccount(ctx context.Context, account models.Account, now time.Time) error {
 	return nil
 }
 
 // FindPrimaryAccount implements the keppel.FederationDriver interface.
-func (federationDriver) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (string, error) {
+func (*federationDriver) FindPrimaryAccount(ctx context.Context, accountName models.AccountName) (string, error) {
 	return "", keppel.ErrNoSuchPrimaryAccount
 }

--- a/internal/drivers/trivial/inbound_cache.go
+++ b/internal/drivers/trivial/inbound_cache.go
@@ -19,21 +19,21 @@ func init() {
 }
 
 // PluginTypeID implements the keppel.InboundCacheDriver interface.
-func (inboundCacheDriver) PluginTypeID() string { return driverName }
+func (*inboundCacheDriver) PluginTypeID() string { return driverName }
 
 // Init implements the keppel.InboundCacheDriver interface.
-func (inboundCacheDriver) Init(ctx context.Context, cfg keppel.Configuration) error {
+func (*inboundCacheDriver) Init(ctx context.Context, cfg keppel.Configuration) error {
 	return nil
 }
 
 // LoadManifest implements the keppel.InboundCacheDriver interface.
-func (inboundCacheDriver) LoadManifest(ctx context.Context, location models.ImageReference, now time.Time) (contents []byte, mediaType string, err error) {
+func (*inboundCacheDriver) LoadManifest(ctx context.Context, location models.ImageReference, now time.Time) (contents []byte, mediaType string, err error) {
 	// always return a cache miss
 	return nil, "", sql.ErrNoRows
 }
 
 // StoreManifest implements the keppel.InboundCacheDriver interface.
-func (inboundCacheDriver) StoreManifest(ctx context.Context, location models.ImageReference, contents []byte, mediaType string, now time.Time) error {
+func (*inboundCacheDriver) StoreManifest(ctx context.Context, location models.ImageReference, contents []byte, mediaType string, now time.Time) error {
 	// no-op
 	return nil
 }


### PR DESCRIPTION
The new function keppel.newDriver() only works if the driver instance is of pointer type. We were seeing this in QA after merging that change:

```
FATAL: cannot unmarshal params for KEPPEL_DRIVER_RATELIMIT "basic": json: Unmarshal(non-pointer basic.RateLimitDriver)
```