### PR TITLE
api/registry: reflect firstpulls from replica to external replica

### DIFF
--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -267,12 +267,36 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 		return nil, nil, nil, nil
 	}
 
+	requestingUserType := authz.UserIdentity.UserType()
+	if authz.UserIdentity.UserType() == keppel.PeerUser {
+		// if another Keppel is performing requests on a user's behalf,
+		// access checks are usually contingent on that user's type
+		// (cf. long comment in mayReplicateManifest())
+		if userType, ok := keppel.ParseUserType(r.Header.Get("X-Keppel-Requesting-User-Type")).Unpack(); ok {
+			requestingUserType = userType
+		}
+	}
+
 	canCreateRepoIfMissing := false
 	switch strategy {
 	case createRepoIfMissing:
 		canCreateRepoIfMissing = true
 	case createRepoIfMissingAndReplica:
-		canCreateRepoIfMissing = account.UpstreamPeerHostName != "" || (account.ExternalPeerURL != "" && (authz.UserIdentity.UserType() == keppel.RegularUser || authz.ScopeSet.AllowsAnonymousFirstPullOn(scope.ResourceName)))
+		switch {
+		case account.UpstreamPeerHostName != "":
+			// on (internal) replica accounts, may always create missing repos to replicate images
+			canCreateRepoIfMissing = true // on replicas
+		case account.ExternalPeerURL != "":
+			// on external replica accounts, may create missing repos if acting as a regular user or as an anon user with firstpull privilege
+			if requestingUserType == keppel.RegularUser {
+				canCreateRepoIfMissing = true
+			} else {
+				canCreateRepoIfMissing = authz.ScopeSet.AllowsAnonymousFirstPullOn(scope.ResourceName)
+			}
+		default:
+			// on non-replica accounts, do not create repos until something is uploaded
+			canCreateRepoIfMissing = false
+		}
 	}
 
 	var repo models.ReducedRepository
@@ -282,7 +306,7 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 		repo, err = keppel.FindReducedRepository(ctx, a.db, repoScope.RepositoryName, account.Name)
 	}
 	if errors.Is(err, sql.ErrNoRows) {
-		if strategy == createRepoIfMissingAndReplica && account.ExternalPeerURL != "" && authz.UserIdentity.UserType() == keppel.AnonymousUser {
+		if strategy == createRepoIfMissingAndReplica && account.ExternalPeerURL != "" && requestingUserType == keppel.AnonymousUser {
 			rerr := keppel.ErrDenied.With("repository does not exist here, and anonymous users may not create new repositories")
 			// this must be a 401 and include a challenge; clients should be able to understand that
 			// they can retry this after authenticating and expect a different result

--- a/internal/api/registry/manifests.go
+++ b/internal/api/registry/manifests.go
@@ -55,7 +55,7 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 
 	if errors.Is(err, sql.ErrNoRows) {
 		// if the manifest does not exist there, we may have the option of replicating from upstream
-		tryReplication, rerr := mayReplicateManifest(*account, *repo, *authz, *challenge)
+		tryReplication, rerr := mayReplicateManifest(*account, *authz, *challenge, r)
 		if rerr != nil {
 			rerr.WriteAsRegistryV2ResponseTo(w, r)
 			return
@@ -215,7 +215,7 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 
 // Checks whether the requesting user may replicate missing manifests in this account/repo.
 // If not, returns either false (to render a regular 404 response) or an error (to render a custom response).
-func mayReplicateManifest(account models.ReducedAccount, repo models.ReducedRepository, authz auth.Authorization, challenge auth.Challenge) (bool, *keppel.RegistryV2Error) {
+func mayReplicateManifest(account models.ReducedAccount, authz auth.Authorization, challenge auth.Challenge, r *http.Request) (bool, *keppel.RegistryV2Error) {
 	// check account eligibility
 	if account.UpstreamPeerHostName == "" && account.ExternalPeerURL == "" {
 		return false, nil // not a replica account of any kind
@@ -230,14 +230,28 @@ func mayReplicateManifest(account models.ReducedAccount, repo models.ReducedRepo
 		return false, nil // our internal Trivy instance may only check images that are already replicated
 	}
 	if userType == keppel.PeerUser {
-		// other Keppels replicating from us always see the true 404 to properly replicate
-		// the non-existence of the manifest from this account into the replica account
+		// other Keppels replicating from us usually see the true state of the manifest
+		//
+		// (esp. for the case where this account is an external replica, and the other Keppel holds a replica of it,
+		// when a user deletes a replicated image here, we want this deletion to be replicated into the replica,
+		// so we need to report 404 here; though usually replication between Keppel is handled by the specialized
+		// manifest-sync API, this fallback path should also have the same effect)
+		//
+		// HOWEVER: authenticated users interacting with a replica in a different Keppel should be able to trigger
+		// a replication in the external replica here (i.e. replication from external -> external replica -> replica
+		// should be possible with a single request to the internal replica account), so we do allow replication
+		// by a PeerUser if it is acting on behalf of a RegularUser with appropriate permissions
+		if account.ExternalPeerURL != "" {
+			if r.Header.Get("X-Keppel-Requesting-User-Type") == keppel.RegularUser.String() {
+				return true, nil
+			}
+		}
 		return false, nil
 	}
 
 	// when replicating from external, only authenticated users can trigger the replication
 	if account.ExternalPeerURL != "" && userType != keppel.RegularUser {
-		if !authz.ScopeSet.AllowsAnonymousFirstPullOn(repo.FullName()) {
+		if !authz.ScopeSet.AllowsAnonymousFirstPullOn(mux.Vars(r)["repository"]) {
 			rerr := keppel.ErrDenied.With("image does not exist here, and anonymous users may not replicate images")
 			// this must be a 401 and include a challenge; clients should be able to understand that
 			// they can retry this after authenticating and expect a different result

--- a/internal/api/registry/manifests.go
+++ b/internal/api/registry/manifests.go
@@ -22,6 +22,7 @@ import (
 	accept "github.com/timewasted/go-accept-headers"
 
 	"github.com/sapcc/keppel/internal/api"
+	"github.com/sapcc/keppel/internal/auth"
 	"github.com/sapcc/keppel/internal/keppel"
 	"github.com/sapcc/keppel/internal/models"
 	"github.com/sapcc/keppel/internal/processor"
@@ -53,23 +54,14 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-		// if the manifest does not exist there, we may have the option of replicating
-		// from upstream (as an exception, other Keppels replicating from us always
-		// see the true 404 to properly replicate the non-existence of the manifest
-		// from this account into the replica account)
-		userType := authz.UserIdentity.UserType()
-		if (account.UpstreamPeerHostName != "" || account.ExternalPeerURL != "") && !account.IsDeleting && (userType != keppel.PeerUser && userType != keppel.TrivyUser) {
-			// when replicating from external, only authenticated users can trigger the replication
-			if account.ExternalPeerURL != "" && userType != keppel.RegularUser {
-				if !authz.ScopeSet.AllowsAnonymousFirstPullOn(mux.Vars(r)["repository"]) {
-					rerr := keppel.ErrDenied.With("image does not exist here, and anonymous users may not replicate images")
-					// this must be a 401 and include a challenge; clients should be able to understand that
-					// they can retry this after authenticating and expect a different result
-					challenge.AddTo(rerr).WithStatus(http.StatusUnauthorized).WriteAsRegistryV2ResponseTo(w, r)
-					return
-				}
-			}
+		// if the manifest does not exist there, we may have the option of replicating from upstream
+		tryReplication, rerr := mayReplicateManifest(*account, *repo, *authz, *challenge)
+		if rerr != nil {
+			rerr.WriteAsRegistryV2ResponseTo(w, r)
+			return
+		}
 
+		if tryReplication {
 			tagPolicies, err := api.GetTagPolicies(a.db, *account)
 			if respondWithError(w, r, err) {
 				return
@@ -219,6 +211,41 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+}
+
+// Checks whether the requesting user may replicate missing manifests in this account/repo.
+// If not, returns either false (to render a regular 404 response) or an error (to render a custom response).
+func mayReplicateManifest(account models.ReducedAccount, repo models.ReducedRepository, authz auth.Authorization, challenge auth.Challenge) (bool, *keppel.RegistryV2Error) {
+	// check account eligibility
+	if account.UpstreamPeerHostName == "" && account.ExternalPeerURL == "" {
+		return false, nil // not a replica account of any kind
+	}
+	if account.IsDeleting {
+		return false, nil // refuse to add new images to an account that is being deleted
+	}
+
+	// check user eligibility
+	userType := authz.UserIdentity.UserType()
+	if userType == keppel.TrivyUser {
+		return false, nil // our internal Trivy instance may only check images that are already replicated
+	}
+	if userType == keppel.PeerUser {
+		// other Keppels replicating from us always see the true 404 to properly replicate
+		// the non-existence of the manifest from this account into the replica account
+		return false, nil
+	}
+
+	// when replicating from external, only authenticated users can trigger the replication
+	if account.ExternalPeerURL != "" && userType != keppel.RegularUser {
+		if !authz.ScopeSet.AllowsAnonymousFirstPullOn(repo.FullName()) {
+			rerr := keppel.ErrDenied.With("image does not exist here, and anonymous users may not replicate images")
+			// this must be a 401 and include a challenge; clients should be able to understand that
+			// they can retry this after authenticating and expect a different result
+			return false, challenge.AddTo(rerr).WithStatus(http.StatusUnauthorized)
+		}
+	}
+
+	return true, nil
 }
 
 func (a *API) findManifestInDB(ctx context.Context, repo models.ReducedRepository, reference models.ManifestReference) (*models.Manifest, error) {

--- a/internal/api/registry/replication_test.go
+++ b/internal/api/registry/replication_test.go
@@ -391,7 +391,7 @@ func TestReplicationFailingOverIntoPullDelegation(t *testing.T) {
 			requestCounter := 0
 			tertiaryHandler := func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
-					http.Error(w, r.Method+"not allowed", http.StatusMethodNotAllowed)
+					http.Error(w, r.Method+" not allowed", http.StatusMethodNotAllowed)
 					return
 				}
 				for _, blob := range append(image.Layers, image.Config) {
@@ -415,6 +415,7 @@ func TestReplicationFailingOverIntoPullDelegation(t *testing.T) {
 					w.Write(image.Manifest.Contents)
 					return
 				}
+				http.NotFound(w, r)
 			}
 			http.DefaultTransport.(*test.RoundTripper).Handlers["registry-tertiary.example.org"] = http.HandlerFunc(tertiaryHandler)
 
@@ -437,6 +438,75 @@ func TestReplicationFailingOverIntoPullDelegation(t *testing.T) {
 			s1.RespondTo(ctx, "GET /v2/test1/foo/manifests/"+image.Manifest.Digest.String(),
 				httptest.WithHeaders(tokenHeaders1),
 			).ExpectJSON(t, http.StatusTooManyRequests, test.ErrorCode(keppel.ErrTooManyRequests))
+		})
+	})
+}
+
+func TestReplicationChainedFromExternalToInternalReplica(t *testing.T) {
+	// Another test with three registries: registry-external is fully mocked,
+	// s1 holds an external replica of that, s2 holds a replica of s1.
+	//
+	// We test that a regular user pulling from s2 can replicate all the way all at once,
+	// whereas an anonymous user will get rejected on s2 the same as it would on s1.
+	testWithPrimary(t, nil, func(s1 test.Setup) {
+		ctx := t.Context()
+		testWithReplica(t, s1, "on_first_use", func(firstPass bool, s2 test.Setup) {
+			if !firstPass {
+				return // no second pass needed
+			}
+
+			// setup registry-external as a mostly static responder
+			image := test.GenerateImage(test.GenerateExampleLayer(1))
+			externalHandler := func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					http.Error(w, r.Method+" not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				for _, blob := range append(image.Layers, image.Config) {
+					if r.URL.Path == "/v2/foo/blobs/"+blob.Digest.String() {
+						w.Header().Set("Content-Length", strconv.Itoa(len(blob.Contents)))
+						w.WriteHeader(http.StatusOK)
+						w.Write(blob.Contents)
+						return
+					}
+				}
+				if r.URL.Path == "/v2/foo/manifests/latest" {
+					w.Header().Set("Content-Type", image.Manifest.MediaType)
+					w.Header().Set("Content-Length", strconv.Itoa(len(image.Manifest.Contents)))
+					w.WriteHeader(http.StatusOK)
+					w.Write(image.Manifest.Contents)
+					return
+				}
+				http.NotFound(w, r)
+			}
+			http.DefaultTransport.(*test.RoundTripper).Handlers["registry-external.example.org"] = http.HandlerFunc(externalHandler)
+
+			// reconfigure "test1" on primary into an external replica
+			test.MustExec(t, s1.DB, `UPDATE accounts SET external_peer_url = $2 WHERE name = $1`,
+				"test1", "registry-external.example.org")
+
+			// anonymous user on both accounts gets rejected in the same way...
+			for _, s := range []test.Setup{s1, s2} {
+				t.Run("host="+s.Config.APIPublicHostname, func(t *testing.T) {
+					// even when anonymous pull is enabled (because that's not the same as anonymous first pull)
+					test.MustExec(t, s.DB, `UPDATE accounts SET rbac_policies_json = $2 WHERE name = $1`, "test1",
+						test.ToJSON([]keppel.RBACPolicy{{
+							RepositoryPattern: ".*",
+							Permissions:       []keppel.RBACPermission{keppel.RBACAnonymousPullPermission},
+						}}),
+					)
+					anonTokenHeaders := s.GetAnonTokenHeaders(t, "repository:test1/foo", []string{"pull"})
+					s.RespondTo(ctx, "GET /v2/test1/foo/manifests/latest", httptest.WithHeaders(anonTokenHeaders)).
+						ExpectJSON(t, http.StatusUnauthorized, test.ErrorCodeWithMessage{
+							Code:    keppel.ErrDenied,
+							Message: "repository does not exist here, and anonymous users may not create new repositories",
+						})
+				})
+			}
+
+			// ... but an authenticated user on s2 triggers replication both into s1 and s2
+			tokenHeaders := s2.GetTokenHeaders(t, "repository:test1/foo:pull")
+			expectManifestExists(t, s2, tokenHeaders, "test1/foo", image.Manifest, "latest")
 		})
 	})
 }

--- a/internal/keppel/user_identity.go
+++ b/internal/keppel/user_identity.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/pluggable"
+	. "go.xyrillian.de/gg/option"
 )
 
 // UserType is an enum that identifies the general type of user. User types are
@@ -28,6 +29,36 @@ const (
 	// JanitorUser is a dummy UserType for when the janitor needs an Authorization for audit logging purposes.
 	JanitorUser
 )
+
+var validUserTypes = []UserType{RegularUser, AnonymousUser, PeerUser, TrivyUser, JanitorUser}
+
+// String converts this UserType into a string representation.
+func (u UserType) String() string {
+	switch u {
+	case RegularUser:
+		return "regular"
+	case AnonymousUser:
+		return "anonymous"
+	case PeerUser:
+		return "peer"
+	case TrivyUser:
+		return "trivy"
+	case JanitorUser:
+		return "janitor"
+	default:
+		panic(fmt.Sprintf("unknown UserType value: %d", u))
+	}
+}
+
+// ParseUserType reverses the effect of [UserType.String], returning None for invalid inputs.
+func ParseUserType(value string) Option[UserType] {
+	for _, u := range validUserTypes {
+		if u.String() == value {
+			return Some(u)
+		}
+	}
+	return None[UserType]()
+}
 
 // UserIdentity describes the identity and access rights of a user. For regular
 // users, it is returned by methods in the AuthDriver interface. For all other

--- a/internal/processor/manifests.go
+++ b/internal/processor/manifests.go
@@ -698,7 +698,15 @@ func (e UpstreamManifestMissingError) Error() string {
 // ReplicateManifest replicates the manifest from its account's upstream registry.
 // On success, the manifest's metadata and contents are returned.
 func (p *Processor) ReplicateManifest(ctx context.Context, account models.ReducedAccount, repo models.ReducedRepository, reference models.ManifestReference, tagPolicies []keppel.TagPolicy, actx keppel.AuditContext) (*models.Manifest, []byte, error) {
-	manifestBytes, manifestMediaType, err := p.downloadManifestViaInboundCache(ctx, account, repo, reference)
+	// when replicating from another Keppel, include a hint about the type of requesting user
+	// (cf. usage of this header in internal/api/registry for why this is necessary)
+	var extraHeaders http.Header
+	if account.UpstreamPeerHostName != "" {
+		extraHeaders = make(http.Header)
+		extraHeaders.Set("X-Keppel-Requesting-User-Type", actx.UserIdentity.UserType().String())
+	}
+
+	manifestBytes, manifestMediaType, err := p.downloadManifestViaInboundCache(ctx, account, repo, reference, extraHeaders)
 	if err != nil {
 		if errorIsManifestNotFound(err) {
 			return nil, nil, UpstreamManifestMissingError{reference, err}
@@ -769,7 +777,7 @@ func (p *Processor) ReplicateManifest(ctx context.Context, account models.Reduce
 // upstream registry. If not, false is returned, An error is returned only if
 // the account is not a replica, or if the upstream registry cannot be queried.
 func (p *Processor) CheckManifestOnPrimary(ctx context.Context, account models.ReducedAccount, repo models.ReducedRepository, reference models.ManifestReference) (bool, error) {
-	_, _, err := p.downloadManifestViaInboundCache(ctx, account, repo, reference)
+	_, _, err := p.downloadManifestViaInboundCache(ctx, account, repo, reference, nil)
 	if err != nil {
 		if errorIsManifestNotFound(err) {
 			return false, nil
@@ -799,7 +807,7 @@ func errorIsUpstreamRateLimit(err error) bool {
 
 // Downloads a manifest from an account's upstream using
 // RepoClient.DownloadManifest(), but also takes into account the inbound cache.
-func (p *Processor) downloadManifestViaInboundCache(ctx context.Context, account models.ReducedAccount, repo models.ReducedRepository, ref models.ManifestReference) (manifestBytes []byte, manifestMediaType string, err error) {
+func (p *Processor) downloadManifestViaInboundCache(ctx context.Context, account models.ReducedAccount, repo models.ReducedRepository, ref models.ManifestReference, extraHeaders http.Header) (manifestBytes []byte, manifestMediaType string, err error) {
 	c, err := p.getRepoClientForUpstream(ctx, account, repo)
 	if err != nil {
 		return nil, "", err
@@ -824,6 +832,7 @@ func (p *Processor) downloadManifestViaInboundCache(ctx context.Context, account
 	// cache miss -> download from actual upstream registry
 	manifestBytes, manifestMediaType, err = c.DownloadManifest(ctx, ref, &client.DownloadManifestOpts{
 		DoNotCountTowardsLastPulled: true,
+		ExtraHeaders:                extraHeaders,
 	})
 	if err != nil && account.ExternalPeerURL != "" && errorIsUpstreamRateLimit(err) {
 		// when a pull from an external registry runs into a rate limit, ask a


### PR DESCRIPTION
When pulling from a replica account whose upstream is an external replica account, users may now initiate replication on the replica account, and Keppel will propagate it to the external replica in one go. Users thus will no longer have to manually interact with the external replica account first. Pulling from any replica will have the desired effect.

Most of the work here is from propagating the UserType of the original requester to the Keppel holding the external replica account, so that we can properly tell anonymous users that they need to be authenticated to proceed.