### PR TITLE
drivers/openstack: support Swift storage types != object-store

### DIFF
--- a/docs/drivers/storage-swift.md
+++ b/docs/drivers/storage-swift.md
@@ -20,4 +20,5 @@ The following parameters may be supplied in `$KEPPEL_DRIVER_STORAGE`:
 
 | Field | Type | Explanation |
 | ----- | ---- | ----------- |
+| `service_type` | string | *(optional)* Service type for Swift in the Keystone service catalog. Defaults to `object-store` for native Swift, but can be set to e.g. `object-store-ceph` to use Ceph's Swift-compatible API. |
 | `use_service_user_project` | bool | *(optional)* When set to `true`, stores all payload in the service user's own project instead of in the project owning the respective Keppel account. Defaults to `false`. |

--- a/internal/drivers/openstack/swift.go
+++ b/internal/drivers/openstack/swift.go
@@ -5,6 +5,7 @@ package openstack
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -36,7 +37,8 @@ type swiftContainerInfo struct {
 }
 
 type swiftDriver struct {
-	UseServiceUserProject bool `json:"use_service_user_project"`
+	ServiceType           string `json:"service_type"`
+	UseServiceUserProject bool   `json:"use_service_user_project"`
 
 	mainAccount         *schwift.Account
 	containerInfos      map[models.AccountName]*swiftContainerInfo
@@ -57,7 +59,9 @@ func (d *swiftDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) error
 		return keppel.ErrAuthDriverMismatch
 	}
 
-	client, err := openstack.NewObjectStorageV1(k.Provider, k.EndpointOpts)
+	eo := k.EndpointOpts
+	eo.Type = cmp.Or(d.ServiceType, "object-store")
+	client, err := openstack.NewObjectStorageV1(k.Provider, eo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Once we migrate to Ceph, we need to use "object-store-ceph" instead.