### PR TITLE
check manifests and Trivy reports in expectStorageEmpty()

### DIFF
--- a/internal/api/registry/shared_test.go
+++ b/internal/api/registry/shared_test.go
@@ -224,6 +224,26 @@ func expectStorageEmpty(t *testing.T, sd *trivial.StorageDriver, db *oblast.DB) 
 	if count > 0 {
 		t.Errorf("expected 0 uploads in the DB, but found %d uploads", count)
 	}
+
+	// same checks for manifests
+	for _, table := range []string{"manifests", "manifest_contents"} {
+		count = must.ReturnT(keppel.SelectOneValue[uint64](db, `SELECT COUNT(*) FROM `+table))(t)
+		if count > 0 {
+			t.Errorf("expected 0 %s in the DB, but found %d %[1]s", table, count)
+		}
+	}
+	if sd.ManifestCount() > 0 {
+		t.Errorf("expected 0 blobs in the storage, but found %d blobs", sd.BlobCount())
+	}
+
+	// same checks for Trivy reports
+	count = must.ReturnT(keppel.SelectOneValue[uint64](db, `SELECT COUNT(*) FROM trivy_security_info`))(t)
+	if count > 0 {
+		t.Errorf("expected 0 Trivy reports in the DB, but found %d Trivy reports", count)
+	}
+	if sd.TrivyReportCount() > 0 {
+		t.Errorf("expected 0 Trivy reports in the storage, but found %d Trivy reports", sd.BlobCount())
+	}
 }
 
 //nolint:unparam

--- a/internal/drivers/trivial/storage.go
+++ b/internal/drivers/trivial/storage.go
@@ -473,18 +473,26 @@ func (d *StorageDriver) CleanupAccount(ctx context.Context, account models.Reduc
 	return err
 }
 
-// BlobCount returns how many blobs exist in this storage driver. This is mostly
-// used to validate that failure cases do not commit data to the storage.
+// BlobCount returns how many blobs exist in this storage driver.
+// This is used to validate that failure cases do not commit data to the storage.
 func (d *StorageDriver) BlobCount() int {
 	d.blobsMutex.RLock()
 	defer d.blobsMutex.RUnlock()
 	return len(d.blobs)
 }
 
-// ManifestCount returns how many manifests exist in this storage driver. This is mostly
-// used to validate that failure cases do not commit data to the storage.
+// ManifestCount returns how many manifests exist in this storage driver.
+// This is used to validate that failure cases do not commit data to the storage.
 func (d *StorageDriver) ManifestCount() int {
 	d.manifestMutex.RLock()
 	defer d.manifestMutex.RUnlock()
 	return len(d.manifests)
+}
+
+// TrivyReportCount returns how many Trivy reports exist in this storage driver.
+// This is used to validate that failure cases do not commit data to the storage.
+func (d *StorageDriver) TrivyReportCount() int {
+	d.trivyReportsMutex.RLock()
+	defer d.trivyReportsMutex.RUnlock()
+	return len(d.trivyReports)
 }


### PR DESCRIPTION
It was an oversight to only consider blobs in that function; I probably forgot to finish the implementation when I added it in 2020. We found this by noticing the otherwise unused ManifestCount() method in the unit-test storage driver.