### PR TITLE
fix error condition for the special "repo not found" message on first pulls

### DIFF
--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -263,17 +263,11 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 	}
 
 	canCreateRepoIfMissing := false
-	canFirstPull := false
 	switch strategy {
 	case createRepoIfMissing:
 		canCreateRepoIfMissing = true
 	case createRepoIfMissingAndReplica:
-		canFirstPull = authz.ScopeSet.Contains(auth.Scope{
-			ResourceType: "repository",
-			ResourceName: scope.ResourceName,
-			Actions:      []string{"anonymous_first_pull"},
-		})
-		canCreateRepoIfMissing = account.UpstreamPeerHostName != "" || (account.ExternalPeerURL != "" && (authz.UserIdentity.UserType() == keppel.RegularUser || canFirstPull))
+		canCreateRepoIfMissing = account.UpstreamPeerHostName != "" || (account.ExternalPeerURL != "" && (authz.UserIdentity.UserType() == keppel.RegularUser || authz.ScopeSet.AllowsAnonymousFirstPullOn(scope.ResourceName)))
 	}
 
 	var repo models.ReducedRepository
@@ -283,8 +277,11 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 		repo, err = keppel.FindReducedRepository(a.db, repoScope.RepositoryName, account.Name)
 	}
 	if errors.Is(err, sql.ErrNoRows) {
-		if canFirstPull {
-			keppel.ErrNameUnknown.With("repository does not exist here, and anonymous users may not create new repositories").WriteAsRegistryV2ResponseTo(w, r)
+		if strategy == createRepoIfMissingAndReplica && account.ExternalPeerURL != "" && authz.UserIdentity.UserType() == keppel.AnonymousUser {
+			rerr := keppel.ErrDenied.With("repository does not exist here, and anonymous users may not create new repositories")
+			// this must be a 401 and include a challenge; clients should be able to understand that
+			// they can retry this after authenticating and expect a different result
+			challenge.AddTo(rerr).WithStatus(http.StatusUnauthorized).WriteAsRegistryV2ResponseTo(w, r)
 		} else {
 			keppel.ErrNameUnknown.With("repository not found").WriteAsRegistryV2ResponseTo(w, r)
 		}

--- a/internal/api/registry/manifests.go
+++ b/internal/api/registry/manifests.go
@@ -21,7 +21,6 @@ import (
 	accept "github.com/timewasted/go-accept-headers"
 
 	"github.com/sapcc/keppel/internal/api"
-	"github.com/sapcc/keppel/internal/auth"
 	"github.com/sapcc/keppel/internal/keppel"
 	"github.com/sapcc/keppel/internal/models"
 	"github.com/sapcc/keppel/internal/processor"
@@ -59,11 +58,7 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 		if (account.UpstreamPeerHostName != "" || account.ExternalPeerURL != "") && !account.IsDeleting && (userType != keppel.PeerUser && userType != keppel.TrivyUser) {
 			// when replicating from external, only authenticated users can trigger the replication
 			if account.ExternalPeerURL != "" && userType != keppel.RegularUser {
-				if !authz.ScopeSet.Contains(auth.Scope{
-					ResourceType: "repository",
-					ResourceName: repo.FullName(),
-					Actions:      []string{"anonymous_first_pull"},
-				}) {
+				if !authz.ScopeSet.AllowsAnonymousFirstPullOn(mux.Vars(r)["repository"]) {
 					rerr := keppel.ErrDenied.With("image does not exist here, and anonymous users may not replicate images")
 					// this must be a 401 and include a challenge; clients should be able to understand that
 					// they can retry this after authenticating and expect a different result

--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -250,11 +250,6 @@ func TestReplicationForbidAnonymousReplicationFromExternal(t *testing.T) {
 				return
 			}
 
-			// make sure that the "test1/foo" repo exists on secondary (otherwise we
-			// will get useless NAME_UNKNOWN errors later, not the errors we're interested in)
-			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
-			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "second")
-
 			// enable anonymous pull on the account
 			test.MustExec(t, s2.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
 				test.ToJSON([]keppel.RBACPolicy{{
@@ -263,9 +258,22 @@ func TestReplicationForbidAnonymousReplicationFromExternal(t *testing.T) {
 				}}),
 			)
 
+			// replicating pull is forbidden with an anonymous token
+			// (error message option 1 for the "repo does not exist" case)
 			anonTokenHeaders := s2.GetAnonTokenHeaders(t, "repository:test1/foo", []string{"pull"})
+			s2.RespondTo(ctx, "GET /v2/test1/foo/manifests/first", httptest.WithHeaders(anonTokenHeaders)).
+				ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry-secondary.example.org/keppel/v1/auth",service="registry-secondary.example.org",scope="repository:test1/foo:pull"`).
+				ExpectJSON(t, http.StatusUnauthorized, test.ErrorCodeWithMessage{
+					Code:    keppel.ErrDenied,
+					Message: "repository does not exist here, and anonymous users may not create new repositories",
+				})
+
+			// create the "test1/foo" repo on secondary to show the other error option
+			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "second")
 
 			// replicating pull is forbidden with an anonymous token...
+			// (error message option 2 for the "repo does exist, but image does not" case)
 			s2.RespondTo(ctx, "GET /v2/test1/foo/manifests/first", httptest.WithHeaders(anonTokenHeaders)).
 				ExpectHeader(t, "Www-Authenticate", `Bearer realm="https://registry-secondary.example.org/keppel/v1/auth",service="registry-secondary.example.org",scope="repository:test1/foo:pull"`).
 				ExpectJSON(t, http.StatusUnauthorized, test.ErrorCodeWithMessage{

--- a/internal/auth/scopeset.go
+++ b/internal/auth/scopeset.go
@@ -90,3 +90,12 @@ func isKeppelAccountViewScope(s Scope) (models.AccountName, bool) {
 	}
 	return "", false
 }
+
+// AllowsAnonymousFirstPullOn is a shorthand for a specific [ScopeSet.Contains] call.
+func (ss ScopeSet) AllowsAnonymousFirstPullOn(repoScopeName string) bool {
+	return ss.Contains(Scope{
+		ResourceType: "repository",
+		ResourceName: repoScopeName,
+		Actions:      []string{"anonymous_first_pull"},
+	})
+}


### PR DESCRIPTION
Usually, we only run into `image does not exist here...`, not into `repository does not exist here...` (including in tests), so this went under the radar.