### PR TITLE
fix container creation when using Ceph

### DIFF
--- a/internal/drivers/openstack/swift.go
+++ b/internal/drivers/openstack/swift.go
@@ -148,6 +148,12 @@ func (d *swiftDriver) getBackendConnection(ctx context.Context, account models.R
 
 	// if all containers are in the same account, use that account's tempurl key
 	if d.UseServiceUserProject {
+		// we do not have the Create() below that writes the container tempurl key,
+		// so we need to explicitly make sure that the backing container exists
+		_, err := c.EnsureExists(ctx)
+		if err != nil {
+			return nil, "", err
+		}
 		return c, d.mainTempURLKey, nil
 	}
 


### PR DESCRIPTION
In the `UseServiceUserProject = true` path, we never get to the part where we do Create() on the container to set tempurl keys, so the containers are never actually created.