### PR TITLE
add "block_push" option to tag policies

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -164,6 +164,7 @@ The following fields may be returned:
 | `accounts[].rbac_policies[].forbidden_permissions` | list of strings | The permissions forbidden by the RBAC policy. Acceptable values are the same as for the `permissions` field. This field takes precedence over `permissions`: Any permission listed here will never be given to matching users, even if another matching policy would grant it. |
 | `accounts[].tag_policies[].block_delete` | bool or omitted | The given tag policy should prevent deleting the matched tags. |
 | `accounts[].tag_policies[].block_overwrite` | bool or omitted | The given tag policy should prevent overwriting the matched tags. |
+| `accounts[].tag_policies[].block_push` | bool or omitted | The given tag policy should prevent pushing images with any matched tags. |
 | `accounts[].tag_policies[].match_repository` | string | Required. The tag policy applies to all repositories in this account whose name matches this regex. The leading account name and slash is stripped from the repository name before matching. The notes on regexes below apply. |
 | `accounts[].tag_policies[].except_repository` | string or omitted | If given, matching repositories will be excluded from this tag policy, even if they match the `match_repository` regex. The syntax and mechanics of matching are otherwise identical to `match_repository` above. |
 | `accounts[].tag_policies[].match_tag` | string or omitted | The tag policy applies to all images in matching repositories that have a tag whose name matches this regex. The notes on regexes below apply. |

--- a/internal/api/registry/fixtures/imagemanifest-001-before-upload-blob.sql
+++ b/internal/api/registry/fixtures/imagemanifest-001-before-upload-blob.sql
@@ -1,4 +1,4 @@
-INSERT INTO accounts (name, auth_tenant_id) VALUES ('test1', 'test1authtenant');
+INSERT INTO accounts (name, auth_tenant_id, tag_policies_json) VALUES ('test1', 'test1authtenant', '[{"match_repository":"foo","block_overwrite":true},{"match_repository":"foo","match_tag":"dangerous.*","block_push":true}]');
 
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 2);
 

--- a/internal/api/registry/fixtures/imagemanifest-002-after-upload-blob.sql
+++ b/internal/api/registry/fixtures/imagemanifest-002-after-upload-blob.sql
@@ -1,4 +1,4 @@
-INSERT INTO accounts (name, auth_tenant_id) VALUES ('test1', 'test1authtenant');
+INSERT INTO accounts (name, auth_tenant_id, tag_policies_json) VALUES ('test1', 'test1authtenant', '[{"match_repository":"foo","block_overwrite":true},{"match_repository":"foo","match_tag":"dangerous.*","block_push":true}]');
 
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 1);
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 2);

--- a/internal/api/registry/fixtures/imagemanifest-003-after-upload-manifest-by-digest.sql
+++ b/internal/api/registry/fixtures/imagemanifest-003-after-upload-manifest-by-digest.sql
@@ -1,4 +1,4 @@
-INSERT INTO accounts (name, auth_tenant_id, tag_policies_json) VALUES ('test1', 'test1authtenant', '[{"match_repository":"foo","block_overwrite":true}]');
+INSERT INTO accounts (name, auth_tenant_id, tag_policies_json) VALUES ('test1', 'test1authtenant', '[{"match_repository":"foo","block_overwrite":true},{"match_repository":"foo","match_tag":"dangerous.*","block_push":true}]');
 
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 1);
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 2);

--- a/internal/api/registry/fixtures/imagemanifest-003-after-upload-manifest-by-tag.sql
+++ b/internal/api/registry/fixtures/imagemanifest-003-after-upload-manifest-by-tag.sql
@@ -1,4 +1,4 @@
-INSERT INTO accounts (name, auth_tenant_id, tag_policies_json) VALUES ('test1', 'test1authtenant', '[{"match_repository":"foo","block_overwrite":true}]');
+INSERT INTO accounts (name, auth_tenant_id, tag_policies_json) VALUES ('test1', 'test1authtenant', '[{"match_repository":"foo","block_overwrite":true},{"match_repository":"foo","match_tag":"dangerous.*","block_push":true}]');
 
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 1);
 INSERT INTO blob_mounts (blob_id, repo_id) VALUES (1, 2);

--- a/internal/keppel/tag_policy.go
+++ b/internal/keppel/tag_policy.go
@@ -11,6 +11,7 @@ type TagPolicy struct {
 	PolicyMatchRule
 	BlockOverwrite bool `json:"block_overwrite,omitempty"`
 	BlockDelete    bool `json:"block_delete,omitempty"`
+	BlockPush      bool `json:"block_push,omitempty"`
 }
 
 // ParseTagPolicies parses the Tag policies for the given account.


### PR DESCRIPTION
I want to be able to enforce on certain repos that the "latest" tag may not be pushed, thus forcing people to build images with more specific versions. As it turns out, this is a very natural and simple extension of the existing TagPolicy structure.