### PR TITLE
fix regression introduced in #633

### DIFF
--- a/internal/client/repo_client.go
+++ b/internal/client/repo_client.go
@@ -36,6 +36,7 @@ type RepoClient struct {
 type repoRequest struct {
 	Method       string
 	Path         string
+	Query        url.Values
 	Headers      http.Header
 	Body         io.ReadSeeker
 	ExpectStatus int
@@ -70,9 +71,10 @@ func (c *RepoClient) doRequest(ctx context.Context, r repoRequest) (*http.Respon
 	}
 
 	uri := &url.URL{
-		Scheme: c.Scheme,
-		Host:   c.Host,
-		Path:   path.Join("v2", c.RepoName, r.Path),
+		Scheme:   c.Scheme,
+		Host:     c.Host,
+		Path:     path.Join("v2", c.RepoName, r.Path),
+		RawQuery: r.Query.Encode(),
 	}
 
 	// send GET request for manifest

--- a/internal/client/upload.go
+++ b/internal/client/upload.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/opencontainers/go-digest"
@@ -19,7 +20,8 @@ func (c *RepoClient) UploadMonolithicBlob(ctx context.Context, contents []byte) 
 
 	resp, err := c.doRequest(ctx, repoRequest{
 		Method: "POST",
-		Path:   "blobs/uploads/?digest=" + d.String(),
+		Path:   "blobs/uploads/",
+		Query:  url.Values{"digest": []string{d.String()}},
 		Headers: http.Header{
 			"Content-Type": {"application/octet-stream"},
 		},


### PR DESCRIPTION
RepoClient.UploadMonolithicBlob put a query string into the repoRequest.Path attribute, so the change in 14ad2e6ab0c770151612ef1714ae7fa2f57f676a to how a URL is built from this path broke the query string:

```
$ kc qa-de-2 keppel
$ k logs keppel-health-monitor-789597bcc5-6wzt9
2026/01/15 10:22:06 INFO: starting keppel-health-monitor 0a97bae
2026/01/15 10:22:09 FATAL: while uploading test image: during POST http://keppel-api.keppel.svc/v2/healthcheck-qa-de-2/healthcheck/blobs/uploads/%3Fdigest=sha256:54f06ec27d30c6b8cefd4610494cfc64daf1fff1ad905c6e81bcbbf61590d089: expected status 200, but got 405 Method Not Allowed
```

Note how the URL is `...uploads/%3Fdigest=...` instead of `...uploads?digest=...`.

I will create a followup issue to increase test coverage for the affected functions.