### PR TITLE
Use json v2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: 2019–2020 Target
 # SPDX-FileCopyrightText: 2021 The Nix Community
 # SPDX-License-Identifier: Apache-2.0
+
+export GOEXPERIMENT=jsonv2
+
 if type -P lorri &>/dev/null; then
   eval "$(lorri direnv)"
 elif type -P nix &>/dev/null; then

--- a/Makefile
+++ b/Makefile
@@ -76,16 +76,19 @@ prepare-static-check: FORCE install-goimports install-golangci-lint install-shel
 # To add additional flags or values (before the default ones), specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.
 # To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.
 GO_BUILDFLAGS += -mod vendor
-GO_LDFLAGS +=
-GO_TESTFLAGS +=
-GO_TESTENV +=
-GO_BUILDENV +=
+GO_LDFLAGS    +=
+GO_TESTFLAGS  +=
+GO_TESTENV    +=
+GO_BUILDENV   +=
 
 # These definitions are overridable, e.g. to provide fixed version/commit values when
 # no .git directory is present or to provide a fixed build date for reproducibility.
 BININFO_VERSION     ?= $(shell git describe --tags --always --abbrev=7)
 BININFO_COMMIT_HASH ?= $(shell git rev-parse --verify HEAD)
 BININFO_BUILD_DATE  ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Custom variables provided in Makefile.maker.yaml
+export GOEXPERIMENT = jsonv2
 
 build-all: build/keppel
 

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -88,6 +88,9 @@ typos:
     fo: fo # part of regex fo+
     DELET: DELET # wrongly detected
 
+variables:
+  GOEXPERIMENT: jsonv2
+
 verbatim: |
   # This is for manual testing.
   run-api: build/keppel

--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -1280,7 +1280,7 @@ func TestGetPutAccountReplicationFromExternalOnFirstUse(t *testing.T) {
 			"strategy": "from_external_on_first_use",
 			"upstream": "registry.example.org",
 		},
-	}).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: json: cannot unmarshal string into Go struct field Account.account.replication of type keppel.ReplicationExternalPeerSpec\n")
+	}).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: json: cannot unmarshal string into Go value of type keppel.ReplicationExternalPeerSpec\n")
 
 	putFirstAccount(map[string]any{
 		"auth_tenant_id": "tenant1",

--- a/internal/keppel/duration_test.go
+++ b/internal/keppel/duration_test.go
@@ -47,7 +47,7 @@ func TestDurationMarshalling(t *testing.T) {
 	// test marshalling error: fractional second value
 	inputDuration := 2500 * time.Millisecond
 	_, err := json.Marshal(Duration(inputDuration))
-	expectedError := `json: error calling MarshalJSON for type keppel.Duration: duration is not a multiple of 1 second: "2.5s"`
+	expectedError := `json: error calling MarshalJSON for type *keppel.Duration: duration is not a multiple of 1 second: "2.5s"`
 	if err == nil {
 		t.Errorf("while marshalling %q: expected error %q, but got no error", inputDuration.String(), expectedError)
 	} else if err.Error() != expectedError {


### PR DESCRIPTION
Requires https://github.com/sapcc/go-makefile-maker/pull/498

Before:
```
 ➜ go test ./internal/keppel -bench BenchmarkEnrichReport -count=5
goos: linux
goarch: amd64
pkg: github.com/sapcc/keppel/internal/keppel
cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
BenchmarkEnrichReportWithOneIgnore-8                 111          10704018 ns/op         1197518 B/op        841 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 100          10775640 ns/op         1206144 B/op        839 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 100          11266311 ns/op         1195523 B/op        838 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 108          11110764 ns/op         1190348 B/op        838 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 114          10712929 ns/op         1194439 B/op        838 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             112          10552613 ns/op         1241263 B/op        822 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             111          10454432 ns/op         1228224 B/op        821 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             114          10671209 ns/op         1238556 B/op        822 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             100          10840005 ns/op         1206542 B/op        820 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             100          11257169 ns/op         1238233 B/op        822 allocs/op
PASS
ok      github.com/sapcc/keppel/internal/keppel 11.637s
```

After:
```
 ➜ GOEXPERIMENT=jsonv2 go test ./internal/keppel -bench BenchmarkEnrichReport -count=5
goos: linux
goarch: amd64
pkg: github.com/sapcc/keppel/internal/keppel
cpu: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
BenchmarkEnrichReportWithOneIgnore-8                 220           5408371 ns/op         1416507 B/op        438 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 228           5377392 ns/op         1385032 B/op        437 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 225           5327164 ns/op         1400845 B/op        435 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 204           5763850 ns/op         1385019 B/op        434 allocs/op
BenchmarkEnrichReportWithOneIgnore-8                 236           4960139 ns/op         1389537 B/op        432 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             242           5154800 ns/op         1528729 B/op        398 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             253           5222548 ns/op         1559122 B/op        397 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             210           5338916 ns/op         1575648 B/op        399 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             242           5423175 ns/op         1555041 B/op        399 allocs/op
BenchmarkEnrichReportExceptFixReleased-8             219           5522375 ns/op         1658860 B/op        403 allocs/op
PASS
ok      github.com/sapcc/keppel/internal/keppel 12.219s
```