### PR TITLE
internal/api/registry: replace more assert.HTTPRequest uses with httptest.Handler

### DIFF
--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -26,26 +26,25 @@ import (
 
 func TestAccountsAPI(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEmpty()
 
 	// test the /keppel/v1 endpoint
-	h.RespondTo(ctx, "GET /keppel/v1").
+	s.RespondTo(ctx, "GET /keppel/v1").
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"auth_driver": "unittest"})
 
 	// no accounts right now
-	h.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"accounts": []jsonmatch.Object{},
 		})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant1")).
 		ExpectText(t, http.StatusForbidden, "no permission for keppel_account:first:view\n")
 
 	// create an account (this request is executed twice to test idempotency)
 	for _, pass := range []int{1, 2} {
-		h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -80,7 +79,7 @@ func TestAccountsAPI(t *testing.T) {
 	}
 
 	// check that account shows up in GET...
-	h.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"accounts": []jsonmatch.Object{{
 				"name":           "first",
@@ -89,7 +88,7 @@ func TestAccountsAPI(t *testing.T) {
 				"rbac_policies":  []jsonmatch.Object{},
 			}},
 		})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"account": jsonmatch.Object{
 				"name":           "first",
@@ -100,11 +99,11 @@ func TestAccountsAPI(t *testing.T) {
 		})
 
 	// ...but only when one has view permission on the correct tenant
-	h.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant2")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant2")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"accounts": []jsonmatch.Object{},
 		})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant2")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant2")).
 		ExpectText(t, http.StatusForbidden, "no permission for keppel_account:first:view\n")
 
 	// create an account with RBAC policies and GC policies (this request is executed twice to test idempotency)
@@ -149,7 +148,7 @@ func TestAccountsAPI(t *testing.T) {
 		},
 	}
 	for _, pass := range []int{1, 2} {
-		h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+		s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -208,7 +207,7 @@ func TestAccountsAPI(t *testing.T) {
 	}
 
 	// check that this account also shows up in GET
-	h.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"accounts": []jsonmatch.Object{
 				{
@@ -227,7 +226,7 @@ func TestAccountsAPI(t *testing.T) {
 				},
 			},
 		})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/second", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/second", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"account": jsonmatch.Object{
 				"name":           "second",
@@ -259,7 +258,7 @@ func TestAccountsAPI(t *testing.T) {
 			"permissions":      []string{"pull", "delete"},
 		},
 	}
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -297,7 +296,7 @@ func TestAccountsAPI(t *testing.T) {
 	// test POST /keppel/v1/:accounts/sublease success case (error cases are in
 	// TestPutAccountErrorCases and TestGetPutAccountReplicationOnFirstUse)
 	s.FD.NextSubleaseTokenSecretToIssue = "this-is-the-token"
-	h.RespondTo(ctx, "POST /keppel/v1/accounts/second/sublease", withPerms("view:tenant1,change:tenant1")).
+	s.RespondTo(ctx, "POST /keppel/v1/accounts/second/sublease", withPerms("view:tenant1,change:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"sublease_token": makeSubleaseToken("second", "registry.example.org", "this-is-the-token"),
 		})
@@ -308,14 +307,13 @@ func TestAccountsAPI(t *testing.T) {
 
 func TestAccountValidationPolicies(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 	_, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEmpty()
 
 	// shorthand for configuring the account "first" with a PUT request
 	putAccount := func(accountConfig map[string]any) httptest.Response {
-		return h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		return s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{"account": accountConfig}),
 		)
@@ -458,20 +456,19 @@ func TestAccountValidationPolicies(t *testing.T) {
 
 func TestGetAccountsErrorCases(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 
 	// test invalid authentication (response includes auth challenges since the
 	// default auth scheme is bearer token auth)
-	h.RespondTo(ctx, "GET /keppel/v1/accounts").
+	s.RespondTo(ctx, "GET /keppel/v1/accounts").
 		ExpectText(t, http.StatusUnauthorized, "unauthorized\n")
 
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/first").
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/first").
 		ExpectHeader(t, "Www-Authenticate",
 			`Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="keppel_account:first:view"`).
 		ExpectText(t, http.StatusForbidden, "no bearer token found in request headers\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
 				"auth_tenant_id": "tenant1",
@@ -484,10 +481,9 @@ func TestGetAccountsErrorCases(t *testing.T) {
 
 func TestPutAccountRBACPolicyNormalization(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -515,13 +511,12 @@ func TestPutAccountRBACPolicyNormalization(t *testing.T) {
 
 func TestPutAccountErrorCases(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEmpty()
 
 	//preparation: create an account (so that we can check the error that the requested account name is taken)
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -538,17 +533,17 @@ func TestPutAccountErrorCases(t *testing.T) {
 	})
 
 	// test invalid inputs
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithBody(strings.NewReader(`{"account":???}`)),
 	).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: invalid character '?' looking for beginning of value\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithBody(strings.NewReader(`{"account":""}`)),
 	).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: json: cannot unmarshal string into Go struct field .account of type keppel.Account\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/keppel-api",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/keppel-api",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -556,7 +551,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			},
 		})).ExpectText(t, http.StatusUnprocessableEntity, "account names with the prefix \"keppel\" are reserved for internal use\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/v1",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/v1",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -566,7 +561,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 
 	// Just to be sure that this does not regress with any refactors in the future
 	for _, accountName := range []string{"_blobs", "_chunks", "-invalid"} {
-		h.RespondTo(ctx, "PUT /keppel/v1/accounts/"+accountName,
+		s.RespondTo(ctx, "PUT /keppel/v1/accounts/"+accountName,
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -576,7 +571,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 		// ^ The API route handler uses `[a-z0-9][a-z0-9-]{0,47}`, so we expect a 404 here.
 	}
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant2"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -585,7 +580,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 		})).ExpectText(t, http.StatusConflict, "account name already in use by a different tenant\n")
 
 	// test invalid authentication/authorization
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
 				"auth_tenant_id": "tenant1",
@@ -595,7 +590,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			`Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="keppel_auth_tenant:tenant1:change"`).
 		ExpectText(t, http.StatusForbidden, "no bearer token found in request headers\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("view:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -607,7 +602,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 	// error to validate that they generate the correct respective HTTP status
 	// codes)
 	s.FD.ClaimFailsBecauseOfUserError = true
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -617,7 +612,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 	s.FD.ClaimFailsBecauseOfUserError = false
 
 	s.FD.ClaimFailsBecauseOfServerError = true
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -628,7 +623,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 
 	// test rejection by storage driver
 	s.SD.ForbidNewAccounts = true
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -638,7 +633,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 	s.SD.ForbidNewAccounts = false
 
 	// test setting up invalid required_labels
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -805,7 +800,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			expectedStatus = http.StatusBadRequest
 		}
 
-		h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -981,7 +976,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			expectedStatus = http.StatusBadRequest
 		}
 
-		h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -992,7 +987,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 	}
 
 	// TODO: why is there a positive test in here?
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1017,7 +1012,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 	tr.DBChanges().AssertEqual(`
 		INSERT INTO accounts (name, auth_tenant_id, rbac_policies_json) VALUES ('first', 'tenant1', '[{"match_cidr":"1.2.0.0/16","permissions":["pull"]}]');
 	`)
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/first", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"account": jsonmatch.Object{
 				"auth_tenant_id": "tenant1",
@@ -1031,7 +1026,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 		})
 
 	// test unexpected platform filter
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1044,7 +1039,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 		})).ExpectText(t, http.StatusConflict, "cannot change platform filter on existing account\n")
 
 	// test unexpected platform filter on new primary account
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/third",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/third",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1057,20 +1052,20 @@ func TestPutAccountErrorCases(t *testing.T) {
 		})).ExpectText(t, http.StatusUnprocessableEntity, "platform filter is only allowed on replica accounts\n")
 
 	// test errors for sublease token issuance: missing authentication/authorization
-	h.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease").
+	s.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease").
 		ExpectHeader(t, "Www-Authenticate",
 			// default auth is bearer token auth, so an auth challenge gets rendered
 			`Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="keppel_account:first:change"`).
 		ExpectText(t, http.StatusForbidden, "no bearer token found in request headers\n")
 
-	h.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease",
+	s.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease",
 		withPerms("view:tenant1"),
 	).ExpectText(t, http.StatusForbidden, "no permission for keppel_account:first:change\n")
-	h.RespondTo(ctx, "POST /keppel/v1/accounts/unknown/sublease", // account does not exist
+	s.RespondTo(ctx, "POST /keppel/v1/accounts/unknown/sublease", // account does not exist
 		withPerms("view:tenant1,change:tenant1"),
 	).ExpectText(t, http.StatusForbidden, "no permission for keppel_account:unknown:change\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1079,7 +1074,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			},
 		})).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: json: unknown field \"in_maintenance\"\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1088,7 +1083,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			},
 		})).ExpectText(t, http.StatusUnprocessableEntity, "malformed attribute \"account.metadata\" in request body does no longer exist\n")
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1097,7 +1092,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 			},
 		})).ExpectStatus(t, http.StatusOK)
 
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1108,7 +1103,7 @@ func TestPutAccountErrorCases(t *testing.T) {
 
 	// test protection for managed accounts
 	test.MustExec(t, s.DB, "UPDATE accounts SET is_managed = TRUE WHERE name = $1", "first")
-	h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"account": map[string]any{
@@ -1124,7 +1119,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 		s1 := test.NewSetup(t, test.WithKeppelAPI, test.WithPeerAPI)
 		s2 := test.NewSetup(t, test.WithKeppelAPI, test.IsSecondaryTo(&s1))
 
-		s1.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s1.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1141,7 +1136,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 		})
 
 		// test error cases on creation
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1150,7 +1145,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 				},
 			})).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: do not know how to deserialize ReplicationPolicy with strategy \"yes_please\"\n")
 
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1159,7 +1154,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 				},
 			})).ExpectText(t, http.StatusUnprocessableEntity, "unknown peer registry: \"someone-else.example.org\"\n")
 
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1169,7 +1164,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 			})).ExpectText(t, http.StatusForbidden, "wrong sublease token\n")
 
 		s2.FD.ValidSubleaseTokenSecrets["first"] = "valid-token"
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithHeader(keppelv1.SubleaseHeader, makeSubleaseToken("first", "registry.example.org", "not-the-valid-token")),
 			httptest.WithJSONBody(map[string]any{
@@ -1180,7 +1175,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 			})).ExpectText(t, http.StatusForbidden, "wrong sublease token\n")
 
 		// test PUT success case
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithHeader(keppelv1.SubleaseHeader, makeSubleaseToken("first", "registry.example.org", "valid-token")),
 			httptest.WithJSONBody(map[string]any{
@@ -1204,7 +1199,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 
 		// PUT on existing account with replication unspecified is okay, leaves
 		// replication settings unchanged
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1225,11 +1220,11 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 		})
 
 		// cannot issue sublease token for replica account (only for primary accounts)
-		s2.Handler.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease", withPerms("view:tenant1,change:tenant1")).
+		s2.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease", withPerms("view:tenant1,change:tenant1")).
 			ExpectText(t, http.StatusBadRequest, "operation not allowed for replica accounts\n")
 
 		// PUT on existing account with different replication settings is not allowed
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 			withPerms("change:tenant2"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1244,7 +1239,7 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 				"rbac_policies":  []jsonmatch.Object{},
 			},
 		})
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 			withPerms("change:tenant2"),
 			httptest.WithJSONBody(map[string]any{
 				"account": map[string]any{
@@ -1257,18 +1252,17 @@ func TestGetPutAccountReplicationOnFirstUse(t *testing.T) {
 
 func TestGetPutAccountReplicationFromExternalOnFirstUse(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 
 	// helper functions for basic PUT calls on accounts
 	putFirstAccount := func(accountConfig map[string]any) httptest.Response {
-		return h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		return s.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{"account": accountConfig}),
 		)
 	}
 	putSecondAccount := func(accountConfig map[string]any) httptest.Response {
-		return h.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+		return s.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 			withPerms("change:tenant2"),
 			httptest.WithJSONBody(map[string]any{"account": accountConfig}),
 		)
@@ -1450,7 +1444,7 @@ func TestGetPutAccountReplicationFromExternalOnFirstUse(t *testing.T) {
 	// accounts for the purposes of account name subleasing)
 	s.FD.NextSubleaseTokenSecretToIssue = "this-is-the-token"
 	expectedToken := makeSubleaseToken("first", "registry.example.org", "this-is-the-token")
-	h.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease", withPerms("view:tenant1,change:tenant1")).
+	s.RespondTo(ctx, "POST /keppel/v1/accounts/first/sublease", withPerms("view:tenant1,change:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"sublease_token": expectedToken})
 
 	// PUT on existing account with different replication settings is not allowed
@@ -1509,7 +1503,6 @@ func TestDeleteAccount(t *testing.T) {
 		test.WithKeppelAPI,
 		test.WithAccount(models.Account{Name: "test1", AuthTenantID: "tenant1"}),
 	)
-	h := s.Handler
 	ctx := t.Context()
 
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
@@ -1517,11 +1510,11 @@ func TestDeleteAccount(t *testing.T) {
 
 	// failure case: insufficient permissions (the "delete" permission refers to
 	// manifests within the account, not the account itself)
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1", withPerms("view:tenant1,delete:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1", withPerms("view:tenant1,delete:tenant1")).
 		ExpectStatus(t, http.StatusForbidden)
 
 	// DELETE on account should immediately mark it for deletion
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1", withPerms("view:tenant1,change:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1", withPerms("view:tenant1,change:tenant1")).
 		ExpectStatus(t, http.StatusNoContent)
 
 	tr.DBChanges().AssertEqualf(`
@@ -1544,7 +1537,7 @@ func TestDeleteAccount(t *testing.T) {
 	)
 
 	// account is already set to be deleted, so nothing happens
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1", withPerms("view:tenant1,change:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1", withPerms("view:tenant1,change:tenant1")).
 		ExpectStatus(t, http.StatusNoContent)
 
 	tr.DBChanges().AssertEmpty()
@@ -1605,7 +1598,7 @@ func TestReplicaAccountsInheritPlatformFilter(t *testing.T) {
 
 		// create some primary accounts to play with
 		for _, name := range []models.AccountName{"first", "second", "third"} {
-			s1.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/"+string(name),
+			s1.RespondTo(ctx, "PUT /keppel/v1/accounts/"+string(name),
 				withPerms("change:tenant1"),
 				httptest.WithJSONBody(map[string]any{
 					"account": map[string]any{
@@ -1638,7 +1631,7 @@ func TestReplicaAccountsInheritPlatformFilter(t *testing.T) {
 		}
 
 		// create an account which inherits the PlatformFilter
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
 			withPerms("change:tenant1"),
 			httptest.WithHeader(keppelv1.SubleaseHeader, makeSubleaseToken("first", "registry.example.org", "valid-token")),
 			httptest.WithJSONBody(map[string]any{
@@ -1665,7 +1658,7 @@ func TestReplicaAccountsInheritPlatformFilter(t *testing.T) {
 		})
 
 		// create an account with the same PlatformFilter
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/second",
 			withPerms("change:tenant1"),
 			httptest.WithHeader(keppelv1.SubleaseHeader, makeSubleaseToken("second", "registry.example.org", "valid-token")),
 			httptest.WithJSONBody(map[string]any{
@@ -1697,7 +1690,7 @@ func TestReplicaAccountsInheritPlatformFilter(t *testing.T) {
 		})
 
 		// create an account with an incompatible PlatformFilter
-		s2.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/third",
+		s2.RespondTo(ctx, "PUT /keppel/v1/accounts/third",
 			withPerms("change:tenant1"),
 			httptest.WithHeader(keppelv1.SubleaseHeader, makeSubleaseToken("third", "registry.example.org", "valid-token")),
 			httptest.WithJSONBody(map[string]any{
@@ -1732,21 +1725,21 @@ func TestSecurityScanPoliciesHappyPath(t *testing.T) {
 	s.AD.ExpectedUserName = "exampleuser"
 
 	// a freshly-created account should have no policies at all
-	s.Handler.RespondTo(ctx, "GET /keppel/v1/accounts/first/security_scan_policies", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/first/security_scan_policies", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"policies": []jsonmatch.Object{}})
 	s.Auditor.IgnoreEventsUntilNow()
 
 	// helper function for testing a successful PUT of policies, followed by a GET
 	// that returns those same policies
 	expectPoliciesToBeApplied := func(policies ...map[string]any) {
-		s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+		s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{"policies": policies}),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"policies": policies,
 		})
 
-		s.Handler.RespondTo(ctx, "GET /keppel/v1/accounts/first/security_scan_policies",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/first/security_scan_policies",
 			withPerms("view:tenant1"),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"policies": policies,
@@ -1830,7 +1823,7 @@ func TestSecurityScanPoliciesHappyPath(t *testing.T) {
 	// test expansion of "$REQUESTER" in "managed_by_user" field (this cannot use
 	// expectPoliciesToBeApplied() since the response body is different from the
 	// request body)
-	s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"policies": []map[string]any{{
@@ -1872,7 +1865,7 @@ func TestSecurityScanPoliciesValidationErrors(t *testing.T) {
 
 	// helper to set security scan policies
 	setPolicies := func(policies []map[string]any) httptest.Response {
-		return s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+		return s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 			withPerms("change:tenant1"),
 			httptest.WithJSONBody(map[string]any{"policies": policies}),
 		)
@@ -1997,7 +1990,7 @@ func TestSecurityScanPoliciesAuthorizationErrors(t *testing.T) {
 	s.AD.ExpectedUserName = "exampleuser"
 
 	// PUT requires CanChangeAccount
-	s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 		withPerms("view:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"policies": []map[string]any{},
@@ -2015,7 +2008,7 @@ func TestSecurityScanPoliciesAuthorizationErrors(t *testing.T) {
 		},
 	}
 	foreignPolicyJSON := toJSONVia[keppel.SecurityScanPolicy](foreignPolicy)
-	s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"policies": []map[string]any{foreignPolicy},
@@ -2030,7 +2023,7 @@ func TestSecurityScanPoliciesAuthorizationErrors(t *testing.T) {
 		fmt.Sprintf("[%s]", foreignPolicyJSON))
 
 	// it's okay if we leave that policy untouched...
-	s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"policies": []map[string]any{foreignPolicy},
@@ -2042,7 +2035,7 @@ func TestSecurityScanPoliciesAuthorizationErrors(t *testing.T) {
 	// ...but updating is not okay...
 	delete(foreignPolicy, "managed_by_user")
 	foreignPolicy["match_repository"] = "definitely-not-the-old-value"
-	s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"policies": []map[string]any{foreignPolicy},
@@ -2052,7 +2045,7 @@ func TestSecurityScanPoliciesAuthorizationErrors(t *testing.T) {
 	)
 
 	// ...and deleting is also not okay
-	s.Handler.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
+	s.RespondTo(ctx, "PUT /keppel/v1/accounts/first/security_scan_policies",
 		withPerms("change:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"policies": []map[string]any{},

--- a/internal/api/keppel/api_test.go
+++ b/internal/api/keppel/api_test.go
@@ -21,11 +21,10 @@ func TestAlternativeAuthSchemes(t *testing.T) {
 		test.WithAccount(models.Account{Name: "test1", AuthTenantID: "tenant1"}),
 		test.WithRepo(models.Repository{Name: "foo", AccountName: "test1"}),
 	)
-	h := s.Handler
 	ctx := t.Context()
 
 	// test anonymous auth: fails without RBAC policy, succeeds with RBAC policy
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/foo/_manifests").
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/foo/_manifests").
 		ExpectHeader(t, "Www-Authenticate",
 			`Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`).
 		ExpectText(t, http.StatusForbidden, "no bearer token found in request headers\n")
@@ -36,7 +35,7 @@ func TestAlternativeAuthSchemes(t *testing.T) {
 			Permissions:       []keppel.RBACPermission{keppel.RBACAnonymousPullPermission},
 		}}),
 	)
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/foo/_manifests").
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/foo/_manifests").
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"manifests": []jsonmatch.Object{}})
 	test.MustExec(t, s.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1", "")
 
@@ -46,10 +45,10 @@ func TestAlternativeAuthSchemes(t *testing.T) {
 	var tokenData struct {
 		Token string `json:"token"`
 	}
-	h.RespondTo(ctx, "GET /keppel/v1/auth?service=registry.example.org&scope=repository:test1/foo:pull",
+	s.RespondTo(ctx, "GET /keppel/v1/auth?service=registry.example.org&scope=repository:test1/foo:pull",
 		withPerms("view:tenant1,pull:tenant1"),
 	).CaptureJSON(&tokenData).ExpectStatus(t, http.StatusOK)
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/foo/_manifests",
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/foo/_manifests",
 		httptest.WithHeader("Authorization", "Bearer "+tokenData.Token),
 	).ExpectJSON(t, http.StatusOK, jsonmatch.Object{"manifests": []jsonmatch.Object{}})
 }

--- a/internal/api/keppel/manifests_test.go
+++ b/internal/api/keppel/manifests_test.go
@@ -48,7 +48,6 @@ func TestManifestsAPI(t *testing.T) {
 		s := test.NewSetup(t, test.WithKeppelAPI, test.WithTrivyDouble,
 			test.WithAccount(models.Account{Name: "test1", AuthTenantID: "tenant1"}),
 			test.WithAccount(models.Account{Name: "test2", AuthTenantID: "tenant2"}))
-		h := s.Handler
 		ctx := t.Context()
 
 		// setup test repos (`repo1-2` and `repo2-1` only exist to validate that we
@@ -63,12 +62,12 @@ func TestManifestsAPI(t *testing.T) {
 		}
 
 		// test empty GET
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{"manifests": []jsonmatch.Object{}})
 
 		// test that Keppel API does not allow domain-remapping
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests",
 			withPerms("view:tenant1,pull:tenant1"),
 			httptest.WithHeader("X-Forwarded-Host", "test1.registry.example.org"),
 			httptest.WithHeader("X-Forwarded-Proto", "https"),
@@ -170,21 +169,21 @@ func TestManifestsAPI(t *testing.T) {
 		})
 
 		// test GET without pagination
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{"manifests": renderedManifests})
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=10",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=10",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{"manifests": renderedManifests})
 
 		// test GET with pagination
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=5",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=5",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"manifests": renderedManifests[0:5],
 			"truncated": true,
 		})
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=5&marker="+renderedManifests[4]["digest"].(digest.Digest).String(),
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=5&marker="+renderedManifests[4]["digest"].(digest.Digest).String(),
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{"manifests": renderedManifests[5:10]})
 		for idx := range 9 {
@@ -194,25 +193,25 @@ func TestManifestsAPI(t *testing.T) {
 			if idx < 8 {
 				expectedBody["truncated"] = true
 			}
-			h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=1&marker="+renderedManifests[idx]["digest"].(digest.Digest).String(),
+			s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=1&marker="+renderedManifests[idx]["digest"].(digest.Digest).String(),
 				withPerms("view:tenant1,pull:tenant1"),
 			).ExpectJSON(t, http.StatusOK, expectedBody)
 		}
 
 		// test GET failure cases
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/doesnotexist/repositories/repo1-1/_manifests",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/doesnotexist/repositories/repo1-1/_manifests",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectText(t, http.StatusForbidden, "no permission for repository:doesnotexist/repo1-1:pull\n")
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/doesnotexist/_manifests",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/doesnotexist/_manifests",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusNotFound)
-		h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=foo",
+		s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories/repo1-1/_manifests?limit=foo",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectText(t, http.StatusBadRequest, "strconv.ParseUint: parsing \"foo\": invalid syntax\n")
 
 		// test DELETE manifest happy case
 		easypg.AssertDBContent(t, s.DB.Db, "fixtures/before-delete-manifest.sql")
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/"+test.DeterministicDummyDigest(11).String(),
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/"+test.DeterministicDummyDigest(11).String(),
 			withPerms("view:tenant1,delete:tenant1"),
 		).ExpectStatus(t, http.StatusNoContent)
 		easypg.AssertDBContent(t, s.DB.Db, "fixtures/after-delete-manifest.sql")
@@ -236,7 +235,7 @@ func TestManifestsAPI(t *testing.T) {
 		})
 
 		// test DELETE tag happy case
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2/_tags/stillfirst",
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2/_tags/stillfirst",
 			withPerms("view:tenant1,delete:tenant1"),
 		).ExpectStatus(t, http.StatusNoContent)
 		easypg.AssertDBContent(t, s.DB.Db, "fixtures/after-delete-tag.sql")
@@ -255,39 +254,39 @@ func TestManifestsAPI(t *testing.T) {
 		})
 
 		// test DELETE manifest failure cases
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1/_manifests/"+test.DeterministicDummyDigest(31).String(),
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1/_manifests/"+test.DeterministicDummyDigest(31).String(),
 			withPerms("delete:tenant1,view:tenant1,pull:tenant1"),
 		).ExpectText(t, http.StatusForbidden, "no permission for repository:test2/repo2-1:delete\n")
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2/_manifests/"+test.DeterministicDummyDigest(21).String(),
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2/_manifests/"+test.DeterministicDummyDigest(21).String(),
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusForbidden)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/doesnotexist/repositories/repo1-2/_manifests/"+test.DeterministicDummyDigest(11).String(),
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/doesnotexist/repositories/repo1-2/_manifests/"+test.DeterministicDummyDigest(11).String(),
 			withPerms("delete:tenant1,view:tenant1,pull:tenant1"),
 		).ExpectText(t, http.StatusForbidden, "no permission for repository:doesnotexist/repo1-2:delete\n")
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/doesnotexist/_manifests/"+test.DeterministicDummyDigest(11).String(),
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/doesnotexist/_manifests/"+test.DeterministicDummyDigest(11).String(),
 			withPerms("delete:tenant1,view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusNotFound)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/"+test.DeterministicDummyDigest(11).String(),
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/"+test.DeterministicDummyDigest(11).String(),
 			withPerms("view:tenant1,delete:tenant1"),
 		).ExpectStatus(t, http.StatusNotFound)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/second", // this endpoint only works with digests
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/second", // this endpoint only works with digests
 			withPerms("view:tenant1,delete:tenant1"),
 		).ExpectStatus(t, http.StatusNotFound)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/sha256:12345",
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1/_manifests/sha256:12345",
 			withPerms("view:tenant1,delete:tenant1"),
 		).ExpectStatus(t, http.StatusNotFound)
 
 		// test DELETE tag failure cases
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2/_tags/first",
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2/_tags/first",
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusForbidden)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1/_tags/"+test.DeterministicDummyDigest(31).String(), // this endpoint only works with tags
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1/_tags/"+test.DeterministicDummyDigest(31).String(), // this endpoint only works with tags
 			withPerms("delete:tenant2,view:tenant2"),
 		).ExpectStatus(t, http.StatusNotFound)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/doesnotexist/_tags/first",
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/doesnotexist/_tags/first",
 			withPerms("delete:tenant2,view:tenant2"),
 		).ExpectStatus(t, http.StatusNotFound)
-		h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1/_tags/doesnotexist",
+		s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1/_tags/doesnotexist",
 			withPerms("delete:tenant2,view:tenant2"),
 		).ExpectStatus(t, http.StatusNotFound)
 	})
@@ -301,7 +300,6 @@ func TestGetTrivyReport(t *testing.T) {
 			test.WithTrivyDouble,
 			test.WithAccount(models.Account{Name: "test1", AuthTenantID: "tenant1"}),
 		)
-		h := s.Handler
 		ctx := t.Context()
 
 		// setup: upload an image and an image list
@@ -314,17 +312,17 @@ func TestGetTrivyReport(t *testing.T) {
 		endpointFor := func(d digest.Digest) string {
 			return "GET /keppel/v1/accounts/test1/repositories/foo/_manifests/" + d.String() + "/trivy_report"
 		}
-		h.RespondTo(ctx, endpointFor(test.DeterministicDummyDigest(1)),
+		s.RespondTo(ctx, endpointFor(test.DeterministicDummyDigest(1)),
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusNotFound)
 
 		// error case: cannot GET report for an image that does not have scannable layers
-		h.RespondTo(ctx, endpointFor(listManifest.Digest),
+		s.RespondTo(ctx, endpointFor(listManifest.Digest),
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusMethodNotAllowed)
 
 		// error case: cannot GET report for an image that has not been scanned by the janitor after upload
-		h.RespondTo(ctx, endpointFor(imageManifest.Digest),
+		s.RespondTo(ctx, endpointFor(imageManifest.Digest),
 			withPerms("view:tenant1,pull:tenant1"),
 		).ExpectStatus(t, http.StatusMethodNotAllowed)
 
@@ -343,7 +341,7 @@ func TestGetTrivyReport(t *testing.T) {
 		)
 
 		// happy case: GET on the default format "json" returns that cached report
-		h.RespondTo(ctx, endpointFor(imageManifest.Digest), withPerms("view:tenant1,pull:tenant1")).
+		s.RespondTo(ctx, endpointFor(imageManifest.Digest), withPerms("view:tenant1,pull:tenant1")).
 			ExpectHeader(t, "Content-Type", "application/json").
 			ExpectText(t, http.StatusOK, string(buf))
 
@@ -356,7 +354,7 @@ func TestGetTrivyReport(t *testing.T) {
 		s.TrivyDouble.ReportFixtures[imageRef] = "fixtures/trivy-report-spdx.json"
 		var expected jsonmatch.Object
 		must.SucceedT(t, json.Unmarshal(must.ReturnT(os.ReadFile("fixtures/trivy-report-spdx.json"))(t), &expected))
-		h.RespondTo(ctx, endpointFor(imageManifest.Digest)+"?format=spdx-json", withPerms("view:tenant1,pull:tenant1")).
+		s.RespondTo(ctx, endpointFor(imageManifest.Digest)+"?format=spdx-json", withPerms("view:tenant1,pull:tenant1")).
 			ExpectHeader(t, "Content-Type", "application/json").
 			ExpectJSON(t, http.StatusOK, expected)
 	})
@@ -379,7 +377,6 @@ func TestRateLimitsTrivyReport(t *testing.T) {
 			test.WithRateLimitEngine(rle),
 			test.WithAccount(models.Account{Name: "test1", AuthTenantID: "tenant1"}),
 		)
-		h := s.Handler
 		ctx := t.Context()
 
 		_ = must.ReturnT(keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1")))(t)
@@ -388,7 +385,7 @@ func TestRateLimitsTrivyReport(t *testing.T) {
 
 		doTrivyRequest := func() httptest.Response {
 			endpoint := fmt.Sprintf("GET /keppel/v1/accounts/test1/repositories/foo/_manifests/%s/trivy_report", test.DeterministicDummyDigest(1))
-			return h.RespondTo(ctx, endpoint, httptest.WithHeaders(tokenHeaders))
+			return s.RespondTo(ctx, endpoint, httptest.WithHeaders(tokenHeaders))
 		}
 		expectRateLimited := func(reset, retryAfter int) {
 			t.Helper()

--- a/internal/api/keppel/peers_test.go
+++ b/internal/api/keppel/peers_test.go
@@ -16,11 +16,10 @@ import (
 
 func TestPeersAPI(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 
 	// check empty response when there are no peers in the DB
-	h.RespondTo(ctx, "GET /keppel/v1/peers", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/peers", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"peers": []any{}})
 
 	// add some peers
@@ -33,6 +32,6 @@ func TestPeersAPI(t *testing.T) {
 	}
 
 	// check non-empty response
-	h.RespondTo(ctx, "GET /keppel/v1/peers", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/peers", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"peers": expectedPeers})
 }

--- a/internal/api/keppel/quotas_test.go
+++ b/internal/api/keppel/quotas_test.go
@@ -21,11 +21,10 @@ import (
 func TestQuotasAPI(t *testing.T) {
 	// NOTE: This tests both the Keppel-native quota API and the LIQUID API which accesses the same logic.
 	s := test.NewSetup(t, test.WithKeppelAPI)
-	h := s.Handler
 	ctx := t.Context()
 
 	// GET on auth tenant without more specific configuration shows default values
-	h.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"manifests": jsonmatch.Object{"quota": 0, "usage": 0},
 		})
@@ -45,30 +44,30 @@ func TestQuotasAPI(t *testing.T) {
 			},
 		}
 	}
-	h.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
+	s.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
 		withPerms("viewquota:tenant1"),
 		httptest.WithJSONBody(map[string]any{"allAZs": []string{"dummy"}}),
 	).ExpectJSON(t, http.StatusOK, buildLiquidResponse(0, 0))
 
 	// GET basic error cases: no permission on the respective auth tenant
-	h.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant2")).
+	s.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant2")).
 		ExpectStatus(t, http.StatusForbidden)
-	h.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
+	s.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
 		withPerms("viewquota:tenant2"),
 		httptest.WithJSONBody(map[string]any{"allAZs": []string{"dummy"}}),
 	).ExpectStatus(t, http.StatusForbidden)
 
 	// GET basic error cases: wrong permission on the respective auth tenant
-	h.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("view:tenant1")).
 		ExpectStatus(t, http.StatusForbidden)
-	h.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
+	s.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
 		withPerms("view:tenant1"),
 		httptest.WithJSONBody(map[string]any{"allAZs": []string{"dummy"}}),
 	).ExpectStatus(t, http.StatusForbidden)
 
 	// PUT happy case with native API
 	for _, pass := range []int{1, 2, 3} {
-		h.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
+		s.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
 			withPerms("changequota:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"manifests": map[string]any{"quota": 50},
@@ -109,7 +108,7 @@ func TestQuotasAPI(t *testing.T) {
 
 	// PUT happy case with LIQUID API
 	for _, pass := range []int{1, 2, 3} {
-		h.RespondTo(ctx, "PUT /liquid/v1/projects/tenant1/quota",
+		s.RespondTo(ctx, "PUT /liquid/v1/projects/tenant1/quota",
 			withPerms("changequota:tenant1"),
 			httptest.WithJSONBody(map[string]any{
 				"resources": map[string]any{
@@ -149,11 +148,11 @@ func TestQuotasAPI(t *testing.T) {
 	}
 
 	// GET reflects changes
-	h.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"manifests": jsonmatch.Object{"quota": 100, "usage": 0},
 		})
-	h.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
+	s.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
 		withPerms("viewquota:tenant1"),
 		httptest.WithJSONBody(map[string]any{"allAZs": []string{"dummy"}}),
 	).ExpectJSON(t, http.StatusOK, buildLiquidResponse(100, 0))
@@ -181,29 +180,29 @@ func TestQuotasAPI(t *testing.T) {
 			NextCheckAt:         Some(time.Unix(0, 0)),
 		}))
 	}
-	h.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/quotas/tenant1", withPerms("viewquota:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"manifests": jsonmatch.Object{"quota": 100, "usage": 10},
 		})
-	h.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
+	s.RespondTo(ctx, "POST /liquid/v1/projects/tenant1/report-usage",
 		withPerms("viewquota:tenant1"),
 		httptest.WithJSONBody(map[string]any{"allAZs": []string{"dummy"}}),
 	).ExpectJSON(t, http.StatusOK, buildLiquidResponse(100, 10))
 
 	// PUT error cases
-	h.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
+	s.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
 		withPerms("viewquota:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"manifests": map[string]any{"quota": 100},
 		}),
 	).ExpectStatus(t, http.StatusForbidden)
-	h.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
+	s.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
 		withPerms("changequota:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"manifests": map[string]any{"quota": 100, "usage": 10},
 		}),
 	).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: json: unknown field \"usage\"\n")
-	h.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
+	s.RespondTo(ctx, "PUT /keppel/v1/quotas/tenant1",
 		withPerms("changequota:tenant1"),
 		httptest.WithJSONBody(map[string]any{
 			"manifests": map[string]any{"quota": 5},

--- a/internal/api/keppel/repos_test.go
+++ b/internal/api/keppel/repos_test.go
@@ -25,11 +25,10 @@ func TestReposAPI(t *testing.T) {
 	s := test.NewSetup(t, test.WithKeppelAPI, test.WithQuotas,
 		test.WithAccount(models.Account{Name: "test1", AuthTenantID: "tenant1"}),
 		test.WithAccount(models.Account{Name: "test2", AuthTenantID: "tenant2"}))
-	h := s.Handler
 	ctx := t.Context()
 
 	// test empty result
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"repositories": []jsonmatch.Object{},
 		})
@@ -115,52 +114,52 @@ func TestReposAPI(t *testing.T) {
 		{"name": "repo1-4", "manifest_count": 0, "tag_count": 0},
 		{"name": "repo1-5", "manifest_count": 0, "tag_count": 0},
 	}
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": renderedRepos})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=5", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=5", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": renderedRepos})
 
 	// test GET with pagination
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 			"repositories": renderedRepos[0:3],
 			"truncated":    true,
 		})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3&marker=repo1-3", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3&marker=repo1-3", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": renderedRepos[3:5]})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3&marker=repo1-2", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3&marker=repo1-2", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": renderedRepos[2:5]})
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3&marker=repo1-5", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=3&marker=repo1-5", withPerms("view:tenant1")).
 		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": []jsonmatch.Object{}})
 
 	// test GET failure cases
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/doesnotexist/repositories", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/doesnotexist/repositories", withPerms("view:tenant1")).
 		ExpectText(t, http.StatusForbidden, "no permission for keppel_account:doesnotexist:view\n")
-	h.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=foo", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "GET /keppel/v1/accounts/test1/repositories?limit=foo", withPerms("view:tenant1")).
 		ExpectText(t, http.StatusBadRequest, "strconv.ParseUint: parsing \"foo\": invalid syntax\n")
 
 	// test DELETE failure cases
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1", withPerms("delete:tenant1,view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test2/repositories/repo2-1", withPerms("delete:tenant1,view:tenant1")).
 		ExpectText(t, http.StatusForbidden, "no permission for repository:test2/repo2-1:delete\n")
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2", withPerms("view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-2", withPerms("view:tenant1")).
 		ExpectText(t, http.StatusForbidden, "no permission for repository:test1/repo1-2:delete\n")
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/doesnotexist/repositories/repo1-2", withPerms("delete:tenant1,view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/doesnotexist/repositories/repo1-2", withPerms("delete:tenant1,view:tenant1")).
 		ExpectText(t, http.StatusForbidden, "no permission for repository:doesnotexist/repo1-2:delete\n")
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/doesnotexist", withPerms("delete:tenant1,view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/doesnotexist", withPerms("delete:tenant1,view:tenant1")).
 		ExpectText(t, http.StatusNotFound, "repository not found\n")
 
 	// test if tag policy prevents deletion
 	deletingTagPolicyJSON := `{"match_repository":".*","block_delete":true}`
 	test.MustExec(t, s.DB, `UPDATE accounts SET tag_policies_json = $1`, "["+deletingTagPolicyJSON+"]")
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-3", withPerms("delete:tenant1,view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-3", withPerms("delete:tenant1,view:tenant1")).
 		ExpectText(t, http.StatusConflict, "cannot delete manifest because it is protected by tag policy ({\"match_repository\":\".*\",\"block_delete\":true})\n")
 	test.MustExec(t, s.DB, `UPDATE accounts SET tag_policies_json = '[]'`)
 
 	// test DELETE happy case
 	easypg.AssertDBContent(t, s.DB.Db, "fixtures/before-delete-repo.sql")
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1", withPerms("delete:tenant1,view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-1", withPerms("delete:tenant1,view:tenant1")).
 		ExpectStatus(t, http.StatusNoContent)
-	h.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-3", withPerms("delete:tenant1,view:tenant1")).
+	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-3", withPerms("delete:tenant1,view:tenant1")).
 		ExpectStatus(t, http.StatusNoContent)
 	easypg.AssertDBContent(t, s.DB.Db, "fixtures/after-delete-repo.sql")
 }

--- a/internal/api/registry/api_test.go
+++ b/internal/api/registry/api_test.go
@@ -153,8 +153,7 @@ func TestAPIAuthNotGrantingAnyScopes(t *testing.T) {
 	testWithPrimary(t, nil, func(s test.Setup) {
 		// any endpoint, when not provided with a token, should respond with 401
 		// and challenge us to get one (unless RBAC policies for anonymous access are set up)
-		s.Handler.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest").
-			ExpectHeader(t, test.VersionHeaderKey, test.VersionHeaderValue).
+		s.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest").
 			ExpectHeader(t, "Www-Authenticate",
 				`Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`).
 			ExpectStatus(t, http.StatusUnauthorized)
@@ -169,7 +168,7 @@ func TestAPIAuthNotGrantingAnyScopes(t *testing.T) {
 				"detail":  nil,
 			}},
 		}
-		s.Handler.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest", httptest.WithHeaders(tokenHeaders)).
+		s.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest", httptest.WithHeaders(tokenHeaders)).
 			ExpectJSON(t, http.StatusUnauthorized, deniedMessage)
 
 		// same test, but with an anonymous user
@@ -181,7 +180,7 @@ func TestAPIAuthNotGrantingAnyScopes(t *testing.T) {
 			Audience:     auth.Audience{IsAnycast: false},
 			ScopeSet:     auth.ScopeSet{},
 		}.IssueToken(s.Config))(t).Token
-		s.Handler.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest", httptest.WithHeader("Authorization", "Bearer "+token)).
+		s.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest", httptest.WithHeader("Authorization", "Bearer "+token)).
 			ExpectJSON(t, http.StatusUnauthorized, deniedMessage)
 	})
 }

--- a/internal/api/registry/api_test.go
+++ b/internal/api/registry/api_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/majewsky/gg/jsonmatch"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 
@@ -20,35 +19,20 @@ import (
 
 func TestVersionCheckEndpoint(t *testing.T) {
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
+		ctx := t.Context()
 
 		// without token, expect auth challenge
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/",
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org"`,
-			},
-			ExpectBody: assert.JSONObject{
-				"errors": []assert.JSONObject{{
-					"code":    keppel.ErrUnauthorized,
-					"detail":  nil,
-					"message": "no bearer token found in request headers",
-				}},
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/").
+			ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org"`).
+			ExpectJSON(t, http.StatusUnauthorized, test.ErrorCodeWithMessage{
+				Code:    keppel.ErrUnauthorized,
+				Message: "no bearer token found in request headers",
+			})
 
 		// with token, expect status code 200
 		tokenHeaders := s.GetTokenHeaders(t /*, no scopes */)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/",
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/", httptest.WithHeaders(tokenHeaders)).
+			ExpectStatus(t, http.StatusOK)
 	})
 }
 
@@ -56,95 +40,57 @@ func TestKeppelAPIAuth(t *testing.T) {
 	// All the other tests use the conventional auth method using bearer tokens.
 	// This test provides test coverage for authenticating with the same
 	// AuthDriver-dependent mechanism used by the Keppel API.
+	ctx := t.Context()
 	testWithPrimary(t, nil, func(s test.Setup) {
 		// upload a manifest for testing (using bearer tokens since all our test
 		// helper functions use those)
-		h := s.Handler
 		image := test.GenerateImage(test.GenerateExampleLayer(1))
 		s.Clock.StepBy(time.Second)
 		image.MustUpload(t, s, fooRepoRef, "first")
 
 		// test scopeless endpoint: happy case
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/",
-			Header: map[string]string{
-				"Authorization": "keppel",
-				"X-Test-Perms":  "view:test1authtenant",
-			},
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/",
+			httptest.WithHeader("Authorization", "keppel"),
+			httptest.WithHeader("X-Test-Perms", "view:test1authtenant"),
+		).ExpectStatus(t, http.StatusOK)
+
 		// test scopeless endpoint: failure case ("Authorization: keppel" means that
 		// we want Keppel API auth, but then we don't pass the respective headers,
 		// so we get a 401; we do not get an auth challenge since Keppel API auth
 		// does not work with auth challenges)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/",
-			Header:       map[string]string{"Authorization": "keppel"},
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Www-Authenticate":    "",
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/", httptest.WithHeader("Authorization", "keppel")).
+			ExpectHeader(t, "Www-Authenticate", "").
+			ExpectStatus(t, http.StatusUnauthorized)
 
 		// test catalog endpoint: happy case
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/_catalog",
-			Header: map[string]string{
-				"Authorization": "keppel",
-				"X-Test-Perms":  "view:test1authtenant",
-			},
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody: assert.JSONObject{
-				"repositories": []string{"test1/foo"},
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/_catalog",
+			httptest.WithHeader("Authorization", "keppel"),
+			httptest.WithHeader("X-Test-Perms", "view:test1authtenant"),
+		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+			"repositories": []string{"test1/foo"},
+		})
+
 		// test catalog endpoint: "failure" case (no access to account -> empty list)
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/_catalog",
-			Header: map[string]string{
-				"Authorization": "keppel",
-				"X-Test-Perms":  "view:someothertenant",
-			},
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody: assert.JSONObject{
-				"repositories": []string{},
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/_catalog",
+			httptest.WithHeader("Authorization", "keppel"),
+			httptest.WithHeader("X-Test-Perms", "view:someothertenant"),
+		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+			"repositories": []string{},
+		})
 
 		// test repository-scoped endpoint: happy case
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-			Header: map[string]string{
-				"Authorization": "keppel",
-				"X-Test-Perms":  "view:test1authtenant,pull:test1authtenant",
-			},
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   assert.ByteData(image.Manifest.Contents),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+image.Manifest.Digest.String(),
+			httptest.WithHeader("Authorization", "keppel"),
+			httptest.WithHeader("X-Test-Perms", "view:test1authtenant,pull:test1authtenant"),
+		).ExpectBody(t, http.StatusOK, image.Manifest.Contents)
+
 		// test repository-scoped endpoint: failure case (no pull permission)
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-			Header: map[string]string{
-				"Authorization": "keppel",
-				"X-Test-Perms":  "view:test1authtenant",
-			},
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Www-Authenticate":    "", // Keppel API auth does not use auth challenges
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+image.Manifest.Digest.String(),
+			httptest.WithHeader("Authorization", "keppel"),
+			httptest.WithHeader("X-Test-Perms", "view:test1authtenant"),
+		).
+			ExpectHeader(t, "Www-Authenticate", "").
+			ExpectStatus(t, http.StatusUnauthorized)
 	})
 }
 

--- a/internal/api/registry/blobs_test.go
+++ b/internal/api/registry/blobs_test.go
@@ -136,17 +136,16 @@ func TestBlobMonolithicUpload(t *testing.T) {
 			}.Check(t, h)
 
 			// validate that the blob was stored at the specified location
-			expectBlobExists(t, h, tokenHeaders, "test1/foo", blob)
+			expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
 		}
 
 		// test GET via anycast
 		if currentlyWithAnycast {
 			testWithReplica(t, s, "on_first_use", func(firstPass bool, s2 test.Setup) {
 				testAnycast(t, firstPass, s2.DB, func() {
-					h2 := s2.Handler
 					anycastTokenHeaders := s.GetAnycastTokenHeaders(t, "repository:test1/foo:pull")
-					expectBlobExists(t, h, anycastTokenHeaders, "test1/foo", blob)
-					expectBlobExists(t, h2, anycastTokenHeaders, "test1/foo", blob)
+					expectBlobExists(t, s, anycastTokenHeaders, "test1/foo", blob)
+					expectBlobExists(t, s2, anycastTokenHeaders, "test1/foo", blob)
 				})
 			})
 		}
@@ -272,7 +271,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 			// request should not contain session state)
 			assert.HTTPRequest{
 				Method:       "PATCH",
-				Path:         keppel.AppendQuery(getBlobUploadURL(t, h, tokenHeaders, "test1/foo"), url.Values{"state": {"unexpected"}}),
+				Path:         keppel.AppendQuery(getBlobUploadURL(t, s, tokenHeaders, "test1/foo"), url.Values{"state": {"unexpected"}}),
 				Header:       getHeadersForPATCH(0, len(blob.Contents)),
 				Body:         assert.ByteData(blob.Contents),
 				ExpectStatus: http.StatusBadRequest,
@@ -281,7 +280,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 			}.Check(t, h)
 
 			// upload with mismatched content length header to trigger a broken session state
-			uploadURL := getBlobUploadURL(t, h, tokenHeaders, "test1/foo")
+			uploadURL := getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
 			assert.HTTPRequest{
 				Method:       "PATCH",
 				Path:         uploadURL,
@@ -299,7 +298,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 
 			// test that content-length header matches which can only occur when doing chunked uploads
 			if isChunked {
-				uploadURL = getBlobUploadURL(t, h, tokenHeaders, "test1/foo")
+				uploadURL = getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
 				assert.HTTPRequest{
 					Method:       "PATCH",
 					Path:         uploadURL,
@@ -319,7 +318,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 			// test failure cases during PATCH: malformed session state (this requires a
 			// successful PATCH first, otherwise the API would not expect to find session
 			// state in our request)
-			uploadURL = getBlobUploadURL(t, h, tokenHeaders, "test1/foo")
+			uploadURL = getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
 			assert.HTTPRequest{
 				Method:       "PATCH",
 				Path:         uploadURL,
@@ -348,7 +347,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 					chunk1, chunk2 := blob.Contents[0:10], blob.Contents[10:15]
 					resp, _ := assert.HTTPRequest{
 						Method:       "PATCH",
-						Path:         getBlobUploadURL(t, h, tokenHeaders, "test1/foo"),
+						Path:         getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
 						Header:       getHeadersForPATCH(0, len(chunk1)),
 						Body:         assert.ByteData(chunk1),
 						ExpectStatus: http.StatusAccepted,
@@ -384,7 +383,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 				// upload all the blob contents at once (we're only interested in the final PUT)
 				resp, _ := assert.HTTPRequest{
 					Method:       "PATCH",
-					Path:         getBlobUploadURL(t, h, tokenHeaders, "test1/foo"),
+					Path:         getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
 					Header:       getHeadersForPATCH(0, len(blob.Contents)),
 					Body:         assert.ByteData(blob.Contents),
 					ExpectStatus: http.StatusAccepted,
@@ -406,7 +405,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 				chunk1, chunk2 := blob.Contents[0:10], blob.Contents[10:]
 				resp, _ := assert.HTTPRequest{
 					Method:       "PATCH",
-					Path:         getBlobUploadURL(t, h, tokenHeaders, "test1/foo"),
+					Path:         getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
 					Header:       getHeadersForPATCH(0, len(chunk1)),
 					Body:         assert.ByteData(chunk1),
 					ExpectStatus: http.StatusAccepted,
@@ -447,7 +446,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 			// test success case twice: should look the same also in the second pass
 			for range []int{1, 2} {
 				// test success case (with multiple chunks!)
-				uploadURL = getBlobUploadURL(t, h, tokenHeaders, "test1/foo")
+				uploadURL = getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
 				progress := 0
 				for _, chunk := range bytes.SplitAfter(blob.Contents, []byte(" ")) {
 					progress += len(chunk)
@@ -487,7 +486,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 				}
 
 				// validate that the blob was stored at the specified location
-				expectBlobExists(t, h, tokenHeaders, "test1/foo", blob)
+				expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
 			}
 
 			if t.Failed() {
@@ -523,7 +522,7 @@ func TestGetBlobUpload(t *testing.T) {
 		}.Check(t, h)
 
 		// test success case: upload without contents in it
-		uploadURL, uploadUUID := getBlobUpload(t, h, tokenHeaders, "test1/foo")
+		uploadURL, uploadUUID := getBlobUpload(t, s, tokenHeaders, "test1/foo")
 		assert.HTTPRequest{
 			Method:       "GET",
 			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
@@ -645,7 +644,7 @@ func TestDeleteBlobUpload(t *testing.T) {
 		}.Check(t, h)
 
 		// test deletion of upload with no contents in it
-		_, uploadUUID := getBlobUpload(t, h, tokenHeaders, "test1/foo")
+		_, uploadUUID := getBlobUpload(t, s, tokenHeaders, "test1/foo")
 		assert.HTTPRequest{
 			Method:       "DELETE",
 			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
@@ -666,7 +665,7 @@ func TestDeleteBlobUpload(t *testing.T) {
 		}.Check(t, h)
 
 		// test deletion of upload with contents in it
-		uploadURL, uploadUUID := getBlobUpload(t, h, tokenHeaders, "test1/foo")
+		uploadURL, uploadUUID := getBlobUpload(t, s, tokenHeaders, "test1/foo")
 		assert.HTTPRequest{
 			Method: "PATCH",
 			Path:   uploadURL,
@@ -739,8 +738,8 @@ func TestDeleteBlob(t *testing.T) {
 		}.Check(t, h)
 
 		// the blob should now be visible in both repos
-		expectBlobExists(t, h, tokenHeaders, "test1/foo", blob)
-		expectBlobExists(t, h, otherRepoTokenHeaders, "test1/bar", blob)
+		expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
+		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 
 		// test failure case: no delete permission
 		assert.HTTPRequest{
@@ -771,8 +770,8 @@ func TestDeleteBlob(t *testing.T) {
 		}.Check(t, h)
 
 		// we only had failed DELETEs until now, so the blob should still be there
-		expectBlobExists(t, h, tokenHeaders, "test1/foo", blob)
-		expectBlobExists(t, h, otherRepoTokenHeaders, "test1/bar", blob)
+		expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
+		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 
 		// test success case: delete the blob from the first repo
 		assert.HTTPRequest{
@@ -796,7 +795,7 @@ func TestDeleteBlob(t *testing.T) {
 			ExpectBody:   test.ErrorCode(keppel.ErrBlobUnknown),
 		}.Check(t, h)
 		// ...but still be visible in test1/bar
-		expectBlobExists(t, h, otherRepoTokenHeaders, "test1/bar", blob)
+		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 	})
 }
 
@@ -894,7 +893,7 @@ func TestCrossRepositoryBlobMount(t *testing.T) {
 		}.Check(t, h)
 
 		// now the blob should be available in both the original and the new repo
-		expectBlobExists(t, h, tokenHeaders, "test1/foo", blob)
-		expectBlobExists(t, h, otherRepoTokenHeaders, "test1/bar", blob)
+		expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
+		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 	})
 }

--- a/internal/api/registry/blobs_test.go
+++ b/internal/api/registry/blobs_test.go
@@ -5,13 +5,15 @@ package registryv2_test
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
 	"testing"
 
-	"github.com/sapcc/go-bits/assert"
+	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 
 	"github.com/sapcc/keppel/internal/keppel"
@@ -19,98 +21,68 @@ import (
 	"github.com/sapcc/keppel/internal/test"
 )
 
+// uploadingBlobMonolithically is a custom RequestOption for the "POST blob upload" endpoint.
+func uploadingBlobMonolithically(blob test.Bytes) httptest.RequestOption {
+	return httptest.MergeRequestOptions(
+		httptest.WithHeader("Content-Length", strconv.Itoa(len(blob.Contents))),
+		httptest.WithHeader("Content-Type", blob.MediaType),
+		httptest.WithBody(bytes.NewReader(blob.Contents)),
+	)
+}
+
 func TestBlobMonolithicUpload(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		readOnlyTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull")
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 
 		blob := test.NewBytes([]byte("just some random data"))
 
 		// test failure cases: token does not have push access
-		assert.HTTPRequest{
-			Method: "POST",
-			Path:   "/v2/test1/foo/blobs/uploads/?digest=" + blob.Digest.String(),
-			Header: test.FlattenHeaders(readOnlyTokenHeaders, map[string]string{
-				"Content-Length": strconv.Itoa(len(blob.Contents)),
-				"Content-Type":   "application/octet-stream",
-			}),
-			Body:         assert.ByteData(blob.Contents),
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+blob.Digest.String(),
+			httptest.WithHeaders(readOnlyTokenHeaders),
+			uploadingBlobMonolithically(blob),
+		).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 		// test failure cases: account is in maintenance
 		testWithAccountIsDeleting(t, s.DB, "test1", func() {
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/?digest=" + blob.Digest.String(),
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Length": strconv.Itoa(len(blob.Contents)),
-					"Content-Type":   "application/octet-stream",
-				}),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusMethodNotAllowed,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody: assert.JSONObject{
-					"errors": []assert.JSONObject{{
-						"code":    "UNSUPPORTED",
-						"message": "account is being deleted",
-						"detail":  nil,
-					}},
-				},
-			}.Check(t, h)
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+blob.Digest.String(),
+				httptest.WithHeaders(tokenHeaders),
+				uploadingBlobMonolithically(blob),
+			).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCodeWithMessage{
+				Code:    keppel.ErrUnsupported,
+				Message: "account is being deleted",
+			})
 		})
 
 		// test failure cases: digest is wrong
 		for _, wrongDigest := range []string{"wrong", test.DeterministicDummyDigest(1).String()} {
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/?digest=" + wrongDigest,
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Length": strconv.Itoa(len(blob.Contents)),
-					"Content-Type":   "application/octet-stream",
-				}),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusBadRequest,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrDigestInvalid),
-			}.Check(t, h)
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+wrongDigest,
+				httptest.WithHeaders(tokenHeaders),
+				uploadingBlobMonolithically(blob),
+			).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrDigestInvalid))
 		}
 
 		// test failure cases: Content-Length is wrong
 		for _, wrongLength := range []string{"", "wrong", "1337"} {
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/?digest=" + blob.Digest.String(),
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Length": wrongLength,
-					"Content-Type":   "application/octet-stream",
-				}),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusBadRequest,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrSizeInvalid),
-			}.Check(t, h)
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+blob.Digest.String(),
+				httptest.WithHeaders(tokenHeaders),
+				uploadingBlobMonolithically(blob),
+				httptest.WithHeader("Content-Length", wrongLength), // overrides Content-Length within uploadingBlobMonolithically()
+			).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrSizeInvalid))
 		}
 
 		// test failure cases: cannot upload manifest via the anycast API
 		if currentlyWithAnycast {
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/?digest=" + blob.Digest.String(),
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Length":    strconv.Itoa(len(blob.Contents)),
-					"Content-Type":      "application/octet-stream",
-					"X-Forwarded-Host":  s.Config.AnycastAPIPublicHostname,
-					"X-Forwarded-Proto": "https",
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+blob.Digest.String(),
+				httptest.WithHeaders(tokenHeaders),
+				uploadingBlobMonolithically(blob),
+				httptest.WithHeaders(http.Header{
+					"X-Forwarded-Host":  {s.Config.AnycastAPIPublicHostname},
+					"X-Forwarded-Proto": {"https"},
 				}),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusMethodNotAllowed,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrUnsupported),
-			}.Check(t, h)
+			).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCode(keppel.ErrUnsupported))
 		}
 
 		// failed requests should not retain anything in the storage
@@ -119,21 +91,13 @@ func TestBlobMonolithicUpload(t *testing.T) {
 		// test success case twice: should look the same also in the second pass
 		for range []int{1, 2} {
 			// test success case
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/?digest=" + blob.Digest.String(),
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Length": strconv.Itoa(len(blob.Contents)),
-					"Content-Type":   "application/octet-stream",
-				}),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusCreated,
-				ExpectHeader: map[string]string{
-					test.VersionHeaderKey: test.VersionHeaderValue,
-					"Content-Length":      "0",
-					"Location":            "/v2/test1/foo/blobs/" + blob.Digest.String(),
-				},
-			}.Check(t, h)
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+blob.Digest.String(),
+				httptest.WithHeaders(tokenHeaders),
+				uploadingBlobMonolithically(blob),
+			).ExpectHeaders(t, http.Header{
+				"Content-Length": {"0"},
+				"Location":       {"/v2/test1/foo/blobs/" + blob.Digest.String()},
+			}).ExpectStatus(t, http.StatusCreated)
 
 			// validate that the blob was stored at the specified location
 			expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
@@ -151,51 +115,43 @@ func TestBlobMonolithicUpload(t *testing.T) {
 		}
 
 		// test GET with anonymous user (fails unless a pull_anonymous RBAC policy is set up)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`,
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String()).
+			ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`).
+			ExpectStatus(t, http.StatusUnauthorized)
+
 		test.MustExec(t, s.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
 			test.ToJSON([]keppel.RBACPolicy{{
 				RepositoryPattern: "foo",
 				Permissions:       []keppel.RBACPermission{keppel.RBACAnonymousPullPermission},
 			}}),
 		)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   assert.ByteData(blob.Contents),
-		}.Check(t, h)
+
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String()).
+			ExpectBody(t, http.StatusOK, blob.Contents)
+
 		test.MustExec(t, s.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1", "")
 	})
 }
 
 func TestBlobStreamedAndChunkedUpload(t *testing.T) {
+	ctx := t.Context()
+
 	// run everything in this testcase once for streamed upload and once for chunked upload
 	for _, isChunked := range []bool{false, true} {
 		testWithPrimary(t, nil, func(s test.Setup) {
-			h := s.Handler
 			readOnlyTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull")
 			tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 
 			blob := test.NewBytes([]byte("just some random data"))
 
 			// shorthand for a common header structure that appears in many requests below
-			getHeadersForPATCH := func(offset, length int) map[string]string {
-				hdr := test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Type": "application/octet-stream",
-				})
+			getHeadersForPATCH := func(offset, length int) http.Header {
+				hdr := maps.Clone(tokenHeaders)
+				hdr.Set("Content-Type", "application/octet-stream")
 				// for streamed upload, Content-Range and Content-Length are omitted
 				if isChunked {
-					hdr["Content-Range"] = fmt.Sprintf("%d-%d", offset, offset+length-1)
-					hdr["Content-Length"] = strconv.Itoa(length)
+					hdr.Set("Content-Range", fmt.Sprintf("%d-%d", offset, offset+length-1))
+					hdr.Set("Content-Length", strconv.Itoa(length))
 				}
 				return hdr
 			}
@@ -205,136 +161,78 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 			_ = must.ReturnT(keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1")))(t)
 
 			// test failure cases during POST: anonymous is not allowed, should yield an auth challenge
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/",
-				Header: map[string]string{
-					"Content-Length": strconv.Itoa(len(blob.Contents)),
-					"Content-Type":   "application/octet-stream",
-				},
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusUnauthorized,
-				ExpectHeader: map[string]string{
-					test.VersionHeaderKey: test.VersionHeaderValue,
-					"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull,push"`,
-				},
-			}.Check(t, h)
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/", uploadingBlobMonolithically(blob)).
+				ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull,push"`).
+				ExpectStatus(t, http.StatusUnauthorized)
 
 			// test failure cases during POST: token does not have push access
-			assert.HTTPRequest{
-				Method: "POST",
-				Path:   "/v2/test1/foo/blobs/uploads/",
-				Header: test.FlattenHeaders(readOnlyTokenHeaders, map[string]string{
-					"Content-Length": strconv.Itoa(len(blob.Contents)),
-					"Content-Type":   "application/octet-stream",
-				}),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusUnauthorized,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-			}.Check(t, h)
+			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/",
+				httptest.WithHeaders(readOnlyTokenHeaders),
+				uploadingBlobMonolithically(blob),
+			).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 			// test failure cases during POST: account is in maintenance
 			testWithAccountIsDeleting(t, s.DB, "test1", func() {
-				assert.HTTPRequest{
-					Method: "POST",
-					Path:   "/v2/test1/foo/blobs/uploads/",
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Length": strconv.Itoa(len(blob.Contents)),
-						"Content-Type":   "application/octet-stream",
-					}),
-					Body:         assert.ByteData(blob.Contents),
-					ExpectStatus: http.StatusMethodNotAllowed,
-					ExpectHeader: test.VersionHeader,
-					ExpectBody: assert.JSONObject{
-						"errors": []assert.JSONObject{{
-							"code":    "UNSUPPORTED",
-							"message": "account is being deleted",
-							"detail":  nil,
-						}},
-					},
-				}.Check(t, h)
+				s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/",
+					httptest.WithHeaders(tokenHeaders),
+					uploadingBlobMonolithically(blob),
+				).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCodeWithMessage{
+					Code:    keppel.ErrUnsupported,
+					Message: "account is being deleted",
+				})
 			})
 
 			// test failure cases during PATCH: bogus session ID
-			assert.HTTPRequest{
-				Method:       "PATCH",
-				Path:         "/v2/test1/foo/blobs/uploads/b9ef33aa-7e2a-4fc8-8083-6b00601dab98", // bogus session ID
-				Header:       getHeadersForPATCH(0, len(blob.Contents)),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusNotFound,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrBlobUploadUnknown),
-			}.Check(t, h)
+			s.RespondTo(ctx, "PATCH /v2/test1/foo/blobs/uploads/b9ef33aa-7e2a-4fc8-8083-6b00601dab98", // bogus session ID
+				httptest.WithHeaders(getHeadersForPATCH(0, len(blob.Contents))),
+				httptest.WithBody(bytes.NewReader(blob.Contents)),
+			).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUploadUnknown))
 
 			// test failure cases during PATCH: unexpected session state (the first PATCH
 			// request should not contain session state)
-			assert.HTTPRequest{
-				Method:       "PATCH",
-				Path:         keppel.AppendQuery(getBlobUploadURL(t, s, tokenHeaders, "test1/foo"), url.Values{"state": {"unexpected"}}),
-				Header:       getHeadersForPATCH(0, len(blob.Contents)),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusBadRequest,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrBlobUploadInvalid),
-			}.Check(t, h)
+			uploadURL := keppel.AppendQuery(getBlobUploadURL(t, s, tokenHeaders, "test1/foo"), url.Values{"state": {"unexpected"}})
+			s.RespondTo(ctx, "PATCH "+uploadURL,
+				httptest.WithHeaders(getHeadersForPATCH(0, len(blob.Contents))),
+				httptest.WithBody(bytes.NewReader(blob.Contents)),
+			).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrBlobUploadInvalid))
 
 			// upload with mismatched content length header to trigger a broken session state
-			uploadURL := getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
-			assert.HTTPRequest{
-				Method:       "PATCH",
-				Path:         uploadURL,
-				Header:       getHeadersForPATCH(0, len(blob.Contents)),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusAccepted,
-			}.Check(t, h)
-			assert.HTTPRequest{
-				Method:       "PATCH",
-				Path:         uploadURL,
-				Header:       getHeadersForPATCH(len(blob.Contents)-5, len(blob.Contents)),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusRequestedRangeNotSatisfiable,
-			}.Check(t, h)
+			uploadURL = getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
+			s.RespondTo(ctx, "PATCH "+uploadURL,
+				httptest.WithHeaders(getHeadersForPATCH(0, len(blob.Contents))),
+				httptest.WithBody(bytes.NewReader(blob.Contents)),
+			).ExpectStatus(t, http.StatusAccepted)
 
-			// test that content-length header matches which can only occur when doing chunked uploads
+			s.RespondTo(ctx, "PATCH "+uploadURL,
+				httptest.WithHeaders(getHeadersForPATCH(len(blob.Contents)-5, len(blob.Contents))),
+				httptest.WithBody(bytes.NewReader(blob.Contents)),
+			).ExpectStatus(t, http.StatusRequestedRangeNotSatisfiable)
+
+			// test that Content-Length header matches which can only occur when doing chunked uploads
 			if isChunked {
 				uploadURL = getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
-				assert.HTTPRequest{
-					Method:       "PATCH",
-					Path:         uploadURL,
-					Header:       getHeadersForPATCH(0, len(blob.Contents)-10),
-					Body:         assert.ByteData(blob.Contents),
-					ExpectStatus: http.StatusRequestedRangeNotSatisfiable,
-					ExpectBody: assert.JSONObject{
-						"errors": []assert.JSONObject{{
-							"code":    string(keppel.ErrSizeInvalid),
-							"message": "expected upload of 11 bytes, but request contained 21 bytes",
-							"detail":  nil,
-						}},
-					},
-				}.Check(t, h)
+				s.RespondTo(ctx, "PATCH "+uploadURL,
+					httptest.WithHeaders(getHeadersForPATCH(0, len(blob.Contents)-10)),
+					httptest.WithBody(bytes.NewReader(blob.Contents)),
+				).ExpectJSON(t, http.StatusRequestedRangeNotSatisfiable, test.ErrorCodeWithMessage{
+					Code:    keppel.ErrSizeInvalid,
+					Message: "expected upload of 11 bytes, but request contained 21 bytes",
+				})
 			}
 
 			// test failure cases during PATCH: malformed session state (this requires a
 			// successful PATCH first, otherwise the API would not expect to find session
 			// state in our request)
 			uploadURL = getBlobUploadURL(t, s, tokenHeaders, "test1/foo")
-			assert.HTTPRequest{
-				Method:       "PATCH",
-				Path:         uploadURL,
-				Header:       getHeadersForPATCH(0, len(blob.Contents)),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusAccepted,
-			}.Check(t, h)
-			assert.HTTPRequest{
-				Method:       "PATCH",
-				Path:         keppel.AppendQuery(uploadURL, url.Values{"state": {"unexpected"}}),
-				Header:       getHeadersForPATCH(len(blob.Contents), len(blob.Contents)),
-				Body:         assert.ByteData(blob.Contents),
-				ExpectStatus: http.StatusBadRequest,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrBlobUploadInvalid),
-			}.Check(t, h)
+			s.RespondTo(ctx, "PATCH "+uploadURL,
+				httptest.WithHeaders(getHeadersForPATCH(0, len(blob.Contents))),
+				httptest.WithBody(bytes.NewReader(blob.Contents)),
+			).ExpectStatus(t, http.StatusAccepted)
+
+			s.RespondTo(ctx, "PATCH "+keppel.AppendQuery(uploadURL, url.Values{"state": {"unexpected"}}),
+				httptest.WithHeaders(getHeadersForPATCH(len(blob.Contents), len(blob.Contents))),
+				httptest.WithBody(bytes.NewReader(blob.Contents)),
+			).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrBlobUploadInvalid))
 
 			// test failure cases during PATCH: malformed Content-Range and/or
 			// Content-Length (only for chunked upload; streamed upload does not have
@@ -345,27 +243,24 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 					// upload the blob contents in two chunks; we will trigger the error
 					// condition in the second PATCH
 					chunk1, chunk2 := blob.Contents[0:10], blob.Contents[10:15]
-					resp, _ := assert.HTTPRequest{
-						Method:       "PATCH",
-						Path:         getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
-						Header:       getHeadersForPATCH(0, len(chunk1)),
-						Body:         assert.ByteData(chunk1),
-						ExpectStatus: http.StatusAccepted,
-					}.Check(t, h)
-					assert.HTTPRequest{
-						Method: "PATCH",
-						Path:   resp.Header.Get("Location"),
-						Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-							"Content-Length": contentLength,
-							"Content-Range":  contentRange,
-							"Content-Type":   "application/octet-stream",
-						}),
-						Body:         assert.ByteData(chunk2),
-						ExpectStatus: http.StatusRequestedRangeNotSatisfiable,
-						ExpectHeader: test.VersionHeader,
-						ExpectBody:   test.ErrorCode(keppel.ErrSizeInvalid),
-					}.Check(t, h)
+					var nextUploadURL string
+
+					s.RespondTo(ctx, "PATCH "+getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
+						httptest.WithHeaders(getHeadersForPATCH(0, len(chunk1))),
+						httptest.WithBody(bytes.NewReader(chunk1)),
+					).
+						CaptureHeader("Location", &nextUploadURL).
+						ExpectStatus(t, http.StatusAccepted)
+
+					s.RespondTo(ctx, "PATCH "+nextUploadURL,
+						httptest.WithHeaders(tokenHeaders),
+						httptest.WithHeader("Content-Length", contentLength),
+						httptest.WithHeader("Content-Range", contentRange),
+						httptest.WithHeader("Content-Type", "application/octet-stream"),
+						httptest.WithBody(bytes.NewReader(chunk2)),
+					).ExpectJSON(t, http.StatusRequestedRangeNotSatisfiable, test.ErrorCode(keppel.ErrSizeInvalid))
 				}
+
 				//NOTE: The correct headers would be Content-Range: 10-14 and Content-Length: 5.
 				testWrongContentRangeAndOrLength("10-13", "4")                         // both consistently wrong
 				testWrongContentRangeAndOrLength("10-14", "6")                         // only Content-Length wrong
@@ -381,63 +276,46 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 			// test failure cases during PUT: digest is missing or wrong
 			for _, wrongDigest := range []string{"", "wrong", test.DeterministicDummyDigest(2).String()} {
 				// upload all the blob contents at once (we're only interested in the final PUT)
-				resp, _ := assert.HTTPRequest{
-					Method:       "PATCH",
-					Path:         getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
-					Header:       getHeadersForPATCH(0, len(blob.Contents)),
-					Body:         assert.ByteData(blob.Contents),
-					ExpectStatus: http.StatusAccepted,
-				}.Check(t, h)
-				uploadURL := resp.Header.Get("Location") //nolint:govet
-				assert.HTTPRequest{
-					Method:       "PUT",
-					Path:         keppel.AppendQuery(uploadURL, url.Values{"digest": {wrongDigest}}),
-					Header:       test.FlattenHeaders(tokenHeaders),
-					ExpectStatus: http.StatusBadRequest,
-					ExpectHeader: test.VersionHeader,
-					ExpectBody:   test.ErrorCode(keppel.ErrDigestInvalid),
-				}.Check(t, h)
+				s.RespondTo(ctx, "PATCH "+getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
+					httptest.WithHeaders(getHeadersForPATCH(0, len(blob.Contents))),
+					httptest.WithBody(bytes.NewReader(blob.Contents)),
+				).
+					CaptureHeader("Location", &uploadURL).
+					ExpectStatus(t, http.StatusAccepted)
+
+				s.RespondTo(ctx, "PUT "+keppel.AppendQuery(uploadURL, url.Values{"digest": {wrongDigest}}),
+					httptest.WithHeaders(tokenHeaders),
+				).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrDigestInvalid))
 			}
 
 			// test failure cases during PUT: broken Content-Length on PUT with content
 			for _, wrongContentLength := range []string{"", "0", "1024"} {
-				// upload the blob contents in two chunks, so that we have a chunk to send with PUT
-				chunk1, chunk2 := blob.Contents[0:10], blob.Contents[10:]
-				resp, _ := assert.HTTPRequest{
-					Method:       "PATCH",
-					Path:         getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
-					Header:       getHeadersForPATCH(0, len(chunk1)),
-					Body:         assert.ByteData(chunk1),
-					ExpectStatus: http.StatusAccepted,
-				}.Check(t, h)
-				uploadURL := resp.Header.Get("Location") //nolint:govet
+				t.Run("Content-Length="+cmp.Or(wrongContentLength, "empty"), func(t *testing.T) {
+					// upload the blob contents in two chunks, so that we have a chunk to send with PUT
+					chunk1, chunk2 := blob.Contents[0:10], blob.Contents[10:]
+					s.RespondTo(ctx, "PATCH "+getBlobUploadURL(t, s, tokenHeaders, "test1/foo"),
+						httptest.WithHeaders(getHeadersForPATCH(0, len(chunk1))),
+						httptest.WithBody(bytes.NewReader(chunk1)),
+					).
+						CaptureHeader("Location", &uploadURL).
+						ExpectStatus(t, http.StatusAccepted)
 
-				// when Content-Length is missing or 0, the request body will just be
-				// ignored and the validation will fail later when the digest does not match
-				// because of the missing chunk
-				expectedError := test.ErrorCode(keppel.ErrSizeInvalid)
-				expectedStatus := http.StatusRequestedRangeNotSatisfiable
-				if wrongContentLength == "" || wrongContentLength == "0" {
-					expectedError = test.ErrorCode(keppel.ErrDigestInvalid)
-					expectedStatus = http.StatusBadRequest
-				}
+					resp := s.RespondTo(ctx, "PUT "+keppel.AppendQuery(uploadURL, url.Values{"digest": {blob.Digest.String()}}),
+						httptest.WithHeaders(tokenHeaders),
+						httptest.WithHeader("Content-Length", wrongContentLength),
+						httptest.WithHeader("Content-Type", "application/octet-stream"),
+						httptest.WithBody(bytes.NewReader(chunk2)),
+					)
 
-				assert.HTTPRequest{
-					Method: "PUT",
-					Path:   keppel.AppendQuery(uploadURL, url.Values{"digest": {blob.Digest.String()}}),
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Length": wrongContentLength,
-						"Content-Type":   "application/octet-stream",
-					}),
-					Body:         assert.ByteData(chunk2),
-					ExpectStatus: expectedStatus,
-					ExpectHeader: test.VersionHeader,
-					ExpectBody:   expectedError,
-				}.Check(t, h)
-
-				if t.Failed() {
-					t.Fatalf("fails on CL %q", wrongContentLength)
-				}
+					// when Content-Length is missing or 0, the request body will just be
+					// ignored and the validation will fail later when the digest does not match
+					// because of the missing chunk
+					if wrongContentLength == "" || wrongContentLength == "0" {
+						resp.ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrDigestInvalid))
+					} else {
+						resp.ExpectJSON(t, http.StatusRequestedRangeNotSatisfiable, test.ErrorCode(keppel.ErrSizeInvalid))
+					}
+				})
 			}
 
 			// failed requests should not retain anything in the storage
@@ -453,35 +331,25 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 
 					if progress == len(blob.Contents) {
 						// send the last chunk with the final PUT request
-						assert.HTTPRequest{
-							Method: "PUT",
-							Path:   keppel.AppendQuery(uploadURL, url.Values{"digest": {blob.Digest.String()}}),
-							Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-								"Content-Length": strconv.Itoa(len(chunk)),
-								"Content-Type":   "application/octet-stream",
-							}),
-							Body:         assert.ByteData(chunk),
-							ExpectStatus: http.StatusCreated,
-							ExpectHeader: map[string]string{
-								test.VersionHeaderKey: test.VersionHeaderValue,
-								"Content-Length":      "0",
-								"Location":            "/v2/test1/foo/blobs/" + blob.Digest.String(),
-							},
-						}.Check(t, h)
+						s.RespondTo(ctx, "PUT "+keppel.AppendQuery(uploadURL, url.Values{"digest": {blob.Digest.String()}}),
+							httptest.WithHeaders(tokenHeaders),
+							httptest.WithHeader("Content-Length", strconv.Itoa(len(chunk))),
+							httptest.WithHeader("Content-Type", "application/octet-stream"),
+							httptest.WithBody(bytes.NewReader(chunk)),
+						).ExpectHeaders(t, http.Header{
+							"Content-Length": {"0"},
+							"Location":       {"/v2/test1/foo/blobs/" + blob.Digest.String()},
+						}).ExpectStatus(t, http.StatusCreated)
 					} else {
-						resp, _ := assert.HTTPRequest{
-							Method:       "PATCH",
-							Path:         uploadURL,
-							Header:       getHeadersForPATCH(progress-len(chunk), len(chunk)),
-							Body:         assert.ByteData(chunk),
-							ExpectStatus: http.StatusAccepted,
-							ExpectHeader: map[string]string{
-								test.VersionHeaderKey: test.VersionHeaderValue,
-								"Content-Length":      "0",
-								"Range":               fmt.Sprintf("0-%d", progress-1),
-							},
-						}.Check(t, h)
-						uploadURL = resp.Header.Get("Location")
+						s.RespondTo(ctx, "PATCH "+uploadURL,
+							httptest.WithHeaders(getHeadersForPATCH(progress-len(chunk), len(chunk))),
+							httptest.WithBody(bytes.NewReader(chunk)),
+						).ExpectHeaders(t, http.Header{
+							"Content-Length": {"0"},
+							"Range":          {fmt.Sprintf("0-%d", progress-1)},
+						}).
+							CaptureHeader("Location", &uploadURL).
+							ExpectStatus(t, http.StatusAccepted)
 					}
 				}
 
@@ -497,8 +365,9 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 }
 
 func TestGetBlobUpload(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		//NOTE: We only use the read-write token for driving the blob upload through
 		// its various stages. All the GET requests use the read-only token to verify
 		// that read-only tokens work here.
@@ -512,118 +381,80 @@ func TestGetBlobUpload(t *testing.T) {
 		_ = must.ReturnT(keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1")))(t)
 
 		// test failure cases: no such upload
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/uploads/b9ef33aa-7e2a-4fc8-8083-6b00601dab98", // bogus session ID
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrBlobUploadUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/uploads/b9ef33aa-7e2a-4fc8-8083-6b00601dab98", // bogus session ID
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUploadUnknown))
 
 		// test success case: upload without contents in it
 		uploadURL, uploadUUID := getBlobUpload(t, s, tokenHeaders, "test1/foo")
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusNoContent,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey:    test.VersionHeaderValue,
-				"Blob-Upload-Session-Id": uploadUUID,
-				"Content-Length":         "0",
-				"Location":               uploadURL,
-				"Range":                  "0-0",
-			},
-			ExpectBody: assert.StringData(""),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectHeaders(t, http.Header{
+			"Blob-Upload-Session-Id": {uploadUUID},
+			"Content-Length":         {"0"},
+			"Location":               {uploadURL},
+			"Range":                  {"0-0"},
+		}).ExpectText(t, http.StatusNoContent, "")
 
 		// test success case: upload with contents in it
-		resp, _ := assert.HTTPRequest{
-			Method: "PATCH",
-			Path:   uploadURL,
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": "application/octet-stream",
-			}),
-			Body:         assert.ByteData(blob.Contents),
-			ExpectStatus: http.StatusAccepted,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-				"Range":               fmt.Sprintf("0-%d", len(blob.Contents)-1),
-			},
-		}.Check(t, h)
-		uploadURL = resp.Header.Get("Location")
+		s.RespondTo(ctx, "PATCH "+uploadURL,
+			httptest.WithHeaders(tokenHeaders),
+			httptest.WithHeader("Content-Type", "application/octet-stream"),
+			httptest.WithBody(bytes.NewReader(blob.Contents)),
+		).ExpectHeaders(t, http.Header{
+			"Content-Length": {"0"},
+			"Range":          {fmt.Sprintf("0-%d", len(blob.Contents)-1)},
+		}).
+			CaptureHeader("Location", &uploadURL).
+			ExpectStatus(t, http.StatusAccepted)
 
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusNoContent,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey:    test.VersionHeaderValue,
-				"Blob-Upload-Session-Id": uploadUUID,
-				"Content-Length":         "0",
-				"Range":                  fmt.Sprintf("0-%d", len(blob.Contents)-1),
-				// This does not show "Location" because we don't have a way to recover
-				// the digest state that's included in the query part of `uploadURL`.
-			},
-			ExpectBody: assert.StringData(""),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectHeaders(t, http.Header{
+			"Blob-Upload-Session-Id": {uploadUUID},
+			"Content-Length":         {"0"},
+			"Range":                  {fmt.Sprintf("0-%d", len(blob.Contents)-1)},
+			// This does not show "Location" because we don't have a way to recover
+			// the digest state that's included in the query part of `uploadURL`.
+		}).ExpectText(t, http.StatusNoContent, "")
 
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         uploadURL,
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusNoContent,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey:    test.VersionHeaderValue,
-				"Blob-Upload-Session-Id": uploadUUID,
-				"Content-Length":         "0",
-				"Range":                  fmt.Sprintf("0-%d", len(blob.Contents)-1),
-				// This DOES show "Location" (as the OCI Distribution Spec demands)
-				// since we have the digest state available from the request URL.
-				"Location": uploadURL,
-			},
-			ExpectBody: assert.StringData(""),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET "+uploadURL,
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectHeaders(t, http.Header{
+			"Blob-Upload-Session-Id": {uploadUUID},
+			"Content-Length":         {"0"},
+			"Range":                  {fmt.Sprintf("0-%d", len(blob.Contents)-1)},
+			// This DOES show "Location" (as the OCI Distribution Spec demands)
+			// since we have the digest state available from the request URL.
+			"Location": {uploadURL},
+		}).ExpectText(t, http.StatusNoContent, "")
 
 		// test failure case: cannot inspect upload via the anycast API
 		if currentlyWithAnycast {
-			assert.HTTPRequest{
-				Method: "GET",
-				Path:   "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-				Header: test.FlattenHeaders(readOnlyTokenHeaders, map[string]string{
-					"X-Forwarded-Host":  s.Config.AnycastAPIPublicHostname,
-					"X-Forwarded-Proto": "https",
+			s.RespondTo(ctx, "GET /v2/test1/foo/blobs/uploads/"+uploadUUID,
+				httptest.WithHeaders(readOnlyTokenHeaders),
+				httptest.WithHeaders(http.Header{
+					"X-Forwarded-Host":  {s.Config.AnycastAPIPublicHostname},
+					"X-Forwarded-Proto": {"https"},
 				}),
-				ExpectStatus: http.StatusMethodNotAllowed,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrUnsupported),
-			}.Check(t, h)
+			).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCode(keppel.ErrUnsupported))
 		}
 
 		// test failure case: finished upload should be cleaned up and not show up in GET anymore
-		assert.HTTPRequest{
-			Method:       "PUT",
-			Path:         keppel.AppendQuery(uploadURL, url.Values{"digest": {blob.Digest.String()}}),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusCreated,
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrBlobUploadUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT "+keppel.AppendQuery(uploadURL, url.Values{"digest": {blob.Digest.String()}}),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectStatus(t, http.StatusCreated)
+
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUploadUnknown))
 	})
 }
 
 func TestDeleteBlobUpload(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 		deleteTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:delete")
 
@@ -634,70 +465,42 @@ func TestDeleteBlobUpload(t *testing.T) {
 		_ = must.ReturnT(keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1")))(t)
 
 		// test failure cases: no such upload
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/uploads/b9ef33aa-7e2a-4fc8-8083-6b00601dab98", // bogus session ID
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrBlobUploadUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/uploads/b9ef33aa-7e2a-4fc8-8083-6b00601dab98", // bogus session ID
+			httptest.WithHeaders(deleteTokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUploadUnknown))
 
 		// test deletion of upload with no contents in it
 		_, uploadUUID := getBlobUpload(t, s, tokenHeaders, "test1/foo")
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusNoContent,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-			},
-			ExpectBody: assert.StringData(""),
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
+
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(deleteTokenHeaders),
+		).
+			ExpectHeader(t, "Content-Length", "0").
+			ExpectText(t, http.StatusNoContent, "")
 
 		// test deletion of upload with contents in it
 		uploadURL, uploadUUID := getBlobUpload(t, s, tokenHeaders, "test1/foo")
-		assert.HTTPRequest{
-			Method: "PATCH",
-			Path:   uploadURL,
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": "application/octet-stream",
-			}),
-			Body:         assert.ByteData(blobContents),
-			ExpectStatus: http.StatusAccepted,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-				"Range":               fmt.Sprintf("0-%d", len(blobContents)-1),
-			},
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/uploads/" + uploadUUID,
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusNoContent,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-			},
-			ExpectBody: assert.StringData(""),
-		}.Check(t, h)
+		s.RespondTo(ctx, "PATCH "+uploadURL,
+			httptest.WithHeaders(tokenHeaders),
+			httptest.WithHeader("Content-Type", "application/octet-stream"),
+			httptest.WithBody(bytes.NewReader(blobContents)),
+		).ExpectHeaders(t, http.Header{
+			"Content-Length": {"0"},
+			"Range":          {fmt.Sprintf("0-%d", len(blobContents)-1)},
+		}).ExpectStatus(t, http.StatusAccepted)
+
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
+
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/uploads/"+uploadUUID,
+			httptest.WithHeaders(deleteTokenHeaders),
+		).
+			ExpectHeader(t, "Content-Length", "0").
+			ExpectText(t, http.StatusNoContent, "")
 
 		// since all uploads were eventually deleted, there should be nothing in the storage
 		expectStorageEmpty(t, s.SD, s.DB)
@@ -705,8 +508,9 @@ func TestDeleteBlobUpload(t *testing.T) {
 }
 
 func TestDeleteBlob(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 		deleteTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:delete")
 		otherRepoTokenHeaders := s.GetTokenHeaders(t, "repository:test1/bar:pull,push")
@@ -714,94 +518,63 @@ func TestDeleteBlob(t *testing.T) {
 		blob := test.NewBytes([]byte("just some random data"))
 
 		// test failure case: delete blob from non-existent repo
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrNameUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/"+blob.Digest.String(),
+			httptest.WithHeaders(deleteTokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrNameUnknown))
 
 		// push a blob so that we can test its deletion
 		blob.MustUpload(t, s, fooRepoRef)
 
 		// cross-mount the same blob in a different repo (the blob should not be
 		// deleted from test1/bar when we delete it from test1/foo)
-		assert.HTTPRequest{
-			Method: "POST",
-			Path:   "/v2/test1/bar/blobs/uploads/?from=test1%2Ffoo&mount=" + blob.Digest.String(),
-			Header: test.FlattenHeaders(otherRepoTokenHeaders, map[string]string{
-				"Content-Length": "0",
-			}),
-			ExpectStatus: http.StatusCreated,
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/bar/blobs/uploads/?from=test1%2Ffoo&mount="+blob.Digest.String(),
+			httptest.WithHeaders(otherRepoTokenHeaders),
+			httptest.WithHeader("Content-Length", "0"),
+		).ExpectStatus(t, http.StatusCreated)
 
 		// the blob should now be visible in both repos
 		expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
 		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 
 		// test failure case: no delete permission
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/"+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 		// test failure case: no such blob
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/" + test.DeterministicDummyDigest(1).String(),
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrBlobUnknown),
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/thisisnotadigest",
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusBadRequest,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrDigestInvalid),
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/"+test.DeterministicDummyDigest(1).String(),
+			httptest.WithHeaders(deleteTokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUnknown))
+
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/thisisnotadigest",
+			httptest.WithHeaders(deleteTokenHeaders),
+		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrDigestInvalid))
 
 		// we only had failed DELETEs until now, so the blob should still be there
 		expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)
 		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 
 		// test success case: delete the blob from the first repo
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusAccepted,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/"+blob.Digest.String(),
+			httptest.WithHeaders(deleteTokenHeaders),
+		).
+			ExpectHeader(t, "Content-Length", "0").
+			ExpectStatus(t, http.StatusAccepted)
 
 		// after successful DELETE, the blob should be gone from test1/foo...
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrBlobUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUnknown))
+
 		// ...but still be visible in test1/bar
 		expectBlobExists(t, s, otherRepoTokenHeaders, "test1/bar", blob)
 	})
 }
 
 func TestCrossRepositoryBlobMount(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		readOnlyTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull")
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 		otherRepoTokenHeaders := s.GetTokenHeaders(t, "repository:test1/bar:pull,push")
@@ -812,85 +585,50 @@ func TestCrossRepositoryBlobMount(t *testing.T) {
 		blob.MustUpload(t, s, barRepoRef)
 
 		// failed blob mounts are usually not fatal, and instead return 202 Accepted to start a regular blob upload session
-		fallbackToRegularUploadStatus := http.StatusAccepted
-		fallbackToRegularUploadHeaders := map[string]string{
-			test.VersionHeaderKey: test.VersionHeaderValue,
-			"Content-Length":      "0",
+		fallbackToRegularUpload := func(resp httptest.Response) {
+			resp.ExpectHeader(t, "Content-Length", "0").ExpectStatus(t, http.StatusAccepted)
 		}
 
 		// test failure cases: token does not have push access
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test1/bar&mount=" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test1/bar&mount="+blob.Digest.String(),
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 		// test failure cases: source repo does not exist
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test1/qux&mount=" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: fallbackToRegularUploadStatus,
-			ExpectHeader: fallbackToRegularUploadHeaders,
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test1/:qux&mount=" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: fallbackToRegularUploadStatus,
-			ExpectHeader: fallbackToRegularUploadHeaders,
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test1/qux&mount="+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).Expect(fallbackToRegularUpload)
+
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test1/:qux&mount="+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).Expect(fallbackToRegularUpload)
 
 		// test failure cases: cannot mount across accounts
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test2/foo&mount=" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: fallbackToRegularUploadStatus,
-			ExpectHeader: fallbackToRegularUploadHeaders,
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test2/foo&mount="+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).Expect(fallbackToRegularUpload)
 
 		// test failure cases: digest is malformed or wrong
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test1/bar&mount=wrong",
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: fallbackToRegularUploadStatus,
-			ExpectHeader: fallbackToRegularUploadHeaders,
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test1/bar&mount=" + test.DeterministicDummyDigest(1).String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: fallbackToRegularUploadStatus,
-			ExpectHeader: fallbackToRegularUploadHeaders,
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test1/bar&mount=wrong",
+			httptest.WithHeaders(tokenHeaders),
+		).Expect(fallbackToRegularUpload)
+
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test1/bar&mount="+test.DeterministicDummyDigest(1).String(),
+			httptest.WithHeaders(tokenHeaders),
+		).Expect(fallbackToRegularUpload)
 
 		// since these all failed, the blob should not be available in test1/foo yet
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrBlobUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrBlobUnknown))
 
 		// test success case
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/?from=test1/bar&mount=" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-				"Location":            "/v2/test1/foo/blobs/" + blob.Digest.String(),
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?from=test1/bar&mount="+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectHeaders(t, http.Header{
+			"Content-Length": {"0"},
+			"Location":       {"/v2/test1/foo/blobs/" + blob.Digest.String()},
+		}).ExpectStatus(t, http.StatusCreated)
 
 		// now the blob should be available in both the original and the new repo
 		expectBlobExists(t, s, tokenHeaders, "test1/foo", blob)

--- a/internal/api/registry/blobs_test.go
+++ b/internal/api/registry/blobs_test.go
@@ -45,7 +45,7 @@ func TestBlobMonolithicUpload(t *testing.T) {
 			uploadingBlobMonolithically(blob),
 		).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
-		// test failure cases: account is in maintenance
+		// test failure cases: account is being deleted
 		testWithAccountIsDeleting(t, s.DB, "test1", func() {
 			s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/?digest="+blob.Digest.String(),
 				httptest.WithHeaders(tokenHeaders),
@@ -171,7 +171,7 @@ func TestBlobStreamedAndChunkedUpload(t *testing.T) {
 				uploadingBlobMonolithically(blob),
 			).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
-			// test failure cases during POST: account is in maintenance
+			// test failure cases during POST: account is being deleted
 			testWithAccountIsDeleting(t, s.DB, "test1", func() {
 				s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/",
 					httptest.WithHeaders(tokenHeaders),

--- a/internal/api/registry/catalog_test.go
+++ b/internal/api/registry/catalog_test.go
@@ -241,7 +241,6 @@ func testAuthErrorsForCatalog(t *testing.T, s test.Setup) {
 func testNoCatalogOnAnycast(t *testing.T, s test.Setup) {
 	ctx := t.Context()
 	tokenHeaders := s.GetAnycastTokenHeaders(t, "registry:catalog:*")
-	s.Handler.RespondTo(ctx, "GET /v2/_catalog", httptest.WithHeaders(tokenHeaders)).
-		ExpectHeader(t, test.VersionHeaderKey, test.VersionHeaderValue).
+	s.RespondTo(ctx, "GET /v2/_catalog", httptest.WithHeaders(tokenHeaders)).
 		ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCode(keppel.ErrUnsupported))
 }

--- a/internal/api/registry/catalog_test.go
+++ b/internal/api/registry/catalog_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sapcc/go-bits/assert"
+	"github.com/majewsky/gg/jsonmatch"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 
@@ -45,30 +45,20 @@ func TestCatalogEndpoint(t *testing.T) {
 func testEmptyCatalog(t *testing.T, s test.Setup) {
 	// token without any account-level permissions is able to call the endpoint,
 	// but cannot list repos in any account, so the list is empty
-	h := s.Handler
+	ctx := t.Context()
 	tokenHeaders := s.GetTokenHeaders(t, "registry:catalog:*")
 
-	req := assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusOK,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody: assert.JSONObject{
-			"repositories": []string{},
-		},
-	}
-	req.Check(t, h)
-
 	// query parameters do not influence this result
-	req.Path = "/v2/_catalog?n=10"
-	req.Check(t, h)
-	req.Path = "/v2/_catalog?n=10&last=test1/foo"
-	req.Check(t, h)
+	for _, query := range []string{"", "?n=10", "?n=10&last=test1/foo"} {
+		t.Run("GET /v2/_catalog"+query, func(t *testing.T) {
+			s.RespondTo(ctx, "GET /v2/_catalog"+query, httptest.WithHeaders(tokenHeaders)).
+				ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": []string{}})
+		})
+	}
 }
 
 func testNonEmptyCatalog(t *testing.T, s test.Setup) {
-	h := s.Handler
+	ctx := t.Context()
 	tokenHeaders := s.GetTokenHeaders(t,
 		"registry:catalog:*",
 		"keppel_account:test1:view",
@@ -89,153 +79,88 @@ func testNonEmptyCatalog(t *testing.T, s test.Setup) {
 	}
 
 	// test unpaginated
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusOK,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody:   assert.JSONObject{"repositories": allRepos},
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog", httptest.WithHeaders(tokenHeaders)).
+		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": allRepos})
 
 	// test paginated
 	for offset := range allRepos {
 		for length := 1; length <= len(allRepos)+1; length++ {
 			expectedPage := allRepos[offset:]
-			expectedHeaders := map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Type":        "application/json",
+			expectedHeaders := http.Header{
+				"Content-Type": {"application/json"},
 			}
 
 			if len(expectedPage) > length {
 				expectedPage = expectedPage[:length]
 				lastRepoName := expectedPage[len(expectedPage)-1]
-				expectedHeaders["Link"] = fmt.Sprintf(`</v2/_catalog?last=%s&n=%d>; rel="next"`,
+				expectedHeaders.Set("Link", fmt.Sprintf(`</v2/_catalog?last=%s&n=%d>; rel="next"`,
 					strings.ReplaceAll(lastRepoName, "/", "%2F"), length,
-				)
+				))
 			}
 
-			path := fmt.Sprintf(`/v2/_catalog?n=%d`, length)
+			methodAndPath := fmt.Sprintf(`GET /v2/_catalog?n=%d`, length)
 			if offset > 0 {
-				path += `&last=` + allRepos[offset-1] //nolint:gosec // slice index is clearly not out of range
+				methodAndPath += `&last=` + allRepos[offset-1] //nolint:gosec // slice index is clearly not out of range
 			}
 
-			assert.HTTPRequest{
-				Method:       "GET",
-				Path:         path,
-				Header:       test.FlattenHeaders(tokenHeaders),
-				ExpectStatus: http.StatusOK,
-				ExpectHeader: expectedHeaders,
-				ExpectBody:   assert.JSONObject{"repositories": expectedPage},
-			}.Check(t, h)
+			s.RespondTo(ctx, methodAndPath, httptest.WithHeaders(tokenHeaders)).
+				ExpectHeaders(t, expectedHeaders).
+				ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": expectedPage})
 		}
 	}
 
 	// test error cases for pagination query params
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog?n=-1",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusBadRequest,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody:   assert.StringData("invalid value for \"n\": strconv.ParseUint: parsing \"-1\": invalid syntax\n"),
-	}.Check(t, h)
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog?n=0",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusBadRequest,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody:   assert.StringData("invalid value for \"n\": must not be 0\n"),
-	}.Check(t, h)
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog?n=10&last=invalid",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusBadRequest,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody:   assert.StringData("invalid value for \"last\": must contain a slash\n"),
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog?n=-1", httptest.WithHeaders(tokenHeaders)).
+		ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": strconv.ParseUint: parsing \"-1\": invalid syntax\n")
+	s.RespondTo(ctx, "GET /v2/_catalog?n=0", httptest.WithHeaders(tokenHeaders)).
+		ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": must not be 0\n")
+	s.RespondTo(ctx, "GET /v2/_catalog?n=10&last=invalid", httptest.WithHeaders(tokenHeaders)).
+		ExpectText(t, http.StatusBadRequest, "invalid value for \"last\": must contain a slash\n")
 }
 
 func testDomainRemappedCatalog(t *testing.T, s test.Setup) {
-	h := s.Handler
+	ctx := t.Context()
 	tokenHeaders := s.GetDomainRemappedTokenHeaders(t, "test1",
 		"registry:catalog:*",
 		"keppel_account:test1:view",
 	)
 
 	// test unpaginated
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusOK,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody:   assert.JSONObject{"repositories": []string{"bar", "foo", "qux"}},
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog", httptest.WithHeaders(tokenHeaders)).
+		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": []string{"bar", "foo", "qux"}})
 
 	// test paginated (only a very basic test: we already have most of the test
 	// coverage in testNonEmptyCatalog, this mostly checks that the "last"
 	// parameter is correctly interpreted as a bare repo name)
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog?last=foo",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusOK,
-		ExpectHeader: test.VersionHeader,
-		ExpectBody:   assert.JSONObject{"repositories": []string{"qux"}},
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog?last=foo", httptest.WithHeaders(tokenHeaders)).
+		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"repositories": []string{"qux"}})
 }
 
 func testAuthErrorsForCatalog(t *testing.T, s test.Setup) {
+	ctx := t.Context()
+
 	// without token, expect auth challenge
-	h := s.Handler
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog",
-		ExpectStatus: http.StatusUnauthorized,
-		ExpectHeader: map[string]string{
-			test.VersionHeaderKey: test.VersionHeaderValue,
-			"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="registry:catalog:*"`,
-			"Content-Type":        "application/json",
-		},
-		ExpectBody: test.ErrorCode(keppel.ErrUnauthorized),
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog").
+		ExpectHeader(t, "Content-Type", "application/json").
+		ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="registry:catalog:*"`).
+		ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrUnauthorized))
 
 	// with token for wrong scope, expect Forbidden and renewed auth challenge
 	tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull")
-	assert.HTTPRequest{
-		Method:       "GET",
-		Path:         "/v2/_catalog",
-		Header:       test.FlattenHeaders(tokenHeaders),
-		ExpectStatus: http.StatusUnauthorized,
-		ExpectHeader: map[string]string{
-			test.VersionHeaderKey: test.VersionHeaderValue,
-			"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="registry:catalog:*",error="insufficient_scope"`,
-			"Content-Type":        "application/json",
-		},
-		//NOTE: Docker Hub (https://registry-1.docker.io) sends UNAUTHORIZED here,
-		// but DENIED is more logical.
-		ExpectBody: test.ErrorCode(keppel.ErrDenied),
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog", httptest.WithHeaders(tokenHeaders)).
+		ExpectHeader(t, "Content-Type", "application/json").
+		ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="registry:catalog:*",error="insufficient_scope"`).
+		//NOTE: Docker Hub (https://registry-1.docker.io) sends UNAUTHORIZED here, but DENIED is more logical.
+		ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 	// without token, expect auth challenge (test for domain-remapped API)
-	assert.HTTPRequest{
-		Method: "GET",
-		Path:   "/v2/_catalog",
-		Header: map[string]string{
-			"X-Forwarded-Host":  "test1.registry.example.org",
-			"X-Forwarded-Proto": "https",
-		},
-		ExpectStatus: http.StatusUnauthorized,
-		ExpectHeader: map[string]string{
-			test.VersionHeaderKey: test.VersionHeaderValue,
-			"Www-Authenticate":    `Bearer realm="https://test1.registry.example.org/keppel/v1/auth",service="test1.registry.example.org",scope="registry:catalog:*"`,
-			"Content-Type":        "application/json",
-		},
-		ExpectBody: test.ErrorCode(keppel.ErrUnauthorized),
-	}.Check(t, h)
+	s.RespondTo(ctx, "GET /v2/_catalog", httptest.WithHeaders(http.Header{
+		"X-Forwarded-Host":  {"test1.registry.example.org"},
+		"X-Forwarded-Proto": {"https"},
+	})).
+		ExpectHeader(t, "Content-Type", "application/json").
+		ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://test1.registry.example.org/keppel/v1/auth",service="test1.registry.example.org",scope="registry:catalog:*"`).
+		ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrUnauthorized))
 }
 
 func testNoCatalogOnAnycast(t *testing.T, s test.Setup) {

--- a/internal/api/registry/catalog_test.go
+++ b/internal/api/registry/catalog_test.go
@@ -111,11 +111,11 @@ func testNonEmptyCatalog(t *testing.T, s test.Setup) {
 
 	// test error cases for pagination query params
 	s.RespondTo(ctx, "GET /v2/_catalog?n=-1", httptest.WithHeaders(tokenHeaders)).
-		ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": strconv.ParseUint: parsing \"-1\": invalid syntax\n")
+		ExpectText(t, http.StatusBadRequest, `invalid value for "n": strconv.ParseUint: parsing "-1": invalid syntax`+"\n")
 	s.RespondTo(ctx, "GET /v2/_catalog?n=0", httptest.WithHeaders(tokenHeaders)).
-		ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": must not be 0\n")
+		ExpectText(t, http.StatusBadRequest, `invalid value for "n": must not be 0`+"\n")
 	s.RespondTo(ctx, "GET /v2/_catalog?n=10&last=invalid", httptest.WithHeaders(tokenHeaders)).
-		ExpectText(t, http.StatusBadRequest, "invalid value for \"last\": must contain a slash\n")
+		ExpectText(t, http.StatusBadRequest, `invalid value for "last": must contain a slash`+"\n")
 }
 
 func testDomainRemappedCatalog(t *testing.T, s test.Setup) {

--- a/internal/api/registry/domain_remap_test.go
+++ b/internal/api/registry/domain_remap_test.go
@@ -8,119 +8,78 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/sapcc/go-bits/assert"
+	"github.com/sapcc/go-bits/httptest"
 
 	"github.com/sapcc/keppel/internal/keppel"
 	"github.com/sapcc/keppel/internal/test"
 )
 
 func TestRegistryAPIDomainRemap(t *testing.T) {
+	ctx := t.Context()
+
 	// test generic Registry API endpoints with request URLs having the account name in the hostname instead of in the path
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
-
 		// without token, expect auth challenge
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/",
-			Header: map[string]string{
-				"X-Forwarded-Host":  "test1.registry.example.org",
-				"X-Forwarded-Proto": "https",
-			},
-			ExpectStatus: http.StatusUnauthorized,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Www-Authenticate":    `Bearer realm="https://test1.registry.example.org/keppel/v1/auth",service="test1.registry.example.org"`,
-			},
-			ExpectBody: test.ErrorCode(keppel.ErrUnauthorized),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/", httptest.WithHeaders(http.Header{
+			"X-Forwarded-Host":  {"test1.registry.example.org"},
+			"X-Forwarded-Proto": {"https"},
+		})).
+			ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://test1.registry.example.org/keppel/v1/auth",service="test1.registry.example.org"`).
+			ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrUnauthorized))
 
 		// with token, expect status code 200
 		tokenHeaders := s.GetDomainRemappedTokenHeaders(t, "test1" /*, no scopes */)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/",
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/", httptest.WithHeaders(tokenHeaders)).
+			ExpectStatus(t, http.StatusOK)
 	})
 }
 
 func TestBlobAPIDomainRemap(t *testing.T) {
+	ctx := t.Context()
+	blob := test.NewBytes([]byte("just some random data"))
+
 	// test blob API with request URLs having the account name in the hostname instead of in the path
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetDomainRemappedTokenHeaders(t, "test1", "repository:foo:pull,push")
 
-		blob := test.NewBytes([]byte("just some random data"))
-
 		// test upload
-		assert.HTTPRequest{
-			Method: "POST",
-			Path:   "/v2/foo/blobs/uploads/?digest=" + blob.Digest.String(),
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Length": strconv.Itoa(len(blob.Contents)),
-				"Content-Type":   "application/octet-stream",
-			}),
-			Body:         assert.ByteData(blob.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      "0",
-				"Location":            "/v2/foo/blobs/" + blob.Digest.String(),
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/foo/blobs/uploads/?digest="+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+			uploadingBlobMonolithically(blob),
+		).ExpectHeaders(t, http.Header{
+			"Content-Length": {"0"},
+			"Location":       {"/v2/foo/blobs/" + blob.Digest.String()},
+		}).ExpectStatus(t, http.StatusCreated)
 
 		// test download
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/foo/blobs/" + blob.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   assert.ByteData(blob.Contents),
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      strconv.Itoa(len(blob.Contents)),
-				"Content-Type":        "application/octet-stream",
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/foo/blobs/"+blob.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectHeaders(t, http.Header{
+			"Content-Length":        {strconv.Itoa(len(blob.Contents))},
+			"Content-Type":          {blob.MediaType},
+			"Docker-Content-Digest": {blob.Digest.String()},
+		}).ExpectBody(t, http.StatusOK, blob.Contents)
 	})
 }
 
 func TestManifestAPIDomainRemap(t *testing.T) {
+	ctx := t.Context()
 	image := test.GenerateImage( /* no layers */ )
 
 	// test manifest API with request URLs having the account name in the hostname instead of in the path
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetDomainRemappedTokenHeaders(t, "test1", "repository:foo:pull,push")
 		image.Config.MustUpload(t, s, fooRepoRef)
 
 		// test upload
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/foo/manifests/" + image.Manifest.Digest.String(),
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": image.Manifest.MediaType,
-			}),
-			Body:         assert.ByteData(image.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/foo/manifests/"+image.Manifest.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(image.Manifest),
+		).ExpectStatus(t, http.StatusCreated)
 
 		// test download
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/foo/manifests/" + image.Manifest.Digest.String(),
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   assert.ByteData(image.Manifest.Contents),
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Content-Length":      strconv.Itoa(len(image.Manifest.Contents)),
-				"Content-Type":        image.Manifest.MediaType,
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/foo/manifests/"+image.Manifest.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).Expect(containsManifest(t, image.Manifest))
 	})
 }

--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -4,14 +4,16 @@
 package registryv2_test
 
 import (
+	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sapcc/go-api-declarations/cadf"
 	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
@@ -24,6 +26,24 @@ import (
 	"github.com/sapcc/keppel/internal/tasks"
 	"github.com/sapcc/keppel/internal/test"
 )
+
+// uploadingManifest is a custom RequestOption for the "PUT manifest" endpoint.
+func uploadingManifest(m test.Bytes) httptest.RequestOption {
+	return httptest.MergeRequestOptions(
+		httptest.WithHeader("Content-Type", m.MediaType),
+		httptest.WithBody(bytes.NewReader(m.Contents)),
+	)
+}
+
+// containsManifest is a custom assertion for the "GET manifest" endpoint.
+func containsManifest(t *testing.T, m test.Bytes) func(httptest.Response) {
+	return func(r httptest.Response) {
+		r.ExpectHeader(t, "Content-Length", strconv.Itoa(len(m.Contents))).
+			ExpectHeader(t, "Content-Type", m.MediaType).
+			ExpectHeader(t, "Docker-Content-Digest", m.Digest.String()).
+			ExpectBody(t, http.StatusOK, m.Contents)
+	}
+}
 
 func TestImageManifestLifecycle(t *testing.T) {
 	ctx := t.Context()
@@ -51,17 +71,13 @@ func TestImageManifestLifecycle(t *testing.T) {
 				}),
 			)
 
-			h := s.Handler
 			tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 			readOnlyTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull")
 			otherRepoTokenHeaders := s.GetTokenHeaders(t, "repository:test1/bar:pull,push")
 			deleteTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:delete")
 
 			// on the API, we either reference the tag name (if uploading with tag) or the digest (if uploading without tag)
-			ref := tagName
-			if tagName == "" {
-				ref = image.Manifest.Digest.String()
-			}
+			ref := cmp.Or(tagName, image.Manifest.Digest.String())
 
 			// repo does not exist before we first push to it
 			for _, method := range []string{"GET", "HEAD"} {
@@ -90,84 +106,52 @@ func TestImageManifestLifecycle(t *testing.T) {
 			}
 
 			// PUT failure case: cannot push with read-only token
-			assert.HTTPRequest{
-				Method: "PUT",
-				Path:   "/v2/test1/foo/manifests/" + ref,
-				Header: test.FlattenHeaders(readOnlyTokenHeaders, map[string]string{
-					"Content-Type": image.Manifest.MediaType,
-				}),
-				Body:         assert.ByteData(image.Manifest.Contents),
-				ExpectStatus: http.StatusUnauthorized,
-				ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-			}.Check(t, h)
+			s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+				httptest.WithHeaders(readOnlyTokenHeaders),
+				uploadingManifest(image.Manifest),
+			).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 			// PUT failure case: cannot push while account is being deleted
 			testWithAccountIsDeleting(t, s.DB, "test1", func() {
-				assert.HTTPRequest{
-					Method: "PUT",
-					Path:   "/v2/test1/foo/manifests/" + ref,
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Type": image.Manifest.MediaType,
-					}),
-					Body:         assert.ByteData(image.Manifest.Contents),
-					ExpectStatus: http.StatusMethodNotAllowed,
-					ExpectBody: test.ErrorCodeWithMessage{
-						Code:    keppel.ErrUnsupported,
-						Message: "account is being deleted",
-					},
-				}.Check(t, h)
+				s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+					httptest.WithHeaders(tokenHeaders),
+					uploadingManifest(image.Manifest),
+				).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCodeWithMessage{
+					Code:    keppel.ErrUnsupported,
+					Message: "account is being deleted",
+				})
 			})
 
 			for _, repo := range []string{"_blobs", "_chunks", `-invalid`} {
 				// PUT failure case: invalid repository names (e.g. repos starting with '_' or '-'),
 				// including reserved internal repos _blobs and _chunks and the '-invalid' case
-				assert.HTTPRequest{
-					Method: "PUT",
-					Path:   "/v2/test1/" + repo + "/manifests/" + ref,
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Type": image.Manifest.MediaType,
-					}),
-					Body:         assert.ByteData(image.Manifest.Contents),
-					ExpectStatus: http.StatusBadRequest,
-					ExpectBody:   test.ErrorCode(keppel.ErrNameInvalid),
-				}.Check(t, h)
+				s.RespondTo(ctx, fmt.Sprintf("PUT /v2/test1/%s/manifests/%s", repo, ref),
+					httptest.WithHeaders(tokenHeaders),
+					uploadingManifest(image.Manifest),
+				).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrNameInvalid))
 			}
 
 			// PUT failure case: malformed manifest
-			assert.HTTPRequest{
-				Method: "PUT",
-				Path:   "/v2/test1/foo/manifests/" + ref,
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Type": image.Manifest.MediaType,
-				}),
-				Body:         assert.ByteData(append([]byte("wtf"), image.Manifest.Contents...)),
-				ExpectStatus: http.StatusBadRequest,
-				ExpectBody:   test.ErrorCode(keppel.ErrManifestInvalid),
-			}.Check(t, h)
+			malformedManifest := test.Bytes{
+				MediaType: image.Manifest.MediaType,
+				Contents:  append([]byte("wtf"), image.Manifest.Contents...),
+			}
+			s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+				httptest.WithHeaders(tokenHeaders),
+				uploadingManifest(malformedManifest),
+			).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrManifestInvalid))
 
 			// PUT failure case: wrong digest
-			assert.HTTPRequest{
-				Method: "PUT",
-				Path:   "/v2/test1/foo/manifests/" + test.DeterministicDummyDigest(1).String(),
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Type": image.Manifest.MediaType,
-				}),
-				Body:         assert.ByteData(image.Manifest.Contents),
-				ExpectStatus: http.StatusBadRequest,
-				ExpectBody:   test.ErrorCode(keppel.ErrDigestInvalid),
-			}.Check(t, h)
+			s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+test.DeterministicDummyDigest(1).String(),
+				httptest.WithHeaders(tokenHeaders),
+				uploadingManifest(image.Manifest),
+			).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrDigestInvalid))
 
 			// PUT failure case: cannot upload manifest if referenced blob is missing
-			assert.HTTPRequest{
-				Method: "PUT",
-				Path:   "/v2/test1/foo/manifests/" + ref,
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Type": image.Manifest.MediaType,
-				}),
-				Body:         assert.ByteData(image.Manifest.Contents),
-				ExpectStatus: http.StatusNotFound,
-				ExpectBody:   test.ErrorCode(keppel.ErrManifestBlobUnknown),
-			}.Check(t, h)
+			s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+				httptest.WithHeaders(tokenHeaders),
+				uploadingManifest(image.Manifest),
+			).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrManifestBlobUnknown))
 
 			// failed requests should not retain anything in the storage
 			expectStorageEmpty(t, s.SD, s.DB)
@@ -175,47 +159,31 @@ func TestImageManifestLifecycle(t *testing.T) {
 
 			// PUT failure case: cannot upload manifest if referenced blob is uploaded, but in the wrong repo
 			image.Config.MustUpload(t, s, barRepoRef)
-			assert.HTTPRequest{
-				Method: "PUT",
-				Path:   "/v2/test1/foo/manifests/" + ref,
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Type": image.Manifest.MediaType,
-				}),
-				Body:         assert.ByteData(image.Manifest.Contents),
-				ExpectStatus: http.StatusNotFound,
-				ExpectBody:   test.ErrorCode(keppel.ErrManifestBlobUnknown),
-			}.Check(t, h)
+			s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+				httptest.WithHeaders(tokenHeaders),
+				uploadingManifest(image.Manifest),
+			).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrManifestBlobUnknown))
 
 			// PUT failure case: cannot upload manifest via the anycast API
 			if currentlyWithAnycast {
-				assert.HTTPRequest{
-					Method: "PUT",
-					Path:   "/v2/test1/foo/manifests/" + ref,
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Type":      image.Manifest.MediaType,
-						"X-Forwarded-Host":  s.Config.AnycastAPIPublicHostname,
-						"X-Forwarded-Proto": "https",
+				s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+					httptest.WithHeaders(tokenHeaders),
+					httptest.WithHeaders(http.Header{
+						"X-Forwarded-Host":  {s.Config.AnycastAPIPublicHostname},
+						"X-Forwarded-Proto": {"https"},
 					}),
-					Body:         assert.ByteData(image.Manifest.Contents),
-					ExpectStatus: http.StatusMethodNotAllowed,
-					ExpectHeader: test.VersionHeader,
-					ExpectBody:   test.ErrorCode(keppel.ErrUnsupported),
-				}.Check(t, h)
+					uploadingManifest(image.Manifest),
+				).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCode(keppel.ErrUnsupported))
 			}
 
 			// PUT failure case: cannot upload manifest without Content-Type, or with
 			// a faulty Content-Type (defense against attacks like CVE-2021-41190)
 			for _, wrongMediaType := range []string{"", manifest.DockerV2ListMediaType} {
-				assert.HTTPRequest{
-					Method: "PUT",
-					Path:   "/v2/test1/foo/manifests/" + ref,
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Type": wrongMediaType,
-					}),
-					Body:         assert.ByteData(image.Manifest.Contents),
-					ExpectStatus: http.StatusBadRequest,
-					ExpectBody:   test.ErrorCode(keppel.ErrManifestInvalid),
-				}.Check(t, h)
+				s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+					httptest.WithHeaders(tokenHeaders),
+					uploadingManifest(image.Manifest),
+					httptest.WithHeader("Content-Type", wrongMediaType), // overrides Content-Type within uploadingManifest()
+				).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrManifestInvalid))
 			}
 
 			// there should still not be any manifests
@@ -243,37 +211,24 @@ func TestImageManifestLifecycle(t *testing.T) {
 
 			if ref == "latest" {
 				// block_overwrite should prevent overwriting the tag
-				assert.HTTPRequest{
-					Method: "PUT",
-					Path:   "/v2/test1/foo/manifests/" + ref,
-					Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-						"Content-Type": manifest.DockerV2Schema2MediaType,
-					}),
-					Body:         assert.ByteData(test.GenerateImage(test.GenerateExampleLayer(1)).Manifest.Contents),
-					ExpectStatus: http.StatusConflict,
-					ExpectHeader: test.VersionHeader,
-					ExpectBody: test.ErrorCodeWithMessage{
-						Code:    keppel.ErrDenied,
-						Message: "cannot overwrite tag \"latest\" as it is protected by a tag_policy",
-					},
-				}.Check(t, h)
+				updatedImage := test.GenerateImage(test.GenerateExampleLayer(1))
+				s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+ref,
+					httptest.WithHeaders(tokenHeaders),
+					uploadingManifest(updatedImage.Manifest),
+				).ExpectJSON(t, http.StatusConflict, test.ErrorCodeWithMessage{
+					Code:    keppel.ErrDenied,
+					Message: "cannot overwrite tag \"latest\" as it is protected by a tag_policy",
+				})
 			}
 
 			// block_push should prevent matching tags from being pushed at all
-			assert.HTTPRequest{
-				Method: "PUT",
-				Path:   "/v2/test1/foo/manifests/dangerous-release",
-				Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-					"Content-Type": manifest.DockerV2Schema2MediaType,
-				}),
-				Body:         assert.ByteData(test.GenerateImage(test.GenerateExampleLayer(1)).Manifest.Contents),
-				ExpectStatus: http.StatusConflict,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody: test.ErrorCodeWithMessage{
-					Code:    keppel.ErrDenied,
-					Message: "cannot push tag \"dangerous-release\" as it is forbidden by a tag_policy",
-				},
-			}.Check(t, h)
+			s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/dangerous-release",
+				httptest.WithHeaders(tokenHeaders),
+				uploadingManifest(image.Manifest),
+			).ExpectJSON(t, http.StatusConflict, test.ErrorCodeWithMessage{
+				Code:    keppel.ErrDenied,
+				Message: "cannot push tag \"dangerous-release\" as it is forbidden by a tag_policy",
+			})
 
 			// we did two PUTs, but only the first one will be logged since the second one did not change anything
 			auditEvents := []cadf.Event{{
@@ -311,14 +266,9 @@ func TestImageManifestLifecycle(t *testing.T) {
 			expectManifestExists(t, s, readOnlyTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
 
 			// GET failure case: wrong scope
-			assert.HTTPRequest{
-				Method:       "GET",
-				Path:         "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-				Header:       test.FlattenHeaders(otherRepoTokenHeaders),
-				ExpectStatus: http.StatusUnauthorized,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-			}.Check(t, h)
+			s.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+image.Manifest.Digest.String(),
+				httptest.WithHeaders(otherRepoTokenHeaders),
+			).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 			// ^ NOTE: docker-registry sends UNAUTHORIZED (401) instead of DENIED (403)
 			//        here, but 403 is more correct.
 
@@ -340,78 +290,54 @@ func TestImageManifestLifecycle(t *testing.T) {
 				`UPDATE manifests SET min_layer_created_at = $1, max_layer_created_at = $2 WHERE digest = $3`,
 				time.Unix(23, 0).UTC(), time.Unix(42, 0).UTC(), image.Manifest.Digest.String(),
 			)
-			test.MustExec(t, s.DB, `UPDATE trivy_security_info SET vuln_status = $1 WHERE digest = $2`, models.CleanSeverity, image.Manifest.Digest.String())
+			test.MustExec(t, s.DB,
+				`UPDATE trivy_security_info SET vuln_status = $1 WHERE digest = $2`,
+				models.CleanSeverity, image.Manifest.Digest.String(),
+			)
 
 			for _, method := range []string{"GET", "HEAD"} {
-				assert.HTTPRequest{
-					Method:       method,
-					Path:         "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-					Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-					ExpectStatus: http.StatusOK,
-					ExpectHeader: map[string]string{
-						test.VersionHeaderKey:           test.VersionHeaderValue,
-						"X-Keppel-Vulnerability-Status": string(models.CleanSeverity),
-						"X-Keppel-Min-Layer-Created-At": "23",
-						"X-Keppel-Max-Layer-Created-At": "42",
-					},
-				}.Check(t, h)
+				s.RespondTo(ctx, method+" /v2/test1/foo/manifests/"+image.Manifest.Digest.String(),
+					httptest.WithHeaders(readOnlyTokenHeaders),
+				).ExpectHeaders(t, http.Header{
+					"X-Keppel-Vulnerability-Status": {string(models.CleanSeverity)},
+					"X-Keppel-Min-Layer-Created-At": {"23"},
+					"X-Keppel-Max-Layer-Created-At": {"42"},
+				}).ExpectStatus(t, http.StatusOK)
 			}
 
 			// test GET with anonymous user (fails unless a pull_anonymous RBAC policy is set up)
-			assert.HTTPRequest{
-				Method:       "GET",
-				Path:         "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-				ExpectStatus: http.StatusUnauthorized,
-				ExpectHeader: map[string]string{
-					test.VersionHeaderKey: test.VersionHeaderValue,
-					"Www-Authenticate":    `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`,
-				},
-			}.Check(t, h)
+			s.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+image.Manifest.Digest.String()).
+				ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry.example.org/keppel/v1/auth",service="registry.example.org",scope="repository:test1/foo:pull"`).
+				ExpectStatus(t, http.StatusUnauthorized)
+
 			test.MustExec(t, s.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
 				test.ToJSON([]keppel.RBACPolicy{{
 					RepositoryPattern: "foo",
 					Permissions:       []keppel.RBACPermission{keppel.RBACAnonymousPullPermission},
 				}}),
 			)
-			assert.HTTPRequest{
-				Method:       "GET",
-				Path:         "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-				ExpectStatus: http.StatusOK,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   assert.ByteData(image.Manifest.Contents),
-			}.Check(t, h)
+
+			s.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+image.Manifest.Digest.String()).
+				Expect(containsManifest(t, image.Manifest))
+
 			test.MustExec(t, s.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1", "")
 
 			// DELETE failure case: no delete permission
-			assert.HTTPRequest{
-				Method:       "DELETE",
-				Path:         "/v2/test1/foo/manifests/" + image.Manifest.Digest.String(),
-				Header:       test.FlattenHeaders(tokenHeaders),
-				ExpectStatus: http.StatusUnauthorized,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrDenied),
-			}.Check(t, h)
+			s.RespondTo(ctx, "DELETE /v2/test1/foo/manifests/"+image.Manifest.Digest.String(),
+				httptest.WithHeaders(tokenHeaders),
+			).ExpectJSON(t, http.StatusUnauthorized, test.ErrorCode(keppel.ErrDenied))
 
 			// DELETE failure case: unknown manifest
-			assert.HTTPRequest{
-				Method:       "DELETE",
-				Path:         "/v2/test1/foo/manifests/" + test.DeterministicDummyDigest(1).String(),
-				Header:       test.FlattenHeaders(deleteTokenHeaders),
-				ExpectStatus: http.StatusNotFound,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrManifestUnknown),
-			}.Check(t, h)
+			s.RespondTo(ctx, "DELETE /v2/test1/foo/manifests/"+test.DeterministicDummyDigest(1).String(),
+				httptest.WithHeaders(deleteTokenHeaders),
+			).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrManifestUnknown))
 
 			// DELETE failure case: cannot delete blob while the manifest still exists in the DB
-			assert.HTTPRequest{
-				Method:       "DELETE",
-				Path:         "/v2/test1/foo/blobs/" + image.Config.Digest.String(),
-				Header:       test.FlattenHeaders(deleteTokenHeaders),
-				ExpectStatus: http.StatusMethodNotAllowed,
-				ExpectHeader: test.VersionHeader,
-				ExpectBody:   test.ErrorCode(keppel.ErrUnsupported),
-			}.Check(t, h)
+			s.RespondTo(ctx, "DELETE /v2/test1/foo/blobs/"+image.Config.Digest.String(),
+				httptest.WithHeaders(deleteTokenHeaders),
+			).ExpectJSON(t, http.StatusMethodNotAllowed, test.ErrorCode(keppel.ErrUnsupported))
 
+			// DELETE failure case: tag is protected by tag policy
 			test.MustExec(t, s.DB, `UPDATE accounts SET tag_policies_json = $2 WHERE name = $1`, "test1",
 				test.ToJSON([]keppel.TagPolicy{{
 					PolicyMatchRule: keppel.PolicyMatchRule{
@@ -421,14 +347,9 @@ func TestImageManifestLifecycle(t *testing.T) {
 				}}),
 			)
 
-			// DELETE failure case: tag is protected by tag policy
-			assert.HTTPRequest{
-				Method:       "DELETE",
-				Path:         "/v2/test1/foo/manifests/" + ref,
-				Header:       test.FlattenHeaders(deleteTokenHeaders),
-				ExpectStatus: http.StatusConflict,
-				ExpectHeader: test.VersionHeader,
-			}.Check(t, h)
+			s.RespondTo(ctx, "DELETE /v2/test1/foo/manifests/"+ref,
+				httptest.WithHeaders(deleteTokenHeaders),
+			).ExpectJSON(t, http.StatusConflict, test.ErrorCode(keppel.ErrDenied))
 
 			test.MustExec(t, s.DB, `UPDATE accounts SET tag_policies_json = '[]' WHERE name = $1`, "test1")
 
@@ -436,13 +357,9 @@ func TestImageManifestLifecycle(t *testing.T) {
 			s.Auditor.ExpectEvents(t /*, nothing */)
 
 			// DELETE success case
-			assert.HTTPRequest{
-				Method:       "DELETE",
-				Path:         "/v2/test1/foo/manifests/" + ref,
-				Header:       test.FlattenHeaders(deleteTokenHeaders),
-				ExpectStatus: http.StatusAccepted,
-				ExpectHeader: test.VersionHeader,
-			}.Check(t, h)
+			s.RespondTo(ctx, "DELETE /v2/test1/foo/manifests/"+ref,
+				httptest.WithHeaders(deleteTokenHeaders),
+			).ExpectStatus(t, http.StatusAccepted)
 			s.Clock.StepBy(time.Second)
 			if ref == "latest" {
 				easypg.AssertDBContent(t, s.DB.Db, "fixtures/imagemanifest-004-after-delete-tag.sql")
@@ -473,11 +390,12 @@ func TestImageManifestLifecycle(t *testing.T) {
 }
 
 func TestImageListManifestLifecycle(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
 		// This test builds on TestImageManifestLifecycle and provides test coverage
 		// for the parts of the manifest push workflow that check manifest-manifest
 		// references. (We don't have those in plain images, only in image lists.)
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 		deleteTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:delete")
 
@@ -493,16 +411,10 @@ func TestImageListManifestLifecycle(t *testing.T) {
 
 		// PUT failure case: cannot upload image list manifest referencing missing manifests
 		list1 := test.GenerateImageList(image1, image3)
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/" + list1.Manifest.Digest.String(),
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": list1.Manifest.MediaType,
-			}),
-			Body:         assert.ByteData(list1.Manifest.Contents),
-			ExpectStatus: http.StatusNotFound,
-			ExpectBody:   test.ErrorCode(keppel.ErrManifestUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/"+list1.Manifest.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(list1.Manifest),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrManifestUnknown))
 
 		// PUT success case: upload image list manifest referencing available manifests
 		list2 := test.GenerateImageList(image1, image2)
@@ -518,51 +430,38 @@ func TestImageListManifestLifecycle(t *testing.T) {
 		// manifest if only single-arch manifests are accepted by the client (this
 		// behavior is somewhat dubious, but required for full compatibility with
 		// existing clients)
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/test1/foo/manifests/" + list2.Manifest.Digest.String(),
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Accept": manifest.DockerV2Schema2MediaType,
-			}),
-			ExpectStatus: http.StatusTemporaryRedirect,
-			ExpectHeader: map[string]string{
-				test.VersionHeaderKey: test.VersionHeaderValue,
-				"Location":            "/v2/test1/foo/manifests/" + image1.Manifest.Digest.String(),
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+list2.Manifest.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+			httptest.WithHeader("Accept", manifest.DockerV2Schema2MediaType),
+		).
+			ExpectHeader(t, "Location", "/v2/test1/foo/manifests/"+image1.Manifest.Digest.String()).
+			ExpectStatus(t, http.StatusTemporaryRedirect)
+
 		// but we return the whole list if at all possible
 		tokenHeaders.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json")
 		expectManifestExists(t, s, tokenHeaders, "test1/foo", list2.Manifest, "list")
 
 		// DELETE failure case: cannot delete manifest list while the manifest still exists in the DB
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/manifests/" + image1.Manifest.Digest.String(),
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusConflict,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody: test.ErrorCodeWithMessage{
-				Code:    keppel.ErrDenied,
-				Message: "cannot delete a manifest which is referenced by the manifest " + list2.Manifest.Digest.String(),
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/manifests/"+image1.Manifest.Digest.String(),
+			httptest.WithHeaders(deleteTokenHeaders),
+		).ExpectJSON(t, http.StatusConflict, test.ErrorCodeWithMessage{
+			Code:    keppel.ErrDenied,
+			Message: "cannot delete a manifest which is referenced by the manifest " + list2.Manifest.Digest.String(),
+		})
 
 		// DELETE success case
-		assert.HTTPRequest{
-			Method:       "DELETE",
-			Path:         "/v2/test1/foo/manifests/" + list2.Manifest.Digest.String(),
-			Header:       test.FlattenHeaders(deleteTokenHeaders),
-			ExpectStatus: http.StatusAccepted,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "DELETE /v2/test1/foo/manifests/"+list2.Manifest.Digest.String(),
+			httptest.WithHeaders(deleteTokenHeaders),
+		).ExpectStatus(t, http.StatusAccepted)
 		s.Clock.StepBy(time.Second)
 		easypg.AssertDBContent(t, s.DB.Db, "fixtures/imagelistmanifest-002-after-delete-manifest.sql")
 	})
 }
 
 func TestManifestQuotaExceeded(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 
 		// as a setup, upload two images
@@ -580,31 +479,19 @@ func TestManifestQuotaExceeded(t *testing.T) {
 		}
 
 		// further blob uploads are not possible now
-		assert.HTTPRequest{
-			Method:       "POST",
-			Path:         "/v2/test1/foo/blobs/uploads/",
-			Header:       test.FlattenHeaders(tokenHeaders),
-			ExpectStatus: http.StatusConflict,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   quotaExceededMessage,
-		}.Check(t, h)
+		s.RespondTo(ctx, "POST /v2/test1/foo/blobs/uploads/", httptest.WithHeaders(tokenHeaders)).
+			ExpectJSON(t, http.StatusConflict, quotaExceededMessage)
 
 		// further manifest uploads are not possible now
-		assert.HTTPRequest{
-			Method:       "PUT",
-			Path:         "/v2/test1/foo/manifests/anotherone",
-			Header:       test.FlattenHeaders(tokenHeaders),
-			Body:         assert.StringData("request body does not matter"),
-			ExpectStatus: http.StatusConflict,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   quotaExceededMessage,
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/anotherone", httptest.WithHeaders(tokenHeaders)).
+			ExpectJSON(t, http.StatusConflict, quotaExceededMessage)
 	})
 }
 
 func TestRuleForManifest(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 
 		labels := map[string]string{"foo": "is there", "bar": "is there"}
@@ -632,35 +519,22 @@ func TestRuleForManifest(t *testing.T) {
 		)
 
 		// docker manifest push should fail ...
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": manifest.DockerV2Schema2MediaType,
-			}),
-			Body:         assert.ByteData(image.Manifest.Contents),
-			ExpectStatus: http.StatusBadRequest,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody: test.ErrorCodeWithMessage{
-				Code:    keppel.ErrManifestInvalid,
-				Message: "manifest upload {\"labels\":{\"bar\":\"is there\",\"foo\":\"is there\"},\"layers\":[{\"annotations\":null,\"media_type\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\"}],\"media_type\":\"application/vnd.docker.distribution.manifest.v2+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels",
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/latest",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(image.Manifest),
+		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCodeWithMessage{
+			Code:    keppel.ErrManifestInvalid,
+			Message: "manifest upload {\"labels\":{\"bar\":\"is there\",\"foo\":\"is there\"},\"layers\":[{\"annotations\":null,\"media_type\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\"}],\"media_type\":\"application/vnd.docker.distribution.manifest.v2+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels",
+		})
+
 		// ... and OCI, too
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": imageOCI.Manifest.MediaType,
-			}),
-			Body:         assert.ByteData(imageOCI.Manifest.Contents),
-			ExpectStatus: http.StatusBadRequest,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody: test.ErrorCodeWithMessage{
-				Code:    keppel.ErrManifestInvalid,
-				Message: "manifest upload {\"labels\":{\"bar\":\"is there\",\"foo\":\"is there\"},\"layers\":[{\"annotations\":null,\"media_type\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\"}],\"media_type\":\"application/vnd.oci.image.manifest.v1+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels",
-			},
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/latest",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(imageOCI.Manifest),
+		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCodeWithMessage{
+			Code:    keppel.ErrManifestInvalid,
+			Message: "manifest upload {\"labels\":{\"bar\":\"is there\",\"foo\":\"is there\"},\"layers\":[{\"annotations\":null,\"media_type\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\"}],\"media_type\":\"application/vnd.oci.image.manifest.v1+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels",
+		})
 
 		// setup required labels on account for success
 		test.MustExec(t, s.DB,
@@ -669,31 +543,24 @@ func TestRuleForManifest(t *testing.T) {
 		)
 
 		// docker manifest push should succeed when all labels are there ...
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": manifest.DockerV2Schema2MediaType,
-			}),
-			Body:         assert.ByteData(image.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/latest",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(image.Manifest),
+		).ExpectStatus(t, http.StatusCreated)
+
 		// ... and OCI, too
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": imageOCI.Manifest.MediaType,
-			}),
-			Body:         assert.ByteData(imageOCI.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/latest",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(imageOCI.Manifest),
+		).ExpectStatus(t, http.StatusCreated)
 
 		// check that the labels_json field is populated correctly in the DB
 		expectLabelsJSONOnManifest(
 			t, s.DB, image.Manifest.Digest,
+			map[string]string{"bar": "is there", "foo": "is there"},
+		)
+		expectLabelsJSONOnManifest(
+			t, s.DB, imageOCI.Manifest.Digest,
 			map[string]string{"bar": "is there", "foo": "is there"},
 		)
 
@@ -708,16 +575,10 @@ func TestRuleForManifest(t *testing.T) {
 		// do not have labels at all), so we can upload this list manifest without
 		// any additional considerations ...
 		list := test.GenerateImageList(image, otherImage)
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/list",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": manifest.DockerV2ListMediaType,
-			}),
-			Body:         assert.ByteData(list.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/list",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(list.Manifest),
+		).ExpectStatus(t, http.StatusCreated)
 
 		// check the labels_json field on the list manifest
 		expectLabelsJSONOnManifest(
@@ -733,36 +594,24 @@ func TestRuleForManifest(t *testing.T) {
 		layer.MediaType = "application/vnd.in-toto+json"
 		provenanceManifest := test.GenerateOCIImage(test.OCIArgs{}, layer)
 		provenanceManifest.Config.MustUpload(t, s, fooRepoRef)
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/list",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": imgspecv1.MediaTypeImageManifest,
-			}),
-			Body: assert.ByteData(provenanceManifest.Manifest.Contents),
-			ExpectBody: test.ErrorCodeWithMessage{
-				Code:    keppel.ErrManifestInvalid,
-				Message: "manifest upload {\"labels\":null,\"layers\":[{\"annotations\":{\"in-toto.io/predicate-type\":\"https://slsa.dev/provenance/v0.2\"},\"media_type\":\"application/vnd.in-toto+json\"}],\"media_type\":\"application/vnd.oci.image.manifest.v1+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'foo' in labels && 'bar' in labels",
-			},
-			ExpectStatus: http.StatusBadRequest,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/list",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(provenanceManifest.Manifest),
+		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCodeWithMessage{
+			Code:    keppel.ErrManifestInvalid,
+			Message: "manifest upload {\"labels\":null,\"layers\":[{\"annotations\":{\"in-toto.io/predicate-type\":\"https://slsa.dev/provenance/v0.2\"},\"media_type\":\"application/vnd.in-toto+json\"}],\"media_type\":\"application/vnd.oci.image.manifest.v1+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'foo' in labels && 'bar' in labels",
+		})
 
 		test.MustExec(t, s.DB,
 			`UPDATE accounts SET rule_for_manifest = $1 WHERE name = $2`,
 			"'foo' in labels && 'bar' in labels || layers.exists(l, l.media_type == 'application/vnd.in-toto+json')", "test1",
 		)
 
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/list",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": imgspecv1.MediaTypeImageManifest,
-			}),
-			Body:         assert.ByteData(provenanceManifest.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/list",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(provenanceManifest.Manifest),
+		).ExpectStatus(t, http.StatusCreated)
 	})
 }
 
@@ -776,8 +625,9 @@ func expectLabelsJSONOnManifest(t *testing.T, db *keppel.DB, manifestDigest dige
 }
 
 func TestImageManifestWrongBlobSize(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 
 		// generate an image that references a layer, but the reference includes the wrong layer size
@@ -788,16 +638,10 @@ func TestImageManifestWrongBlobSize(t *testing.T) {
 		image := test.GenerateImage(layer)
 		image.Config.MustUpload(t, s, fooRepoRef)
 
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": image.Manifest.MediaType,
-			}),
-			Body:         assert.ByteData(image.Manifest.Contents),
-			ExpectStatus: http.StatusBadRequest,
-			ExpectBody:   test.ErrorCode(keppel.ErrManifestInvalid),
-		}.Check(t, h)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/latest",
+			httptest.WithHeaders(tokenHeaders),
+			uploadingManifest(image.Manifest),
+		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCode(keppel.ErrManifestInvalid))
 	})
 }
 
@@ -823,27 +667,10 @@ func TestImageManifestCmdEntrypointAsString(t *testing.T) {
 
 func TestManifestAnnotations(t *testing.T) {
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
-		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
-
 		image := test.GenerateOCIImage(test.OCIArgs{
-			Annotations: map[string]string{
-				"abc": "def",
-			}},
-		)
+			Annotations: map[string]string{"abc": "def"},
+		})
 		image.MustUpload(t, s, fooRepoRef, "latest")
-
-		// manifest push should succeed
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": imgspecv1.MediaTypeImageManifest,
-			}),
-			Body:         assert.ByteData(image.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
 
 		// check that the annotations_json field is populated correctly in the DB
 		labelsJSONStr := must.ReturnT(s.DB.SelectStr(`SELECT annotations_json FROM manifests WHERE digest = $1`, image.Manifest.Digest.String()))(t)
@@ -856,28 +683,14 @@ func TestManifestAnnotations(t *testing.T) {
 
 func TestManifestArtifactType(t *testing.T) {
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
-		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
-
 		artifactType := "application/vnd.oci.artifact.config.v1+json"
-		image := test.GenerateOCIImage(test.OCIArgs{ArtifactType: artifactType})
+		image := test.GenerateOCIImage(test.OCIArgs{
+			ArtifactType: artifactType,
+		})
 		image.MustUpload(t, s, fooRepoRef, "latest")
 
-		// manifest push should succeed
-		assert.HTTPRequest{
-			Method: "PUT",
-			Path:   "/v2/test1/foo/manifests/latest",
-			Header: test.FlattenHeaders(tokenHeaders, map[string]string{
-				"Content-Type": imgspecv1.MediaTypeImageManifest,
-			}),
-			Body:         assert.ByteData(image.Manifest.Contents),
-			ExpectStatus: http.StatusCreated,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
-
 		// check that the annotations_json field is populated correctly in the DB
-		artifactTypeStr := must.ReturnT(s.DB.SelectStr(`SELECT artifact_type FROM manifests WHERE digest = $1`, image.Manifest.Digest.String()))(t)
-
-		assert.DeepEqual(t, "artifact_type", artifactType, artifactTypeStr)
+		actualArtifactType := must.ReturnT(s.DB.SelectStr(`SELECT artifact_type FROM manifests WHERE digest = $1`, image.Manifest.Digest.String()))(t)
+		assert.Equal(t, actualArtifactType, artifactType)
 	})
 }

--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -217,7 +218,7 @@ func TestImageManifestLifecycle(t *testing.T) {
 					uploadingManifest(updatedImage.Manifest),
 				).ExpectJSON(t, http.StatusConflict, test.ErrorCodeWithMessage{
 					Code:    keppel.ErrDenied,
-					Message: "cannot overwrite tag \"latest\" as it is protected by a tag_policy",
+					Message: `cannot overwrite tag "latest" as it is protected by a tag_policy`,
 				})
 			}
 
@@ -227,7 +228,7 @@ func TestImageManifestLifecycle(t *testing.T) {
 				uploadingManifest(image.Manifest),
 			).ExpectJSON(t, http.StatusConflict, test.ErrorCodeWithMessage{
 				Code:    keppel.ErrDenied,
-				Message: "cannot push tag \"dangerous-release\" as it is forbidden by a tag_policy",
+				Message: `cannot push tag "dangerous-release" as it is forbidden by a tag_policy`,
 			})
 
 			// we did two PUTs, but only the first one will be logged since the second one did not change anything
@@ -483,8 +484,10 @@ func TestManifestQuotaExceeded(t *testing.T) {
 			ExpectJSON(t, http.StatusConflict, quotaExceededMessage)
 
 		// further manifest uploads are not possible now
-		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/anotherone", httptest.WithHeaders(tokenHeaders)).
-			ExpectJSON(t, http.StatusConflict, quotaExceededMessage)
+		s.RespondTo(ctx, "PUT /v2/test1/foo/manifests/anotherone",
+			httptest.WithHeaders(tokenHeaders),
+			httptest.WithBody(strings.NewReader("request body does not matter")),
+		).ExpectJSON(t, http.StatusConflict, quotaExceededMessage)
 	})
 }
 
@@ -524,7 +527,7 @@ func TestRuleForManifest(t *testing.T) {
 			uploadingManifest(image.Manifest),
 		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCodeWithMessage{
 			Code:    keppel.ErrManifestInvalid,
-			Message: "manifest upload {\"labels\":{\"bar\":\"is there\",\"foo\":\"is there\"},\"layers\":[{\"annotations\":null,\"media_type\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\"}],\"media_type\":\"application/vnd.docker.distribution.manifest.v2+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels",
+			Message: `manifest upload {"labels":{"bar":"is there","foo":"is there"},"layers":[{"annotations":null,"media_type":"application/vnd.docker.image.rootfs.diff.tar.gzip"}],"media_type":"application/vnd.docker.distribution.manifest.v2+json","repo_name":"foo"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels`,
 		})
 
 		// ... and OCI, too
@@ -533,7 +536,7 @@ func TestRuleForManifest(t *testing.T) {
 			uploadingManifest(imageOCI.Manifest),
 		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCodeWithMessage{
 			Code:    keppel.ErrManifestInvalid,
-			Message: "manifest upload {\"labels\":{\"bar\":\"is there\",\"foo\":\"is there\"},\"layers\":[{\"annotations\":null,\"media_type\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\"}],\"media_type\":\"application/vnd.oci.image.manifest.v1+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels",
+			Message: `manifest upload {"labels":{"bar":"is there","foo":"is there"},"layers":[{"annotations":null,"media_type":"application/vnd.docker.image.rootfs.diff.tar.gzip"}],"media_type":"application/vnd.oci.image.manifest.v1+json","repo_name":"foo"} does not satisfy validation rule: 'random-label-that-does-not-exist' in labels`,
 		})
 
 		// setup required labels on account for success
@@ -600,7 +603,7 @@ func TestRuleForManifest(t *testing.T) {
 			uploadingManifest(provenanceManifest.Manifest),
 		).ExpectJSON(t, http.StatusBadRequest, test.ErrorCodeWithMessage{
 			Code:    keppel.ErrManifestInvalid,
-			Message: "manifest upload {\"labels\":null,\"layers\":[{\"annotations\":{\"in-toto.io/predicate-type\":\"https://slsa.dev/provenance/v0.2\"},\"media_type\":\"application/vnd.in-toto+json\"}],\"media_type\":\"application/vnd.oci.image.manifest.v1+json\",\"repo_name\":\"foo\"} does not satisfy validation rule: 'foo' in labels && 'bar' in labels",
+			Message: `manifest upload {"labels":null,"layers":[{"annotations":{"in-toto.io/predicate-type":"https://slsa.dev/provenance/v0.2"},"media_type":"application/vnd.in-toto+json"}],"media_type":"application/vnd.oci.image.manifest.v1+json","repo_name":"foo"} does not satisfy validation rule: 'foo' in labels && 'bar' in labels`,
 		})
 
 		test.MustExec(t, s.DB,

--- a/internal/api/registry/manifests_test.go
+++ b/internal/api/registry/manifests_test.go
@@ -65,9 +65,9 @@ func TestImageManifestLifecycle(t *testing.T) {
 
 			// repo does not exist before we first push to it
 			for _, method := range []string{"GET", "HEAD"} {
-				resp := h.RespondTo(ctx, fmt.Sprintf("%s /v2/test1/foo/manifests/%s", method, ref),
+				resp := s.RespondTo(ctx, fmt.Sprintf("%s /v2/test1/foo/manifests/%s", method, ref),
 					httptest.WithHeaders(readOnlyTokenHeaders),
-				).ExpectHeader(t, test.VersionHeaderKey, test.VersionHeaderValue)
+				)
 				if method == "GET" {
 					resp.ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrNameUnknown))
 				} else {
@@ -79,9 +79,9 @@ func TestImageManifestLifecycle(t *testing.T) {
 			_ = must.ReturnT(keppel.FindOrCreateRepository(s.DB, "foo", models.AccountName("test1")))(t)
 			// ...the manifest does not exist before it is pushed
 			for _, method := range []string{"GET", "HEAD"} {
-				resp := h.RespondTo(ctx, fmt.Sprintf("%s /v2/test1/foo/manifests/%s", method, ref),
+				resp := s.RespondTo(ctx, fmt.Sprintf("%s /v2/test1/foo/manifests/%s", method, ref),
 					httptest.WithHeaders(readOnlyTokenHeaders),
-				).ExpectHeader(t, test.VersionHeaderKey, test.VersionHeaderValue)
+				)
 				if method == "GET" {
 					resp.ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrManifestUnknown))
 				} else {
@@ -306,9 +306,9 @@ func TestImageManifestLifecycle(t *testing.T) {
 
 			// check GET/HEAD: manifest should now be available under the reference
 			// where it was pushed to...
-			expectManifestExists(t, h, readOnlyTokenHeaders, "test1/foo", image.Manifest, ref)
+			expectManifestExists(t, s, readOnlyTokenHeaders, "test1/foo", image.Manifest, ref)
 			// ...and under its digest
-			expectManifestExists(t, h, readOnlyTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
+			expectManifestExists(t, s, readOnlyTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
 
 			// GET failure case: wrong scope
 			assert.HTTPRequest{
@@ -325,13 +325,12 @@ func TestImageManifestLifecycle(t *testing.T) {
 			// test GET via anycast
 			if currentlyWithAnycast {
 				testWithReplica(t, s, "on_first_use", func(firstPass bool, s2 test.Setup) {
-					h2 := s2.Handler
 					testAnycast(t, firstPass, s2.DB, func() {
 						anycastTokenHeaders := s.GetAnycastTokenHeaders(t, "repository:test1/foo:pull")
-						expectManifestExists(t, h, anycastTokenHeaders, "test1/foo", image.Manifest, ref)
-						expectManifestExists(t, h, anycastTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
-						expectManifestExists(t, h2, anycastTokenHeaders, "test1/foo", image.Manifest, ref)
-						expectManifestExists(t, h2, anycastTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
+						expectManifestExists(t, s, anycastTokenHeaders, "test1/foo", image.Manifest, ref)
+						expectManifestExists(t, s, anycastTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
+						expectManifestExists(t, s2, anycastTokenHeaders, "test1/foo", image.Manifest, ref)
+						expectManifestExists(t, s2, anycastTokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
 					})
 				})
 			}
@@ -513,7 +512,7 @@ func TestImageListManifestLifecycle(t *testing.T) {
 		easypg.AssertDBContent(t, s.DB.Db, "fixtures/imagelistmanifest-001-after-upload-manifest.sql")
 
 		// check GET for manifest list
-		expectManifestExists(t, h, tokenHeaders, "test1/foo", list2.Manifest, "list")
+		expectManifestExists(t, s, tokenHeaders, "test1/foo", list2.Manifest, "list")
 
 		// as a special case, GET on the manifest list returns the linux/amd64
 		// manifest if only single-arch manifests are accepted by the client (this
@@ -533,7 +532,7 @@ func TestImageListManifestLifecycle(t *testing.T) {
 		}.Check(t, h)
 		// but we return the whole list if at all possible
 		tokenHeaders.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json")
-		expectManifestExists(t, h, tokenHeaders, "test1/foo", list2.Manifest, "list")
+		expectManifestExists(t, s, tokenHeaders, "test1/foo", list2.Manifest, "list")
 
 		// DELETE failure case: cannot delete manifest list while the manifest still exists in the DB
 		assert.HTTPRequest{

--- a/internal/api/registry/ratelimit_test.go
+++ b/internal/api/registry/ratelimit_test.go
@@ -164,12 +164,10 @@ func TestAnycastRateLimits(t *testing.T) {
 		}
 
 		// upload the test blob
-		h := s.Handler
 		blob.MustUpload(t, s, fooRepoRef)
 
 		// pull it via anycast
 		testWithReplica(t, s, "on_first_use", func(firstPass bool, s2 test.Setup) {
-			h2 := s2.Handler
 			s.Clock.StepBy(time.Hour) // reset all rate limits
 			testAnycast(t, firstPass, s2.DB, func() {
 				anycastTokenHeaders := s.GetAnycastTokenHeaders(t, "repository:test1/foo:pull")
@@ -178,11 +176,11 @@ func TestAnycastRateLimits(t *testing.T) {
 				// four requests because each expectBlobExists() does one GET and one
 				// HEAD, but the rate limit only counts GETs since the rate limit is on
 				// the blob contents, which don't get transferred during HEAD)
-				expectBlobExists(t, h2, anycastTokenHeaders, "test1/foo", blob)
-				expectBlobExists(t, h2, anycastTokenHeaders, "test1/foo", blob)
+				expectBlobExists(t, s2, anycastTokenHeaders, "test1/foo", blob)
+				expectBlobExists(t, s2, anycastTokenHeaders, "test1/foo", blob)
 
 				// third pull will be rejected by the rate limit
-				h2.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String(),
+				s2.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String(),
 					httptest.WithHeaders(anycastTokenHeaders),
 				).ExpectHeaders(t, http.Header{
 					test.VersionHeaderKey:   {test.VersionHeaderValue},
@@ -194,7 +192,7 @@ func TestAnycastRateLimits(t *testing.T) {
 				}).ExpectJSON(t, http.StatusTooManyRequests, test.ErrorCode(keppel.ErrTooManyRequests))
 
 				// pull from primary is okay since we don't traverse regions
-				expectBlobExists(t, h, anycastTokenHeaders, "test1/foo", blob)
+				expectBlobExists(t, s, anycastTokenHeaders, "test1/foo", blob)
 			})
 		})
 	})

--- a/internal/api/registry/ratelimit_test.go
+++ b/internal/api/registry/ratelimit_test.go
@@ -183,7 +183,6 @@ func TestAnycastRateLimits(t *testing.T) {
 				s2.RespondTo(ctx, "GET /v2/test1/foo/blobs/"+blob.Digest.String(),
 					httptest.WithHeaders(anycastTokenHeaders),
 				).ExpectHeaders(t, http.Header{
-					test.VersionHeaderKey:   {test.VersionHeaderValue},
 					"X-RateLimit-Action":    {string(keppel.AnycastBlobBytePullAction)},
 					"X-RateLimit-Limit":     {strconv.Itoa(limit.Burst)},
 					"X-RateLimit-Remaining": {"0"},

--- a/internal/api/registry/referrers_test.go
+++ b/internal/api/registry/referrers_test.go
@@ -8,15 +8,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/majewsky/gg/jsonmatch"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sapcc/go-bits/assert"
+	"github.com/sapcc/go-bits/httptest"
 
 	"github.com/sapcc/keppel/internal/test"
 )
 
 func TestReferrersApi(t *testing.T) {
+	ctx := t.Context()
+
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		tokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull,push")
 
 		image := test.GenerateOCIImage(test.OCIArgs{
@@ -30,22 +32,17 @@ func TestReferrersApi(t *testing.T) {
 		})
 		subjectManifest.MustUpload(t, s, fooRepoRef, strings.ReplaceAll(image.Manifest.Digest.String(), ":", "-"))
 
-		assert.HTTPRequest{
-			Method: "GET",
-			Path:   "/v2/test1/foo/referrers/" + image.Manifest.Digest.String(),
-			Header: test.FlattenHeaders(tokenHeaders),
-			ExpectBody: assert.JSONObject{
-				"schemaVersion": 2,
-				"mediaType":     "application/vnd.oci.image.index.v1+json",
-				"manifests": []assert.JSONObject{{
-					"artifactType": imgspecv1.MediaTypeImageManifest,
-					"digest":       subjectManifest.Manifest.Digest.String(),
-					"mediaType":    imgspecv1.MediaTypeImageManifest,
-					"size":         subjectManifest.SizeBytes(),
-				}},
-			},
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/referrers/"+image.Manifest.Digest.String(),
+			httptest.WithHeaders(tokenHeaders),
+		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+			"schemaVersion": 2,
+			"mediaType":     "application/vnd.oci.image.index.v1+json",
+			"manifests": []jsonmatch.Object{{
+				"artifactType": imgspecv1.MediaTypeImageManifest,
+				"digest":       subjectManifest.Manifest.Digest.String(),
+				"mediaType":    imgspecv1.MediaTypeImageManifest,
+				"size":         subjectManifest.SizeBytes(),
+			}},
+		})
 	})
 }

--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -47,20 +47,20 @@ func TestReplicationSimpleImage(t *testing.T) {
 			} else {
 				// if manifest is already present locally, we don't care about the maintenance mode
 				testWithAccountIsDeleting(t, s2.DB, "test1", func() {
-					expectManifestExists(t, h2, tokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
+					expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
 				})
 			}
 
 			s1.Clock.StepBy(time.Second)
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
 
 			if firstPass && strategy == "on_first_use" {
 				easypg.AssertDBContent(t, s2.DB.Db, "fixtures/imagemanifest-replication-001-after-pull-manifest.sql")
 			}
 
 			s1.Clock.StepBy(time.Second)
-			expectBlobExists(t, h2, tokenHeaders, "test1/foo", image.Config)
-			expectBlobExists(t, h2, tokenHeaders, "test1/foo", image.Layers[0])
+			expectBlobExists(t, s2, tokenHeaders, "test1/foo", image.Config)
+			expectBlobExists(t, s2, tokenHeaders, "test1/foo", image.Layers[0])
 
 			if firstPass && strategy == "on_first_use" {
 				easypg.AssertDBContent(t, s2.DB.Db, "fixtures/imagemanifest-replication-002-after-pull-blobs.sql")
@@ -69,11 +69,10 @@ func TestReplicationSimpleImage(t *testing.T) {
 
 		// test pull by tag in secondary account
 		testWithAllReplicaTypes(t, s1, func(strategy string, firstPass bool, s2 test.Setup) {
-			h2 := s2.Handler
 			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", image.Manifest, "first")
-			expectBlobExists(t, h2, tokenHeaders, "test1/foo", image.Config)
-			expectBlobExists(t, h2, tokenHeaders, "test1/foo", image.Layers[0])
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "first")
+			expectBlobExists(t, s2, tokenHeaders, "test1/foo", image.Config)
+			expectBlobExists(t, s2, tokenHeaders, "test1/foo", image.Layers[0])
 		})
 	})
 }
@@ -91,7 +90,6 @@ func TestReplicationImageList(t *testing.T) {
 
 		// test pull in secondary account
 		testWithAllReplicaTypes(t, s1, func(strategy string, firstPass bool, s2 test.Setup) {
-			h2 := s2.Handler
 			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
 
 			if firstPass {
@@ -99,7 +97,7 @@ func TestReplicationImageList(t *testing.T) {
 				// will fail on the changed last_pulled_at timestamp
 				s1.Clock.StepBy(time.Second)
 			}
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", list.Manifest, "list")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", list.Manifest, "list")
 
 			if strategy == "on_first_use" {
 				easypg.AssertDBContent(t, s2.DB.Db, "fixtures/imagelistmanifest-replication-001-after-pull-listmanifest.sql")
@@ -108,8 +106,8 @@ func TestReplicationImageList(t *testing.T) {
 			if !firstPass {
 				// test that this also transferred the referenced manifests eagerly (this
 				// part only runs when the primary registry is not reachable)
-				expectManifestExists(t, h2, tokenHeaders, "test1/foo", image1.Manifest, "")
-				expectManifestExists(t, h2, tokenHeaders, "test1/foo", image2.Manifest, "")
+				expectManifestExists(t, s2, tokenHeaders, "test1/foo", image1.Manifest, "")
+				expectManifestExists(t, s2, tokenHeaders, "test1/foo", image2.Manifest, "")
 			}
 		})
 	})
@@ -252,7 +250,7 @@ func TestReplicationUseCachedBlobMetadata(t *testing.T) {
 			// in the first pass, just replicate the manifest
 			h2 := s2.Handler
 			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", image.Manifest, "first")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "first")
 
 			// in the second pass, query blobs with HEAD - this should work fine even
 			// though the blob contents are not replicated since all necessary metadata
@@ -293,7 +291,7 @@ func TestReplicationForbidAnonymousReplicationFromExternal(t *testing.T) {
 			// will get useless NAME_UNKNOWN errors later, not the errors we're interested in)
 			h2 := s2.Handler
 			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", image.Manifest, "second")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "second")
 
 			// enable anonymous pull on the account
 			test.MustExec(t, s2.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
@@ -319,9 +317,9 @@ func TestReplicationForbidAnonymousReplicationFromExternal(t *testing.T) {
 			}.Check(t, h2)
 
 			// ...but allowed with a non-anonymous token...
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", image.Manifest, "first")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "first")
 			// ...and once replicated, the anonymous token can pull as well
-			expectManifestExists(t, h2, anonTokenHeaders, "test1/foo", image.Manifest, "first")
+			expectManifestExists(t, s2, anonTokenHeaders, "test1/foo", image.Manifest, "first")
 		})
 	})
 }
@@ -349,7 +347,7 @@ func TestReplicationAllowAnonymousReplicationFromExternal(t *testing.T) {
 
 			// the rbac policy allows to replicate test1/foo images
 			anonTokenHeaders := s2.GetAnonTokenHeaders(t, "repository:test1/foo", []string{"pull", "anonymous_first_pull"})
-			expectManifestExists(t, s2.Handler, anonTokenHeaders, "test1/foo", image.Manifest, "first")
+			expectManifestExists(t, s2, anonTokenHeaders, "test1/foo", image.Manifest, "first")
 		})
 	})
 }
@@ -381,7 +379,7 @@ func TestReplicationImageListWithPlatformFilter(t *testing.T) {
 				// will fail on the changed last_pulled_at timestamp
 				s1.Clock.StepBy(time.Second)
 			}
-			expectManifestExists(t, h2, tokenHeaders, "test1/foo", list.Manifest, "list")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", list.Manifest, "list")
 
 			if strategy == "on_first_use" {
 				easypg.AssertDBContent(t, s2.DB.Db, "fixtures/imagelistmanifest-replication-with-platformfilter-001-after-pull-listmanifest.sql")
@@ -390,7 +388,7 @@ func TestReplicationImageListWithPlatformFilter(t *testing.T) {
 			if !firstPass {
 				// test that this also transferred the referenced manifests eagerly (this
 				// part only runs when the primary registry is not reachable)
-				expectManifestExists(t, h2, tokenHeaders, "test1/foo", image1.Manifest, "")
+				expectManifestExists(t, s2, tokenHeaders, "test1/foo", image1.Manifest, "")
 
 				// when now requesting the unreplicated manifest, the replica will try
 				// to replicate and therefore run into a network error

--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -33,7 +33,7 @@ func TestReplicationSimpleImage(t *testing.T) {
 			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
 
 			if firstPass {
-				// replication will not take place while the account is in maintenance
+				// replication will not take place while the account is being deleted
 				testWithAccountIsDeleting(t, s2.DB, "test1", func() {
 					assert.HTTPRequest{
 						Method:       "GET",
@@ -45,7 +45,7 @@ func TestReplicationSimpleImage(t *testing.T) {
 					}.Check(t, h2)
 				})
 			} else {
-				// if manifest is already present locally, we don't care about the maintenance mode
+				// if manifest is already present locally, we don't care about the IsDeleting flag
 				testWithAccountIsDeleting(t, s2.DB, "test1", func() {
 					expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, image.Manifest.Digest.String())
 				})

--- a/internal/api/registry/shared_test.go
+++ b/internal/api/registry/shared_test.go
@@ -127,10 +127,10 @@ func testAnycast(t *testing.T, firstPass bool, db2 *keppel.DB, action func()) {
 ////////////////////////////////////////////////////////////////////////////////
 // helpers for setting up test scenarios
 
-func getBlobUpload(t *testing.T, h httptest.Handler, hdr http.Header, fullRepoName string) (uploadURL, uploadUUID string) {
+func getBlobUpload(t *testing.T, s test.Setup, hdr http.Header, fullRepoName string) (uploadURL, uploadUUID string) {
 	t.Helper()
 
-	h.RespondTo(t.Context(),
+	s.RespondTo(t.Context(),
 		fmt.Sprintf("POST /v2/%s/blobs/uploads/", fullRepoName),
 		httptest.WithHeaders(hdr),
 	).ExpectHeaders(t, http.Header{
@@ -146,9 +146,9 @@ func getBlobUpload(t *testing.T, h httptest.Handler, hdr http.Header, fullRepoNa
 }
 
 //nolint:unparam
-func getBlobUploadURL(t *testing.T, h httptest.Handler, hdr http.Header, fullRepoName string) string {
+func getBlobUploadURL(t *testing.T, s test.Setup, hdr http.Header, fullRepoName string) string {
 	t.Helper()
-	u, _ := getBlobUpload(t, h, hdr, fullRepoName)
+	u, _ := getBlobUpload(t, s, hdr, fullRepoName)
 	return u
 }
 
@@ -162,10 +162,10 @@ func bodyForMethod(method string, body []byte) []byte {
 	return body
 }
 
-func expectBlobExists(t *testing.T, h httptest.Handler, hdr http.Header, fullRepoName string, blob test.Bytes) {
+func expectBlobExists(t *testing.T, s test.Setup, hdr http.Header, fullRepoName string, blob test.Bytes) {
 	t.Helper()
 	for _, method := range []string{"GET", "HEAD"} {
-		h.RespondTo(t.Context(),
+		s.RespondTo(t.Context(),
 			fmt.Sprintf("%s /v2/%s/blobs/%s", method, fullRepoName, blob.Digest.String()),
 			httptest.WithHeaders(hdr),
 		).ExpectHeaders(t, http.Header{
@@ -178,16 +178,16 @@ func expectBlobExists(t *testing.T, h httptest.Handler, hdr http.Header, fullRep
 }
 
 //nolint:unparam
-func expectManifestExists(t *testing.T, h httptest.Handler, hdr http.Header, fullRepoName string, manifest test.Bytes, reference string) {
+func expectManifestExists(t *testing.T, s test.Setup, hdr http.Header, fullRepoName string, manifest test.Bytes, reference string) {
 	t.Helper()
 	for _, method := range []string{"GET", "HEAD"} {
 		// NOTE: `hdr.Get("Accept")` may be empty, in which case we test without any non-empty Accept header
 		for _, acceptHeader := range []string{hdr.Get("Accept"), manifest.MediaType, "text/plain"} {
-			resp := h.RespondTo(t.Context(),
+			resp := s.RespondTo(t.Context(),
 				fmt.Sprintf("%s /v2/%s/manifests/%s", method, fullRepoName, cmp.Or(reference, manifest.Digest.String())),
 				httptest.WithHeaders(hdr),
 				httptest.WithHeader("Accept", acceptHeader), // must be last to take priority over hdr["Accept"] (if that is set)
-			).ExpectHeader(t, test.VersionHeaderKey, test.VersionHeaderValue)
+			)
 
 			if acceptHeader == "text/plain" {
 				// with mismatching Accept header, expect error response

--- a/internal/api/registry/shared_test.go
+++ b/internal/api/registry/shared_test.go
@@ -134,9 +134,8 @@ func getBlobUpload(t *testing.T, s test.Setup, hdr http.Header, fullRepoName str
 		fmt.Sprintf("POST /v2/%s/blobs/uploads/", fullRepoName),
 		httptest.WithHeaders(hdr),
 	).ExpectHeaders(t, http.Header{
-		test.VersionHeaderKey: {test.VersionHeaderValue},
-		"Content-Length":      {"0"},
-		"Range":               {"0-0"},
+		"Content-Length": {"0"},
+		"Range":          {"0-0"},
 	}).
 		CaptureHeader("Location", &uploadURL).
 		CaptureHeader("Blob-Upload-Session-Id", &uploadUUID).
@@ -169,7 +168,6 @@ func expectBlobExists(t *testing.T, s test.Setup, hdr http.Header, fullRepoName 
 			fmt.Sprintf("%s /v2/%s/blobs/%s", method, fullRepoName, blob.Digest.String()),
 			httptest.WithHeaders(hdr),
 		).ExpectHeaders(t, http.Header{
-			test.VersionHeaderKey:   {test.VersionHeaderValue},
 			"Content-Length":        {strconv.Itoa(len(blob.Contents))},
 			"Content-Type":          {blob.MediaType},
 			"Docker-Content-Digest": {blob.Digest.String()},

--- a/internal/api/registry/tags_test.go
+++ b/internal/api/registry/tags_test.go
@@ -140,15 +140,13 @@ func TestListTags(t *testing.T) {
 			testWithReplica(t, s, "on_first_use", func(firstPass bool, s2 test.Setup) {
 				testAnycast(t, firstPass, s2.DB, func() {
 					anycastTokenHeaders := s.GetAnycastTokenHeaders(t, "repository:test1/foo:pull")
-					for _, handler := range []httptest.Handler{s.Handler, s2.Handler} {
-						handler.RespondTo(ctx, "GET /v2/test1/foo/tags/list",
+					for _, setup := range []test.Setup{s, s2} {
+						setup.RespondTo(ctx, "GET /v2/test1/foo/tags/list",
 							httptest.WithHeaders(anycastTokenHeaders),
-						).
-							ExpectHeader(t, test.VersionHeaderKey, test.VersionHeaderValue).
-							ExpectJSON(t, http.StatusOK, jsonmatch.Object{
-								"name": "test1/foo",
-								"tags": allTagNames,
-							})
+						).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+							"name": "test1/foo",
+							"tags": allTagNames,
+						})
 					}
 				})
 			})

--- a/internal/api/registry/tags_test.go
+++ b/internal/api/registry/tags_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/majewsky/gg/jsonmatch"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/httptest"
 
 	"github.com/sapcc/keppel/internal/keppel"
@@ -23,39 +22,26 @@ func TestListTags(t *testing.T) {
 	ctx := t.Context()
 
 	testWithPrimary(t, nil, func(s test.Setup) {
-		h := s.Handler
 		readOnlyTokenHeaders := s.GetTokenHeaders(t, "repository:test1/foo:pull")
 
 		// test tag list for missing repo
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/tags/list",
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusNotFound,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   test.ErrorCode(keppel.ErrNameUnknown),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/tags/list",
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectJSON(t, http.StatusNotFound, test.ErrorCode(keppel.ErrNameUnknown))
 
 		// upload a test image without tagging it
 		image := test.GenerateImage( /* no layers */ )
 		image.MustUpload(t, s, fooRepoRef, "")
 
-		// test empty tag list for existing repo
-		req := assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/tags/list",
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   assert.JSONObject{"name": "test1/foo", "tags": []string{}},
+		// test empty tag list for existing repo (query parameters do not influence this result)
+		for _, query := range []string{"", "?n=10", "?n=10&last=foo"} {
+			s.RespondTo(ctx, "GET /v2/test1/foo/tags/list"+query,
+				httptest.WithHeaders(readOnlyTokenHeaders),
+			).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+				"name": "test1/foo",
+				"tags": []string{},
+			})
 		}
-		req.Check(t, h)
-
-		// query parameters do not influence this result
-		req.Path = "/v2/test1/foo/tags/list?n=10"
-		req.Check(t, h)
-		req.Path = "/v2/test1/foo/tags/list?n=10&last=foo"
-		req.Check(t, h)
 
 		// generate pseudo-random, but deterministic tag names
 		allTagNames := make([]string, 10)
@@ -75,65 +61,48 @@ func TestListTags(t *testing.T) {
 		sort.Strings(allTagNames)
 
 		// test unpaginated
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/tags/list",
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusOK,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   assert.JSONObject{"name": "test1/foo", "tags": allTagNames},
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/tags/list",
+			httptest.WithHeaders(readOnlyTokenHeaders),
+		).ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+			"name": "test1/foo",
+			"tags": allTagNames,
+		})
 
 		// test paginated
 		for offset := range allTagNames {
 			for length := 1; length <= len(allTagNames)+1; length++ {
 				expectedPage := allTagNames[offset:]
-				expectedHeaders := map[string]string{
-					test.VersionHeaderKey: test.VersionHeaderValue,
-					"Content-Type":        "application/json",
+				expectedHeaders := http.Header{
+					"Content-Type": {"application/json"},
 				}
 
 				if len(expectedPage) > length {
 					expectedPage = expectedPage[:length]
 					lastRepoName := expectedPage[len(expectedPage)-1]
-					expectedHeaders["Link"] = fmt.Sprintf(`</v2/test1/foo/tags/list?last=%s&n=%d>; rel="next"`,
+					expectedHeaders.Set("Link", fmt.Sprintf(`</v2/test1/foo/tags/list?last=%s&n=%d>; rel="next"`,
 						strings.ReplaceAll(lastRepoName, "/", "%2F"), length,
-					)
+					))
 				}
 
-				path := fmt.Sprintf(`/v2/test1/foo/tags/list?n=%d`, length)
+				methodAndPath := fmt.Sprintf(`GET /v2/test1/foo/tags/list?n=%d`, length)
 				if offset > 0 {
-					path += `&last=` + allTagNames[offset-1]
+					methodAndPath += `&last=` + allTagNames[offset-1]
 				}
 
-				assert.HTTPRequest{
-					Method:       "GET",
-					Path:         path,
-					Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-					ExpectStatus: http.StatusOK,
-					ExpectHeader: expectedHeaders,
-					ExpectBody:   assert.JSONObject{"name": "test1/foo", "tags": expectedPage},
-				}.Check(t, h)
+				s.RespondTo(ctx, methodAndPath, httptest.WithHeaders(readOnlyTokenHeaders)).
+					ExpectHeaders(t, expectedHeaders).
+					ExpectJSON(t, http.StatusOK, jsonmatch.Object{
+						"name": "test1/foo",
+						"tags": expectedPage,
+					})
 			}
 		}
 
 		// test error cases for pagination query params
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/tags/list?n=-1",
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusBadRequest,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   assert.StringData("invalid value for \"n\": strconv.ParseUint: parsing \"-1\": invalid syntax\n"),
-		}.Check(t, h)
-		assert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v2/test1/foo/tags/list?n=0",
-			Header:       test.FlattenHeaders(readOnlyTokenHeaders),
-			ExpectStatus: http.StatusBadRequest,
-			ExpectHeader: test.VersionHeader,
-			ExpectBody:   assert.StringData("invalid value for \"n\": must not be 0\n"),
-		}.Check(t, h)
+		s.RespondTo(ctx, "GET /v2/test1/foo/tags/list?n=-1", httptest.WithHeaders(readOnlyTokenHeaders)).
+			ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": strconv.ParseUint: parsing \"-1\": invalid syntax\n")
+		s.RespondTo(ctx, "GET /v2/test1/foo/tags/list?n=0", httptest.WithHeaders(readOnlyTokenHeaders)).
+			ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": must not be 0\n")
 
 		// test anycast tag listing
 		if currentlyWithAnycast {

--- a/internal/api/registry/tags_test.go
+++ b/internal/api/registry/tags_test.go
@@ -100,9 +100,9 @@ func TestListTags(t *testing.T) {
 
 		// test error cases for pagination query params
 		s.RespondTo(ctx, "GET /v2/test1/foo/tags/list?n=-1", httptest.WithHeaders(readOnlyTokenHeaders)).
-			ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": strconv.ParseUint: parsing \"-1\": invalid syntax\n")
+			ExpectText(t, http.StatusBadRequest, `invalid value for "n": strconv.ParseUint: parsing "-1": invalid syntax`+"\n")
 		s.RespondTo(ctx, "GET /v2/test1/foo/tags/list?n=0", httptest.WithHeaders(readOnlyTokenHeaders)).
-			ExpectText(t, http.StatusBadRequest, "invalid value for \"n\": must not be 0\n")
+			ExpectText(t, http.StatusBadRequest, `invalid value for "n": must not be 0`+"\n")
 
 		// test anycast tag listing
 		if currentlyWithAnycast {

--- a/internal/api/registry/uploads.go
+++ b/internal/api/registry/uploads.go
@@ -65,7 +65,7 @@ func (a *API) handleStartBlobUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// forbid pushing during maintenance
+	// forbid pushing while account is already being deleted
 	if account.IsDeleting {
 		keppel.ErrUnsupported.With("account is being deleted").WithStatus(http.StatusMethodNotAllowed).WriteAsRegistryV2ResponseTo(w, r)
 		return

--- a/internal/tasks/manifests.go
+++ b/internal/tasks/manifests.go
@@ -641,7 +641,7 @@ func (j *Janitor) doSecurityCheck(ctx context.Context, securityInfo *models.Triv
 	securityInfo.CheckedAt = None[time.Time]()
 	securityInfo.CheckDurationSecs = None[float64]()
 
-	// skip validation while account is in maintenance (maintenance mode blocks
+	// skip validation while account is being deleted (an ongoing deletion blocks
 	// all kinds of activity on an account's contents)
 	if account.IsDeleting {
 		securityInfo.NextCheckAt = Some(j.timeNow().Add(j.addJitter(1 * time.Hour)))

--- a/internal/tasks/manifests_test.go
+++ b/internal/tasks/manifests_test.go
@@ -323,7 +323,7 @@ func TestManifestSyncJob(t *testing.T) {
 			// again, nothing to do on the primary side
 			assert.ErrEqual(t, syncManifestsJob1.ProcessOne(s1.Ctx), sql.ErrNoRows)
 			// ManifestSyncJob on the replica side should not do anything while
-			// the account is in maintenance; only the timestamp is updated to make sure
+			// the account is being deleted; only the timestamp is updated to make sure
 			// that the job loop progresses to the next repo
 			test.MustExec(t, s2.DB, `UPDATE accounts SET is_deleting = TRUE`)
 			assert.ErrEqual(t, syncManifestsJob2.ProcessOne(s2.Ctx), nil)
@@ -342,7 +342,7 @@ func TestManifestSyncJob(t *testing.T) {
 
 			// test that replication from external uses the inbound cache
 			if strategy == "from_external_on_first_use" {
-				// after the end of the maintenance, we would naively expect
+				// after resetting the IsDeleting flag, we would naively expect
 				// ManifestSyncJob to actually replicate the deletion, BUT we have an
 				// inbound cache with a lifetime of 6 hours, so actually nothing should
 				// happen (only the tag gets synced, which includes a validation of the
@@ -364,7 +364,7 @@ func TestManifestSyncJob(t *testing.T) {
 			// From now on, we will go in clock increments of 7 hours to force the
 			// inbound cache to never hit.
 
-			// after the end of the maintenance, ManifestSyncJob on the replica
+			// after resetting the IsDeleting flag, ManifestSyncJob on the replica
 			// side should delete the same manifest that we deleted in the primary
 			// account, and also replicate the tag change (which includes a validation
 			// of the tagged manifests)

--- a/internal/test/helper_upload.go
+++ b/internal/test/helper_upload.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sapcc/keppel/internal/models"
 )
 
+// TODO: make private once assert.HTTPRequest is removed
 const (
 	// VersionHeaderKey is the standard version header name included in all
 	// Registry v2 API responses.
@@ -28,6 +29,8 @@ const (
 
 // VersionHeader is the standard version header included in all Registry v2 API
 // responses.
+//
+// TODO: remove once assert.HTTPRequest is removed
 var VersionHeader = map[string]string{VersionHeaderKey: VersionHeaderValue}
 
 // MustUpload uploads the blob via the Registry V2 API.

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -363,7 +363,7 @@ func MustExec(t *testing.T, db *keppel.DB, query string, args ...any) {
 
 var looksLikeDistributionAPIEndpointRx = regexp.MustCompile(`^[A-Z]* /v2(?:/|$)`)
 
-// RespondTo is a shorthand for s.Handler.RespondTo() that also checks the following universal response properties:
+// RespondTo is like s.handler.RespondTo(), but also checks the following universal response properties:
 //
 //   - Requests for endpoints in the OCI Distribution API (any path at or below /v2/)
 //     must always include the response header "Docker-Distribution-Api-Version: registry/2.0", even for error responses.

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -4,10 +4,12 @@
 package test
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -151,7 +153,7 @@ type Setup struct {
 	FD           *FederationDriver
 	SD           *trivial.StorageDriver
 	ICD          *InboundCacheDriver
-	Handler      httptest.Handler
+	Handler      http.Handler
 	Ctx          context.Context //nolint: containedctx  // only used in tests
 	Registry     *prometheus.Registry
 	// fields that are only set if the respective With... setup option is included
@@ -161,6 +163,7 @@ type Setup struct {
 	Repos    []*models.Repository
 	// fields that are only accessible to helper functions
 	tokenCache map[string]string
+	handler    httptest.Handler // not exposed publicly to force usage of s.RespondTo() instead of s.Handler.RespondTo()
 }
 
 // these credentials are in global vars so that we don't have to recompute them in every test run
@@ -301,7 +304,8 @@ func NewSetup(t testing.TB, opts ...SetupOption) Setup {
 	if params.WithPeerAPI {
 		apis = append(apis, peerv1.NewAPI(s.Config, ad, s.DB))
 	}
-	s.Handler = httptest.NewHandler(httpapi.Compose(apis...))
+	s.Handler = httpapi.Compose(apis...)
+	s.handler = httptest.NewHandler(s.Handler)
 	if tt, ok := http.DefaultTransport.(*RoundTripper); ok {
 		// make our own API reachable to other peers
 		tt.Handlers[s.Config.APIPublicHostname] = s.Handler
@@ -355,4 +359,33 @@ func MustExec(t *testing.T, db *keppel.DB, query string, args ...any) {
 	t.Helper()
 	_, err := db.Exec(query, args...)
 	must.SucceedT(t, err)
+}
+
+var looksLikeDistributionAPIEndpointRx = regexp.MustCompile(`^[A-Z]* /v2(?:/|$)`)
+
+// RespondTo is a shorthand for s.Handler.RespondTo() that also checks the following universal response properties:
+//
+//   - Requests for endpoints in the OCI Distribution API (any path at or below /v2/)
+//     must always include the response header "Docker-Distribution-Api-Version: registry/2.0", even for error responses.
+//
+// This saves the trouble of having to duplicate these checks hundreds of times.
+func (s Setup) RespondTo(ctx context.Context, methodAndPath string, options ...httptest.RequestOption) httptest.Response {
+	resp := s.handler.RespondTo(ctx, methodAndPath, options...)
+
+	if looksLikeDistributionAPIEndpointRx.MatchString(methodAndPath) {
+		// this is written in a slightly roundabout way because RespondTo() does not get a `t` argument
+		// (yes, yes, I could add it to the method signature, but then this would not be a behavioral equivalent of s.Handler.RespondTo() anymore)
+		if resp.Header().Get(VersionHeaderKey) != VersionHeaderValue {
+			fakeHandler := httptest.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				msg := fmt.Sprintf("expected %q, but got %q",
+					fmt.Sprintf("%s: %s", VersionHeaderKey, VersionHeaderValue),
+					fmt.Sprintf("%s: %s", VersionHeaderKey, cmp.Or(resp.Header().Get(VersionHeaderKey), "<missing>")),
+				)
+				http.Error(w, msg, 999)
+			}))
+			return fakeHandler.RespondTo(ctx, methodAndPath, options...)
+		}
+	}
+
+	return resp
 }


### PR DESCRIPTION
This is the majority of the remaining uses, though I chose to leave some gnarly instances for a later PR.

When reviewing, you will find that the one thing that I did not map was `ExpectHeader: test.VersionHeader`. This is now done in `test.Setup.RespondTo()` centrally (see the first commit in the changeset), so I don't have to repeat this check literally hundreds of times.