### PR TITLE
drivers/swift: use account tempurl key for UseServiceUserProject = true

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -55,7 +55,7 @@ func run(cmd *cobra.Command, args []string) {
 	rc := must.Return(initRedis())
 	ad := must.Return(keppel.NewAuthDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_AUTH"), rc))
 	fd := must.Return(keppel.NewFederationDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_FEDERATION"), ad, cfg))
-	sd := must.Return(keppel.NewStorageDriver(osext.MustGetenv("KEPPEL_DRIVER_STORAGE"), ad, cfg))
+	sd := must.Return(keppel.NewStorageDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_STORAGE"), ad, cfg))
 	icd := must.Return(keppel.NewInboundCacheDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_INBOUND_CACHE"), cfg))
 
 	rle := (*keppel.RateLimitEngine)(nil)

--- a/cmd/janitor/main.go
+++ b/cmd/janitor/main.go
@@ -43,7 +43,7 @@ func run(cmd *cobra.Command, args []string) {
 	ad := must.Return(keppel.NewAuthDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_AUTH"), nil))
 	amd := must.Return(keppel.NewAccountManagementDriver(osext.MustGetenv("KEPPEL_DRIVER_ACCOUNT_MANAGEMENT")))
 	fd := must.Return(keppel.NewFederationDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_FEDERATION"), ad, cfg))
-	sd := must.Return(keppel.NewStorageDriver(osext.MustGetenv("KEPPEL_DRIVER_STORAGE"), ad, cfg))
+	sd := must.Return(keppel.NewStorageDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_STORAGE"), ad, cfg))
 	icd := must.Return(keppel.NewInboundCacheDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_INBOUND_CACHE"), cfg))
 
 	// start task loops

--- a/cmd/liquidapi/main.go
+++ b/cmd/liquidapi/main.go
@@ -42,7 +42,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	db := keppel.InitDB()
 	ad := must.Return(keppel.NewAuthDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_AUTH"), nil))
-	sd := must.Return(keppel.NewStorageDriver(osext.MustGetenv("KEPPEL_DRIVER_STORAGE"), ad, cfg))
+	sd := must.Return(keppel.NewStorageDriver(ctx, osext.MustGetenv("KEPPEL_DRIVER_STORAGE"), ad, cfg))
 
 	// wire up HTTP handlers
 	handler := httpapi.Compose(

--- a/cmd/test/storage.go
+++ b/cmd/test/storage.go
@@ -173,7 +173,7 @@ func wrapStorageCommand(action func(context.Context, keppel.StorageDriver, model
 			must.Return(json.Marshal(storageDriverType)),
 			storageDriverParamsJSON,
 		)
-		sd := must.Return(keppel.NewStorageDriver(storageConfig, ad, cfg))
+		sd := must.Return(keppel.NewStorageDriver(ctx, storageConfig, ad, cfg))
 
 		action(ctx, sd, account, args)
 	}

--- a/internal/drivers/filesystem/storage.go
+++ b/internal/drivers/filesystem/storage.go
@@ -34,7 +34,7 @@ type StorageDriver struct {
 func (d *StorageDriver) PluginTypeID() string { return "filesystem" }
 
 // Init implements the keppel.StorageDriver interface.
-func (d *StorageDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) (err error) {
+func (d *StorageDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) (err error) {
 	d.RootPath, err = filepath.Abs(d.RootPath)
 	return err
 }

--- a/internal/drivers/openstack/swift.go
+++ b/internal/drivers/openstack/swift.go
@@ -54,7 +54,7 @@ func init() {
 func (d *swiftDriver) PluginTypeID() string { return "swift" }
 
 // Init implements the keppel.StorageDriver interface.
-func (d *swiftDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) error {
+func (d *swiftDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) error {
 	k, ok := ad.(*keystoneDriver)
 	if !ok {
 		return keppel.ErrAuthDriverMismatch

--- a/internal/drivers/openstack/swift.go
+++ b/internal/drivers/openstack/swift.go
@@ -41,7 +41,12 @@ type swiftDriver struct {
 	UseServiceUserProject   bool   `json:"use_service_user_project"`
 	ApplyWorkaroundsForCeph bool   `json:"apply_workarounds_for_ceph"`
 
-	mainAccount         *schwift.Account
+	mainAccount *schwift.Account
+
+	// NOTE: This is only used if UseServiceUserProject == true.
+	mainTempURLKey string
+
+	// NOTE: This is only used if UseServiceUserProject == false.
 	containerInfos      map[models.AccountName]*swiftContainerInfo
 	containerInfosMutex sync.RWMutex
 }
@@ -72,7 +77,33 @@ func (d *swiftDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel
 		return err
 	}
 	d.mainAccount.ModifyReportedCapabilities(fixCapabilities)
-	d.containerInfos = make(map[models.AccountName]*swiftContainerInfo)
+
+	if d.UseServiceUserProject {
+		// with UseServiceUserProject = true, we will be taking the tempurl key from account level
+		hdr, err := d.mainAccount.Headers(ctx)
+		if err != nil {
+			return err
+		}
+		d.mainTempURLKey = cmp.Or(hdr.TempURLKey().Get(), hdr.TempURLKey2().Get())
+
+		// generate tempurl key if none exists yet
+		if d.mainTempURLKey == "" {
+			d.mainTempURLKey, err = generateSecret()
+			if err != nil {
+				return err
+			}
+			hdr := schwift.NewAccountHeaders()
+			hdr.TempURLKey().Set(d.mainTempURLKey)
+			err = d.mainAccount.Update(ctx, hdr, nil)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// with UseServiceUserProject = false, we will be issuing tempurl keys per container in getBackendConnection()
+		d.containerInfos = make(map[models.AccountName]*swiftContainerInfo)
+	}
+
 	return nil
 }
 
@@ -105,14 +136,21 @@ func (d *swiftDriver) getBackendContainerName(account models.ReducedAccount) str
 	return "keppel-" + string(account.Name)
 }
 
-func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.ReducedAccount) (*schwift.Container, *swiftContainerInfo, error) {
+func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.ReducedAccount) (_ *schwift.Container, tempURLKey string, _ error) {
 	c := d.getBackendAccount(account.AuthTenantID).Container(d.getBackendContainerName(account))
 
-	// we want to cache the tempurl key to speed up URLForBlob() calls; but we
+	// if all containers are in the same account, use that account's tempurl key
+	if d.UseServiceUserProject {
+		return c, d.mainTempURLKey, nil
+	}
+
+	// otherwise use the individual tempurl keys of each container
+	//
+	// We want to cache the tempurl key to speed up URLForBlob() calls, but we
 	// cannot cache it indefinitely because the Keppel account (and hence the
 	// Swift container) may get deleted and later re-created with a different
-	// tempurl key; by only caching tempurl keys for a few minutes, we get the
-	// opportunity to self-heal when the tempurl key changes
+	// tempurl key. By only caching tempurl keys for a few minutes, we get the
+	// opportunity to self-heal when the tempurl key changes.
 	d.containerInfosMutex.RLock()
 	info := d.containerInfos[account.Name]
 	d.containerInfosMutex.RUnlock()
@@ -121,7 +159,7 @@ func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.R
 		// get container metadata (404 is not a problem, in that case we will create the container down below)
 		hdr, err := c.Headers(ctx)
 		if err != nil && !schwift.Is(err, http.StatusNotFound) {
-			return nil, nil, err
+			return nil, "", err
 		}
 
 		tempURLKey := hdr.TempURLKey().Get()
@@ -136,7 +174,7 @@ func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.R
 			if tempURLKey == "" {
 				tempURLKey, err = generateSecret()
 				if err != nil {
-					return nil, nil, err
+					return nil, "", err
 				}
 				hdr.TempURLKey().Set(tempURLKey)
 			}
@@ -147,7 +185,7 @@ func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.R
 			}
 			err = c.Create(ctx, hdr.ToOpts())
 			if err != nil {
-				return nil, nil, err
+				return nil, "", err
 			}
 		}
 
@@ -159,8 +197,7 @@ func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.R
 		d.containerInfos[account.Name] = info
 		d.containerInfosMutex.Unlock()
 	}
-
-	return c, info, nil
+	return c, info.TempURLKey, nil
 }
 
 func generateSecret() (string, error) {
@@ -280,13 +317,13 @@ func (d *swiftDriver) ReadBlob(ctx context.Context, account models.ReducedAccoun
 
 // URLForBlob implements the keppel.StorageDriver interface.
 func (d *swiftDriver) URLForBlob(ctx context.Context, account models.ReducedAccount, storageID string) (string, error) {
-	c, info, err := d.getBackendConnection(ctx, account)
+	c, tempURLKey, err := d.getBackendConnection(ctx, account)
 	if err != nil {
 		return "", err
 	}
 
 	expiresAt := time.Now().Add(20 * time.Minute)
-	return c.Object(stringy.BlobObjectName(storageID)).TempURL(ctx, info.TempURLKey, "GET", expiresAt)
+	return c.Object(stringy.BlobObjectName(storageID)).TempURL(ctx, tempURLKey, "GET", expiresAt)
 }
 
 // DeleteBlob implements the keppel.StorageDriver interface.

--- a/internal/drivers/trivial/storage.go
+++ b/internal/drivers/trivial/storage.go
@@ -70,7 +70,7 @@ type trivyReportKey struct {
 func (d *StorageDriver) PluginTypeID() string { return "in-memory-for-testing" }
 
 // Init implements the keppel.StorageDriver interface.
-func (d *StorageDriver) Init(ad keppel.AuthDriver, cfg keppel.Configuration) error {
+func (d *StorageDriver) Init(ctx context.Context, ad keppel.AuthDriver, cfg keppel.Configuration) error {
 	d.blobs = make(map[blobKey][]byte)
 	d.blobChunkCounts = make(map[blobKey]uint32)
 	d.manifests = make(map[manifestKey][]byte)

--- a/internal/keppel/storage_driver.go
+++ b/internal/keppel/storage_driver.go
@@ -26,7 +26,7 @@ type StorageDriver interface {
 	// perform first-time initialization.
 	//
 	// Implementations should inspect the auth driver to ensure that the
-	// federation driver can work with this authentication method, or return
+	// storage driver can work with this authentication method, or return
 	// ErrAuthDriverMismatch otherwise.
 	Init(context.Context, AuthDriver, Configuration) error
 

--- a/internal/keppel/storage_driver.go
+++ b/internal/keppel/storage_driver.go
@@ -28,7 +28,7 @@ type StorageDriver interface {
 	// Implementations should inspect the auth driver to ensure that the
 	// federation driver can work with this authentication method, or return
 	// ErrAuthDriverMismatch otherwise.
-	Init(AuthDriver, Configuration) error
+	Init(context.Context, AuthDriver, Configuration) error
 
 	// `storageID` identifies blobs within an account. (The storage ID is
 	// different from the digest: The storage ID gets chosen at the start of the
@@ -144,9 +144,9 @@ var StorageDriverRegistry pluggable.Registry[StorageDriver]
 // The supplied config must be a string of the form {"type":"foobar","params":{...}},
 // where `type` is the plugin type ID and `params` is json.Unmarshal()ed into
 // the driver instance to supply driver-specific configuration.
-func NewStorageDriver(configJSON string, ad AuthDriver, cfg Configuration) (StorageDriver, error) {
+func NewStorageDriver(ctx context.Context, configJSON string, ad AuthDriver, cfg Configuration) (StorageDriver, error) {
 	callInit := func(sd StorageDriver) error {
-		return sd.Init(ad, cfg)
+		return sd.Init(ctx, ad, cfg)
 	}
 	return newDriver("KEPPEL_DRIVER_STORAGE", StorageDriverRegistry, configJSON, callInit)
 }

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -295,7 +295,7 @@ func NewSetup(t testing.TB, opts ...SetupOption) Setup {
 	s.AD = ad.(*AuthDriver)
 	fd := must.ReturnT(keppel.NewFederationDriver(s.Ctx, `{"type":"unittest"}`, ad, s.Config))(t)
 	s.FD = fd.(*FederationDriver)
-	sd := must.ReturnT(keppel.NewStorageDriver(`{"type":"in-memory-for-testing"}`, ad, s.Config))(t)
+	sd := must.ReturnT(keppel.NewStorageDriver(s.Ctx, `{"type":"in-memory-for-testing"}`, ad, s.Config))(t)
 	s.SD = sd.(*trivial.StorageDriver)
 	icd := must.ReturnT(keppel.NewInboundCacheDriver(s.Ctx, `{"type":"unittest"}`, s.Config))(t)
 	s.ICD = icd.(*InboundCacheDriver)


### PR DESCRIPTION
This is required for Ceph because it does not support container-level tempurl keys (https://tracker.ceph.com/issues/20862).