### PR TITLE
api/keppel: fix evaluation of tag policies during repo deletion

### DIFF
--- a/internal/api/keppel/repos.go
+++ b/internal/api/keppel/repos.go
@@ -238,22 +238,25 @@ func (a *API) handleDeleteRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var (
-		tagResults []models.Tag
-		tags       []string
-	)
-	_, err = a.db.Select(&tagResults, `SELECT * FROM tags WHERE repo_id = $1`, repo.ID)
+	var tags []models.Tag
+	_, err = a.db.Select(&tags, `SELECT * FROM tags WHERE repo_id = $1`, repo.ID)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	for _, tagResult := range tagResults {
-		tags = append(tags, tagResult.Name)
+	tagsByManifestDigest := make(map[digest.Digest][]string)
+	for _, tag := range tags {
+		tagsByManifestDigest[tag.Digest] = append(tagsByManifestDigest[tag.Digest], tag.Name)
 	}
 
 	for _, tagPolicy := range tagPolicies {
-		if tagPolicy.BlockDelete && tagPolicy.MatchesRepository(repo.Name) && tagPolicy.MatchesTags(tags) {
-			http.Error(w, processor.DeleteManifestBlockedByTagPolicyError{Policy: tagPolicy}.Error(), http.StatusConflict)
-			return
+		if tagPolicy.BlockDelete && tagPolicy.MatchesRepository(repo.Name) {
+			for manifestDigest, manifestTags := range tagsByManifestDigest {
+				if tagPolicy.MatchesTags(manifestTags) {
+					err := processor.DeleteManifestBlockedByTagPolicyError{Digest: manifestDigest, Policy: tagPolicy}
+					http.Error(w, err.Error(), http.StatusConflict)
+					return
+				}
+			}
 		}
 	}
 

--- a/internal/api/keppel/repos_test.go
+++ b/internal/api/keppel/repos_test.go
@@ -149,10 +149,14 @@ func TestReposAPI(t *testing.T) {
 		ExpectText(t, http.StatusNotFound, "repository not found\n")
 
 	// test if tag policy prevents deletion
-	deletingTagPolicyJSON := `{"match_repository":".*","block_delete":true}`
+	//
+	// The "except_tag": "tag1" checks that tags of each image are considered separately.
+	// Even though we have an image tagged "tag1", that should not cause this policy to be ignored
+	// because there are matching images that do not have that tag.
+	deletingTagPolicyJSON := `{"match_repository":".*","match_tag":"tag2","except_tag":"tag1","block_delete":true}`
 	test.MustExec(t, s.DB, `UPDATE accounts SET tag_policies_json = $1`, "["+deletingTagPolicyJSON+"]")
 	s.RespondTo(ctx, "DELETE /keppel/v1/accounts/test1/repositories/repo1-3", withPerms("delete:tenant1,view:tenant1")).
-		ExpectText(t, http.StatusConflict, "cannot delete manifest because it is protected by tag policy ({\"match_repository\":\".*\",\"block_delete\":true})\n")
+		ExpectText(t, http.StatusConflict, fmt.Sprintf("cannot delete manifest %s because it is protected by tag policy ({\"match_repository\":\".*\",\"match_tag\":\"tag2\",\"except_tag\":\"tag1\",\"block_delete\":true})\n", test.DeterministicDummyDigest(2)))
 	test.MustExec(t, s.DB, `UPDATE accounts SET tag_policies_json = '[]'`)
 
 	// test DELETE happy case

--- a/internal/processor/manifests.go
+++ b/internal/processor/manifests.go
@@ -882,11 +882,12 @@ func (p *Processor) downloadManifestViaPullDelegation(ctx context.Context, image
 // DeleteManifestBlockedByTagPolicyError is returned from DeleteManifest when
 // the manifest cannot be deleted because it is protected by a tag policy.
 type DeleteManifestBlockedByTagPolicyError struct {
+	Digest digest.Digest
 	Policy keppel.TagPolicy
 }
 
 func (e DeleteManifestBlockedByTagPolicyError) Error() string {
-	return fmt.Sprintf("cannot delete manifest because it is protected by tag policy (%s)", e.Policy.String())
+	return fmt.Sprintf("cannot delete manifest %s because it is protected by tag policy (%s)", e.Digest.String(), e.Policy.String())
 }
 
 // DeleteManifest deletes the given manifest from both the database and the
@@ -911,7 +912,7 @@ func (p *Processor) DeleteManifest(ctx context.Context, account models.ReducedAc
 
 	for _, tagPolicy := range tagPolicies {
 		if tagPolicy.BlockDelete && tagPolicy.MatchesRepository(repo.Name) && tagPolicy.MatchesTags(tags) {
-			return keppel.ErrDenied.WithError(DeleteManifestBlockedByTagPolicyError{tagPolicy}).WithStatus(http.StatusConflict)
+			return keppel.ErrDenied.WithError(DeleteManifestBlockedByTagPolicyError{manifestDigest, tagPolicy}).WithStatus(http.StatusConflict)
 		}
 	}
 


### PR DESCRIPTION
When considering a repository deletion request, the previous logic evaluated tag policies by looking at all tags of all images at once. This is incorrect, because tag policies can have negative matches, but those should only apply per manifest, not for all manifests of a repo as a whole. If the policy is "block deletion if tagged `.*latest`, but not if tagged `.*testingonly`", the previous logic would allow to delete a repo containing an image tagged `foo-latest` if there is also another unrelated image tagged `bar-testingonly` in the same repo.