### PR TITLE
improve memory usage spikiness of Trivy scan job

### DIFF
--- a/cmd/janitor/main.go
+++ b/cmd/janitor/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/httpapi/pprofapi"
 	"github.com/sapcc/go-bits/httpext"
-	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/osext"
 	"github.com/spf13/cobra"
@@ -67,7 +66,7 @@ func run(cmd *cobra.Command, args []string) {
 	go janitor.BlobValidationJob(nil).Run(ctx)
 	go janitor.ManifestValidationJob(nil).Run(ctx)
 	if cfg.Trivy != nil {
-		go janitor.CheckTrivySecurityStatusJob(nil).Run(ctx, jobloop.NumGoroutines(3))
+		go janitor.CheckTrivySecurityStatusJob(nil).Run(ctx)
 	}
 
 	// start HTTP server for Prometheus metrics and health check

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/rs/cors v1.11.1
 	github.com/sapcc/go-api-declarations v1.18.0
-	github.com/sapcc/go-bits v0.0.0-20251204133412-746f1e02903e
+	github.com/sapcc/go-bits v0.0.0-20251209144653-16fc382ed6f1
 	github.com/spf13/cobra v1.10.2
 	github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sapcc/go-api-declarations v1.18.0 h1:I73wuBKJEAeAI7nYuB4tHY9n9pydj5mgM7Zn+9fryAA=
 github.com/sapcc/go-api-declarations v1.18.0/go.mod h1:N2klk2oDNa1lsS6gUBnCDJedHy/c2vmwJ1sryckRW40=
-github.com/sapcc/go-bits v0.0.0-20251204133412-746f1e02903e h1:h/NPe/nGGZ6/gO52XK4bEuzmLarzu8Tg4uGVMfkbfCA=
-github.com/sapcc/go-bits v0.0.0-20251204133412-746f1e02903e/go.mod h1:/4xXSAuH6QpwA8fdg+igq6SNsHaayjxXXOwvQvrNr08=
+github.com/sapcc/go-bits v0.0.0-20251209144653-16fc382ed6f1 h1:ygUTz8sxLeYj7eVpQVXsP6bIdJCh37irjVTA9Y2nXxI=
+github.com/sapcc/go-bits v0.0.0-20251209144653-16fc382ed6f1/go.mod h1:/4xXSAuH6QpwA8fdg+igq6SNsHaayjxXXOwvQvrNr08=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/vendor/github.com/sapcc/go-bits/syncext/semaphore.go
+++ b/vendor/github.com/sapcc/go-bits/syncext/semaphore.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package syncext
+
+// Semaphore implements a counting semaphore: When multiple calls to its methods are made concurrently,
+// only a maximum number of them may execute at the same time, and additional calls are made to wait until earlier ones finish.
+//
+// This is most commonly used with expensive operations (either in terms of CPU or RAM) in order to avoid consuming all
+// available resources or running into an OOM (Out Of Memory) error.
+//
+// The implementation is based on <https://eli.thegreenplace.net/2019/on-concurrency-in-go-http-servers/>.
+type Semaphore struct {
+	ch chan struct{}
+}
+
+// NewSemaphore creates a new semaphore that allows up to the given number of concurrent operations.
+func NewSemaphore(count int) *Semaphore {
+	return &Semaphore{
+		ch: make(chan struct{}, count),
+	}
+}
+
+// Run executes the given function, ensuring that no more than the maximum number of ops for this semaphore execute concurrently.
+func (s *Semaphore) Run(action func()) {
+	s.ch <- struct{}{}
+	defer func() { <-s.ch }()
+	action()
+}
+
+// RunFallible is like Run, but allows the callback to return an error.
+func (s *Semaphore) RunFallible(action func() error) (err error) {
+	s.Run(func() { err = action() })
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/sapcc/go-api-declarations/cadf
 github.com/sapcc/go-api-declarations/internal/clone
 github.com/sapcc/go-api-declarations/internal/errorset
 github.com/sapcc/go-api-declarations/liquid
-# github.com/sapcc/go-bits v0.0.0-20251204133412-746f1e02903e
+# github.com/sapcc/go-bits v0.0.0-20251209144653-16fc382ed6f1
 ## explicit; go 1.25
 github.com/sapcc/go-bits/assert
 github.com/sapcc/go-bits/audittools
@@ -223,6 +223,7 @@ github.com/sapcc/go-bits/pluggable
 github.com/sapcc/go-bits/regexpext
 github.com/sapcc/go-bits/respondwith
 github.com/sapcc/go-bits/sqlext
+github.com/sapcc/go-bits/syncext
 # github.com/sergi/go-diff v1.4.0
 ## explicit; go 1.13
 github.com/sergi/go-diff/diffmatchpatch


### PR DESCRIPTION
Please view this with `?w=1`, there is barely any diff here once you do.