### PR TITLE
drivers/swift: work around SLO manifest retrieval not working in Ceph

### DIFF
--- a/docs/drivers/storage-swift.md
+++ b/docs/drivers/storage-swift.md
@@ -20,5 +20,6 @@ The following parameters may be supplied in `$KEPPEL_DRIVER_STORAGE`:
 
 | Field | Type | Explanation |
 | ----- | ---- | ----------- |
+| `apply_workarounds_for_ceph` | bool | *(optional)* Set to true when using Ceph's Swift-compatible API to work around known bugs. |
 | `service_type` | string | *(optional)* Service type for Swift in the Keystone service catalog. Defaults to `object-store` for native Swift, but can be set to e.g. `object-store-ceph` to use Ceph's Swift-compatible API. |
 | `use_service_user_project` | bool | *(optional)* When set to `true`, stores all payload in the service user's own project instead of in the project owning the respective Keppel account. Defaults to `false`. |

--- a/internal/drivers/openstack/swift.go
+++ b/internal/drivers/openstack/swift.go
@@ -37,8 +37,9 @@ type swiftContainerInfo struct {
 }
 
 type swiftDriver struct {
-	ServiceType           string `json:"service_type"`
-	UseServiceUserProject bool   `json:"use_service_user_project"`
+	ServiceType             string `json:"service_type"`
+	UseServiceUserProject   bool   `json:"use_service_user_project"`
+	ApplyWorkaroundsForCeph bool   `json:"apply_workarounds_for_ceph"`
 
 	mainAccount         *schwift.Account
 	containerInfos      map[models.AccountName]*swiftContainerInfo
@@ -294,7 +295,24 @@ func (d *swiftDriver) DeleteBlob(ctx context.Context, account models.ReducedAcco
 	if err != nil {
 		return err
 	}
-	err = c.Object(stringy.BlobObjectName(storageID)).Delete(ctx, &schwift.DeleteOptions{DeleteSegments: true}, nil)
+	obj := c.Object(stringy.BlobObjectName(storageID))
+
+	if d.ApplyWorkaroundsForCeph {
+		// Ceph codepath: Ceph does not understand ?multipart-manifest=get, so we need to enumerate chunks on our own
+		iter := c.Objects()
+		iter.Prefix = stringy.ChunkObjectPrefix(storageID)
+		objects, err := iter.Collect(ctx)
+		if err != nil {
+			return fmt.Errorf("while enumerating chunks of %s: %w", obj.Name(), err)
+		}
+		objects = append(objects, obj) // delete the blob together with its chunks
+		_, _, err = c.Account().BulkDelete(ctx, objects, nil, nil)
+		reportObjectErrorsIfAny("DeleteBlob", err)
+		return err
+	}
+
+	// regular codepath: let Schwift figure out what to delete via ?multipart-manifest=get
+	err = obj.Delete(ctx, &schwift.DeleteOptions{DeleteSegments: true}, nil)
 	reportObjectErrorsIfAny("DeleteBlob", err)
 	return err
 }

--- a/internal/stringy/swift_object_names.go
+++ b/internal/stringy/swift_object_names.go
@@ -18,8 +18,14 @@ func BlobObjectName(storageID string) string {
 
 // ChunkObjectName builds the name under which a chunk with the provided storage ID and chunk number will be stored in a Swift container.
 func ChunkObjectName(storageID string, chunkNumber uint32) string {
-	//NOTE: uint32 numbers never have more than 10 digits
+	// NOTE: uint32 numbers never have more than 10 digits
 	return fmt.Sprintf("_chunks/%s/%s/%s/%010d", storageID[0:2], storageID[2:4], storageID[4:], chunkNumber)
+}
+
+// ChunkObjectPrefix returns the common prefix of all values returned by ChunkObjectName for the given storageID.
+// It can be used to list chunk objects for a single blob.
+func ChunkObjectPrefix(storageID string) string {
+	return fmt.Sprintf("_chunks/%s/%s/%s/", storageID[0:2], storageID[2:4], storageID[4:])
 }
 
 // ManifestObjectName builds the name under which a manifest with the provided repository name and digest will be stored in a Swift container.

--- a/internal/stringy/swift_object_names_test.go
+++ b/internal/stringy/swift_object_names_test.go
@@ -4,13 +4,14 @@
 package stringy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
 	"go.xyrillian.de/gg/assert"
 )
 
-var (
+const (
 	storageID         string        = "bd1df5ffd83b94f365adc7b9011e2079856cd4aa401ee19b6cdfcffcecad7a61"
 	manifestDigest    digest.Digest = digest.Digest("sha256:1d6f90850896f753a6c4c5d8edc7086f0290ce90a34d92439c30d1257f44979f")
 	repoName          string        = "foo-repository"
@@ -56,6 +57,9 @@ func TestParseChunkObject(t *testing.T) {
 	}
 	assert.Equal(t, parsedStorageID, storageID)
 	assert.Equal(t, parsedChunkNumber, chunkNumber)
+
+	// ChunkObjectPrefix must be a true prefix of ChunkObjectName
+	assert.Equal(t, strings.HasPrefix(objName, ChunkObjectPrefix(storageID)), true)
 }
 
 func TestParseManifestObject(t *testing.T) {


### PR DESCRIPTION
Listing chunks of a multipart object via `?multipart-manifest=get` is broken in current Ceph (it just returns `Content-Length: 0`), so this lists chunks by hand and delete them.