### PR TITLE
fix nolintlint

### DIFF
--- a/internal/api/keppel/liquid.go
+++ b/internal/api/keppel/liquid.go
@@ -113,7 +113,7 @@ func liquidConvertQuotaResponse(resp processor.QuotaResponse) liquid.ServiceUsag
 		Metrics:     map[liquid.MetricName][]liquid.Metric{},
 		Resources: map[liquid.ResourceName]*liquid.ResourceUsageReport{
 			"images": {
-				Quota: Some(int64(resp.Manifests.Quota)), //nolint:gosec // quota is admin controlled
+				Quota: Some(int64(resp.Manifests.Quota)),
 				PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{
 					Usage: resp.Manifests.Usage,
 				}),

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -82,7 +82,7 @@ func TestManifestsAPI(t *testing.T) {
 
 		// insert some dummy manifests and tags into each repo
 		for repoID := 1; repoID <= 3; repoID++ {
-			repo := repos[repoID-1] //nolint:gosec // subtraction cannot overflow below 0 because iteration starts at 1
+			repo := repos[repoID-1]
 
 			for idx := 1; idx <= 10; idx++ {
 				dummyDigest := test.DeterministicDummyDigest(repoID*10 + idx)
@@ -94,7 +94,7 @@ func TestManifestsAPI(t *testing.T) {
 					RepositoryID:      int64(repoID),
 					Digest:            dummyDigest,
 					MediaType:         manifest.DockerV2Schema2MediaType,
-					SizeBytes:         uint64(sizeBytes), //nolint:gosec // construction guarantees that value is positive
+					SizeBytes:         uint64(sizeBytes),
 					PushedAt:          pushedAt,
 					NextValidationAt:  pushedAt.Add(models.ManifestValidationInterval),
 					LabelsJSON:        `{"foo":"is there"}`,
@@ -151,7 +151,7 @@ func TestManifestsAPI(t *testing.T) {
 			renderedManifests[idx-1] = assert.JSONObject{
 				"digest":                          test.DeterministicDummyDigest(10 + idx),
 				"media_type":                      manifest.DockerV2Schema2MediaType,
-				"size_bytes":                      uint64(1000 * idx), //nolint:gosec // construction guarantees that value is positive
+				"size_bytes":                      uint64(1000 * idx),
 				"pushed_at":                       int64(1000 * (10 + idx)),
 				"last_pulled_at":                  nil,
 				"labels":                          assert.JSONObject{"foo": "is there"},

--- a/internal/api/keppel/quotas_test.go
+++ b/internal/api/keppel/quotas_test.go
@@ -207,7 +207,7 @@ func TestQuotasAPI(t *testing.T) {
 			RepositoryID:     1,
 			Digest:           test.DeterministicDummyDigest(idx),
 			MediaType:        "",
-			SizeBytes:        uint64(1000 * idx), //nolint:gosec // construction guarantees that value is positive
+			SizeBytes:        uint64(1000 * idx),
 			PushedAt:         pushedAt,
 			NextValidationAt: pushedAt.Add(models.ManifestValidationInterval),
 		}))

--- a/internal/api/keppel/repos_test.go
+++ b/internal/api/keppel/repos_test.go
@@ -59,7 +59,7 @@ func TestReposAPI(t *testing.T) {
 		blob := models.Blob{
 			AccountName:      "test1",
 			Digest:           dummyDigest,
-			SizeBytes:        uint64(2000 * idx), //nolint:gosec // construction guarantees that value is positive
+			SizeBytes:        uint64(2000 * idx),
 			PushedAt:         blobPushedAt,
 			NextValidationAt: blobPushedAt.Add(models.BlobValidationInterval),
 		}
@@ -75,7 +75,7 @@ func TestReposAPI(t *testing.T) {
 			RepositoryID:     filledRepo.ID,
 			Digest:           dummyDigest,
 			MediaType:        "",
-			SizeBytes:        uint64(1000 * idx), //nolint:gosec // construction guarantees that value is positive
+			SizeBytes:        uint64(1000 * idx),
 			PushedAt:         manifestPushedAt,
 			NextValidationAt: manifestPushedAt.Add(models.ManifestValidationInterval),
 		}))

--- a/internal/api/registry/blobs.go
+++ b/internal/api/registry/blobs.go
@@ -157,7 +157,7 @@ func (a *API) handleGetOrHeadBlob(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodHead {
 		// The use of io.LimitReader() here is a hint to io.Copy() to not allocate
 		// a buffer bigger than the expected size of the blob if the blob is small.
-		_, err = io.Copy(w, io.LimitReader(reader, int64(lengthBytes))) //nolint:gosec // lengthBytes will probably not be above 2^63 :)
+		_, err = io.Copy(w, io.LimitReader(reader, int64(lengthBytes)))
 		if err != nil {
 			logg.Error("unexpected error from io.Copy() while sending blob to client: %s", err.Error())
 		}

--- a/internal/api/registry/referrers.go
+++ b/internal/api/registry/referrers.go
@@ -59,7 +59,7 @@ func (a *API) handleGetReferrers(w http.ResponseWriter, r *http.Request) {
 
 		manifest := imgspecv1.Descriptor{
 			MediaType:   dbManifest.MediaType,
-			Size:        int64(dbManifest.SizeBytes), //nolint:gosec // validated on write
+			Size:        int64(dbManifest.SizeBytes),
 			Digest:      dbManifest.Digest,
 			Annotations: annotations,
 		}

--- a/internal/processor/blobs.go
+++ b/internal/processor/blobs.go
@@ -340,7 +340,7 @@ func (r *chunkingTrackingReader) IsEOF() bool {
 		return true
 	}
 	if n == 1 {
-		r.peeked = &buf[0] //nolint:gosec // "index out of range" error is a clear false positive
+		r.peeked = &buf[0]
 	}
 	return false
 	//NOTE: Non-EOF errors are discarded here, but the next Read() should surface them.

--- a/internal/tasks/uploads_test.go
+++ b/internal/tasks/uploads_test.go
@@ -54,7 +54,7 @@ func TestDeleteAbandonedUploadWithManyChunks(t *testing.T) {
 	testDeleteUpload(t, func(ctx context.Context, sd keppel.StorageDriver, account models.ReducedAccount) models.Upload {
 		chunks := []string{"just", "some", "test", "data"}
 		for idx, data := range chunks {
-			err := sd.AppendToBlob(ctx, account, testStorageID, uint32(idx+1), Some(uint64(len(data))), strings.NewReader(data)) //nolint:gosec // chunks has a fixed size of 4
+			err := sd.AppendToBlob(ctx, account, testStorageID, uint32(idx+1), Some(uint64(len(data))), strings.NewReader(data))
 			if err != nil {
 				t.Fatalf("AppendToBlob %d failed: %s", idx, err.Error())
 			}


### PR DESCRIPTION
gosec as of golangci-lint 2.7.0 has much fewer false positives.