### PR TITLE
rework some handler helper functions to return proper errors

### DIFF
--- a/internal/api/keppel/accounts.go
+++ b/internal/api/keppel/accounts.go
@@ -70,8 +70,8 @@ func (a *API) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -88,8 +88,8 @@ func (a *API) handlePutAccount(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Account keppel.Account `json:"account"`
 	}
-	ok := decodeJSONRequestBody(w, r.Body, &req)
-	if !ok {
+	err := decodeJSONRequestBody(r.Body, &req)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 	// we do not allow to set name in the request body ...
@@ -148,8 +148,8 @@ func (a *API) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -158,7 +158,7 @@ func (a *API) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := a.processor().MarkAccountForDeletion(account, keppel.AuditContext{
+	err = a.processor().MarkAccountForDeletion(account, keppel.AuditContext{
 		UserIdentity: authz.UserIdentity,
 		Request:      r,
 	})
@@ -175,8 +175,8 @@ func (a *API) handlePostAccountSublease(w http.ResponseWriter, r *http.Request) 
 	if authz == nil {
 		return
 	}
-	account, ok := a.findReducedAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findReducedAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -190,7 +190,6 @@ func (a *API) handlePostAccountSublease(w http.ResponseWriter, r *http.Request) 
 		PrimaryHostname: a.cfg.APIPublicHostname,
 	}
 
-	var err error
 	st.Secret, err = a.fd.IssueSubleaseTokenSecret(r.Context(), account)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
@@ -204,8 +203,8 @@ func (a *API) handleGetSecurityScanPolicies(w http.ResponseWriter, r *http.Reque
 	if authz == nil {
 		return
 	}
-	account, ok := a.findAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -222,14 +221,14 @@ func (a *API) handlePutSecurityScanPolicies(w http.ResponseWriter, r *http.Reque
 	if authz == nil {
 		return
 	}
-	account, ok := a.findAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
 	// decode existing policies
 	var dbPolicies []keppel.SecurityScanPolicy
-	err := json.Unmarshal([]byte(account.SecurityScanPoliciesJSON), &dbPolicies)
+	err = json.Unmarshal([]byte(account.SecurityScanPoliciesJSON), &dbPolicies)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -238,8 +237,8 @@ func (a *API) handlePutSecurityScanPolicies(w http.ResponseWriter, r *http.Reque
 	var req struct {
 		Policies []keppel.SecurityScanPolicy `json:"policies"`
 	}
-	ok = decodeJSONRequestBody(w, r.Body, &req)
-	if !ok {
+	err = decodeJSONRequestBody(r.Body, &req)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 

--- a/internal/api/keppel/api.go
+++ b/internal/api/keppel/api.go
@@ -143,6 +143,7 @@ func repoScopeFromRequest(r *http.Request, perm keppel.Permission) auth.ScopeSet
 	})
 }
 
+// TODO: remove `w` argument and return errors using respondwith.CustomStatus(), like in findAccountFromRequest()
 func (a *API) authenticateRequest(w http.ResponseWriter, r *http.Request, ss auth.ScopeSet) *auth.Authorization {
 	authz, _, rerr := auth.IncomingRequest{
 		HTTPRequest:          r,
@@ -157,69 +158,72 @@ func (a *API) authenticateRequest(w http.ResponseWriter, r *http.Request, ss aut
 	return authz
 }
 
+var (
+	errAccountNotFound   = errors.New("account not found")
+	errAccountIsDeleting = errors.New("account is being deleted")
+	errRepoNameInvalid   = errors.New("repo name invalid")
+	errRepoNotFound      = errors.New("repository not found")
+)
+
 // NOTE: The *auth.Authorization argument is only used to ensure that we call authenticateRequest
 // first. This is important because this function may otherwise leak information about whether
 // accounts exist or not to unauthorized users.
-func (a *API) findAccountFromRequest(w http.ResponseWriter, r *http.Request, _ *auth.Authorization) (models.Account, bool) {
+func (a *API) findAccountFromRequest(r *http.Request, _ *auth.Authorization) (models.Account, error) {
 	accountName := models.AccountName(mux.Vars(r)["account"])
 	account, err := keppel.FindAccount(a.db, accountName)
-	if errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "account not found", http.StatusNotFound)
-		return models.Account{}, false
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return models.Account{}, respondwith.CustomStatus(http.StatusNotFound, errAccountNotFound)
+	case err != nil:
+		return models.Account{}, err
+	case account.IsDeleting && r.Method == http.MethodGet:
+		return models.Account{}, respondwith.CustomStatus(http.StatusConflict, errAccountIsDeleting)
+	default:
+		return account, nil
 	}
-	if respondwith.ObfuscatedErrorText(w, err) {
-		return models.Account{}, false
-	}
-	if account.IsDeleting && r.Method == http.MethodGet {
-		http.Error(w, "account is being deleted", http.StatusConflict)
-		return models.Account{}, false
-	}
-	return account, true
-}
-func (a *API) findReducedAccountFromRequest(w http.ResponseWriter, r *http.Request, _ *auth.Authorization) (models.ReducedAccount, bool) {
-	accountName := models.AccountName(mux.Vars(r)["account"])
-	account, err := keppel.FindReducedAccount(a.db, accountName)
-	if errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "account not found", http.StatusNotFound)
-		return models.ReducedAccount{}, false
-	}
-	if respondwith.ObfuscatedErrorText(w, err) {
-		return models.ReducedAccount{}, false
-	}
-	if account.IsDeleting && r.Method == http.MethodGet {
-		http.Error(w, "account is being deleted", http.StatusConflict)
-		return models.ReducedAccount{}, false
-	}
-	return account, true
 }
 
-func (a *API) findRepositoryFromRequest(w http.ResponseWriter, r *http.Request, accountName models.AccountName) *models.Repository {
+func (a *API) findReducedAccountFromRequest(r *http.Request, _ *auth.Authorization) (models.ReducedAccount, error) {
+	accountName := models.AccountName(mux.Vars(r)["account"])
+	account, err := keppel.FindReducedAccount(a.db, accountName)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return models.ReducedAccount{}, respondwith.CustomStatus(http.StatusNotFound, errAccountNotFound)
+	case err != nil:
+		return models.ReducedAccount{}, err
+	case account.IsDeleting && r.Method == http.MethodGet:
+		return models.ReducedAccount{}, respondwith.CustomStatus(http.StatusConflict, errAccountIsDeleting)
+	default:
+		return account, nil
+	}
+}
+
+func (a *API) findRepositoryFromRequest(r *http.Request, accountName models.AccountName) (models.Repository, error) {
 	repoName := mux.Vars(r)["repo_name"]
 	if !isValidRepoName(repoName) {
-		http.Error(w, "repo name invalid", http.StatusUnprocessableEntity)
-		return nil
+		return models.Repository{}, respondwith.CustomStatus(http.StatusUnprocessableEntity, errRepoNameInvalid)
 	}
 
 	repo, err := keppel.FindRepository(a.db, repoName, accountName)
-	if errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "repository not found", http.StatusNotFound)
-		return nil
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return models.Repository{}, respondwith.CustomStatus(http.StatusNotFound, errRepoNotFound)
+	case err != nil:
+		return models.Repository{}, err
+	default:
+		return *repo, nil
 	}
-	if respondwith.ObfuscatedErrorText(w, err) {
-		return nil
-	}
-	return repo
 }
 
-func decodeJSONRequestBody(w http.ResponseWriter, body io.Reader, target any) (ok bool) {
+func decodeJSONRequestBody(body io.Reader, target any) error {
 	decoder := json.NewDecoder(body)
 	decoder.DisallowUnknownFields()
 	err := decoder.Decode(&target)
 	if err != nil {
-		http.Error(w, "request body is not valid JSON: "+err.Error(), http.StatusBadRequest)
-		return false
+		err = fmt.Errorf("request body is not valid JSON: %w", err)
+		return respondwith.CustomStatus(http.StatusBadRequest, err)
 	}
-	return true
+	return nil
 }
 
 func isValidRepoName(name string) bool {

--- a/internal/api/keppel/liquid.go
+++ b/internal/api/keppel/liquid.go
@@ -42,8 +42,8 @@ func (a *API) handleLiquidReportCapacity(w http.ResponseWriter, r *http.Request)
 
 	// we don't need the request data, but we check it to satisfy the spec
 	var req liquid.ServiceCapacityRequest
-	ok := decodeJSONRequestBody(w, r.Body, &req)
-	if !ok {
+	err := decodeJSONRequestBody(r.Body, &req)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -64,8 +64,8 @@ func (a *API) handleLiquidReportUsage(w http.ResponseWriter, r *http.Request) {
 
 	// we don't need the request data, but we check it to satisfy the spec
 	var req liquid.ServiceUsageRequest
-	ok := decodeJSONRequestBody(w, r.Body, &req)
-	if !ok {
+	err := decodeJSONRequestBody(r.Body, &req)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -85,12 +85,12 @@ func (a *API) handleLiquidSetQuota(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req liquid.ServiceQuotaRequest
-	ok := decodeJSONRequestBody(w, r.Body, &req)
-	if !ok {
+	err := decodeJSONRequestBody(r.Body, &req)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
-	_, err := a.processor().SetQuotas(authTenantID, liquidConvertQuotaRequest(req), authz.UserIdentity.UserInfo(), r)
+	_, err = a.processor().SetQuotas(authTenantID, liquidConvertQuotaRequest(req), authz.UserIdentity.UserInfo(), r)
 	if iqerr, ok := errext.As[processor.ImpossibleQuotaError](err); ok {
 		http.Error(w, iqerr.Message, http.StatusUnprocessableEntity)
 		return

--- a/internal/api/keppel/manifests.go
+++ b/internal/api/keppel/manifests.go
@@ -78,12 +78,12 @@ func (a *API) handleGetManifests(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findReducedAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findReducedAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, account.Name)
-	if repo == nil {
+	repo, err := a.findRepositoryFromRequest(r, account.Name)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -201,12 +201,12 @@ func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findReducedAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findReducedAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, account.Name)
-	if repo == nil {
+	repo, err := a.findRepositoryFromRequest(r, account.Name)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 	parsedDigest, err := digest.Parse(mux.Vars(r)["digest"])
@@ -241,12 +241,12 @@ func (a *API) handleDeleteTag(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findReducedAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findReducedAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, account.Name)
-	if repo == nil {
+	repo, err := a.findRepositoryFromRequest(r, account.Name)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 	tagName := mux.Vars(r)["tag_name"]
@@ -277,12 +277,12 @@ func (a *API) handleGetTrivyReport(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findReducedAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findReducedAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
-	err := api.CheckRateLimit(r, w, a.rle, account, authz, keppel.TrivyReportRetrieveAction, 1)
+	err = api.CheckRateLimit(r, w, a.rle, account, authz, keppel.TrivyReportRetrieveAction, 1)
 	if err != nil {
 		if rerr, ok := errext.As[*keppel.RegistryV2Error](err); ok && rerr != nil {
 			rerr.WriteAsRegistryV2ResponseTo(w, r)
@@ -292,8 +292,8 @@ func (a *API) handleGetTrivyReport(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	repo := a.findRepositoryFromRequest(w, r, account.Name)
-	if repo == nil {
+	repo, err := a.findRepositoryFromRequest(r, account.Name)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 	parsedDigest, err := digest.Parse(mux.Vars(r)["digest"])

--- a/internal/api/keppel/quotas.go
+++ b/internal/api/keppel/quotas.go
@@ -39,8 +39,8 @@ func (a *API) handlePutQuotas(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req processor.QuotaRequest
-	ok := decodeJSONRequestBody(w, r.Body, &req)
-	if !ok {
+	err := decodeJSONRequestBody(r.Body, &req)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 

--- a/internal/api/keppel/repos.go
+++ b/internal/api/keppel/repos.go
@@ -66,8 +66,8 @@ func (a *API) handleGetRepositories(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findReducedAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findReducedAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -162,7 +162,7 @@ var (
 	`)
 )
 
-func (a *API) deleteAllManifestsInRepository(r *http.Request, authz *auth.Authorization, repo *models.Repository, account models.ReducedAccount, tagPolicies []keppel.TagPolicy) error {
+func (a *API) deleteAllManifestsInRepository(r *http.Request, authz *auth.Authorization, repo models.Repository, account models.ReducedAccount, tagPolicies []keppel.TagPolicy) error {
 	// can only delete repository when first deleting all manifests which reference others
 	deletedManifestCount := 0
 	err := sqlext.ForeachRow(a.db, deleteRepositoryFindManifestsQuery, []any{repo.ID},
@@ -217,12 +217,12 @@ func (a *API) handleDeleteRepository(w http.ResponseWriter, r *http.Request) {
 	if authz == nil {
 		return
 	}
-	account, ok := a.findAccountFromRequest(w, r, authz)
-	if !ok {
+	account, err := a.findAccountFromRequest(r, authz)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	repo := a.findRepositoryFromRequest(w, r, account.Name)
-	if repo == nil {
+	repo, err := a.findRepositoryFromRequest(r, account.Name)
+	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 
@@ -275,7 +275,7 @@ func (a *API) handleDeleteRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = tx.Delete(repo)
+	_, err = tx.Delete(&repo)
 	if err == nil {
 		err = tx.Commit()
 	}

--- a/internal/api/peer/api.go
+++ b/internal/api/peer/api.go
@@ -36,6 +36,7 @@ func (a *API) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/peer/v1/sync-replica/{account}/{repo:.+}").HandlerFunc(a.handleSyncReplica)
 }
 
+// TODO: remove `w` argument and return errors using respondwith.CustomStatus(), like in findAccountFromRequest()
 func (a *API) authenticateRequest(w http.ResponseWriter, r *http.Request) *models.Peer {
 	authz, _, rerr := auth.IncomingRequest{
 		HTTPRequest: r,

--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -135,7 +135,7 @@ func (a *API) handleToplevel(w http.ResponseWriter, r *http.Request) {
 	respondwith.JSON(w, http.StatusOK, map[string]any{})
 }
 
-// Like respondwith.ObfuscatedErrorText(), but writes a RegistryV2Error instead of plain text.
+// Like respondwith.ErrorText(), but writes a RegistryV2Error instead of plain text.
 func respondWithError(w http.ResponseWriter, r *http.Request, err error) bool {
 	if err == nil {
 		return false
@@ -149,6 +149,7 @@ func respondWithError(w http.ResponseWriter, r *http.Request, err error) bool {
 		return true
 	}
 
+	// TODO: should use obfuscation (like respondwith.ObfuscatedErrorText())
 	keppel.ErrUnknown.With(err.Error()).WriteAsRegistryV2ResponseTo(w, r)
 	return true
 }
@@ -186,6 +187,9 @@ func (info anycastRequestInfo) asPrometheusLabels() prometheus.Labels {
 // If the account does not exist locally, but the request is for the anycast API
 // and the account exists elsewhere, the `anycastHandler` is invoked if given
 // instead of giving a 404 response.
+//
+// TODO: remove `w` argument and return errors using respondwith.CustomStatus(), like in findAccountFromRequest()
+// TODO: return non-pointer arguments to avoid useless heap allocations
 func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strategy repoAccessStrategy, anycastHandler func(http.ResponseWriter, *http.Request, anycastRequestInfo)) (*models.ReducedAccount, *models.ReducedRepository, *auth.Authorization, *auth.Challenge) {
 	// must be set even for 401 responses!
 	w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")

--- a/internal/api/registry/uploads.go
+++ b/internal/api/registry/uploads.go
@@ -494,6 +494,8 @@ func (a *API) handleFinishBlobUpload(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
+// TODO: remove `w` argument and return errors using respondwith.CustomStatus(), like in findAccountFromRequest()
+// TODO: return non-pointer arguments to avoid useless heap allocations
 func (a *API) findUpload(w http.ResponseWriter, r *http.Request, repo models.ReducedRepository) *models.Upload {
 	uploadUUID := mux.Vars(r)["uuid"]
 

--- a/internal/keppel/database_helpers.go
+++ b/internal/keppel/database_helpers.go
@@ -14,6 +14,9 @@ import (
 	"github.com/sapcc/keppel/internal/models"
 )
 
+// TODO: rework all functions that may return nil to instead return sql.ErrNoRows
+// TODO: then make all functions return their result without a pointer indirection
+
 // FindAccount works similar to db.SelectOne().
 func FindAccount(db gorp.SqlExecutor, name models.AccountName) (models.Account, error) {
 	var account models.Account


### PR DESCRIPTION
I added respondwith.CustomStatus() a good while back to allow for this pattern, but have not found the time to use it in Keppel yet. This is the first batch, with most functions only being marked as TODO for subsequent refactors. The functions in `internal/api/registry` are going to be of particular interest since this API needs to report errors as JSON instead of as text, even if they are obfuscated.