### PR TITLE
Cleanup pending_blobs after OOMkill by emitting a heartbeat every minute

### DIFF
--- a/cmd/janitor/main.go
+++ b/cmd/janitor/main.go
@@ -59,6 +59,7 @@ func run(cmd *cobra.Command, args []string) {
 	go janitor.ManifestSyncJob(nil).Run(ctx)
 	go janitor.BlobValidationJob(nil).Run(ctx)
 	go janitor.ManifestValidationJob(nil).Run(ctx)
+	go janitor.CleanupPendingBlobsJob(nil).Run(ctx)
 	if cfg.Trivy != nil {
 		go janitor.CheckTrivySecurityStatusJob(nil).Run(ctx)
 	}

--- a/internal/keppel/database.go
+++ b/internal/keppel/database.go
@@ -310,6 +310,10 @@ var sqlMigrations = map[int64]string{
 		ALTER TABLE quotas
 			ADD COLUMN bytes BIGINT NOT NULL DEFAULT -1;
 	`,
+	55: `
+		ALTER TABLE pending_blobs
+			ADD COLUMN last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+	`,
 }
 
 // DBInterface is implemented by both [*gsql.DB] and [*gsql.Tx].

--- a/internal/models/pending_blob.go
+++ b/internal/models/pending_blob.go
@@ -16,6 +16,7 @@ type PendingBlob struct {
 	Digest       digest.Digest `db:"digest"`
 	Reason       PendingReason `db:"reason"`
 	PendingSince time.Time     `db:"since"`
+	LastSeenAt   time.Time     `db:"last_seen_at"`
 }
 
 // PendingBlobStore provides loading and storing of [PendingBlob] objects from the DB.

--- a/internal/processor/blobs.go
+++ b/internal/processor/blobs.go
@@ -124,6 +124,7 @@ func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account
 		Digest:       blob.Digest,
 		Reason:       models.PendingBecauseOfReplication,
 		PendingSince: p.timeNow(),
+		LastSeenAt:   p.timeNow(),
 	}
 	err := models.PendingBlobStore.Insert(ctx, p.db, &pendingBlob)
 	if err != nil {
@@ -151,12 +152,40 @@ func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account
 		}
 	}()
 
+	// start a heartbeat so that the janitor does not clean up this entry while it is still replicating
+	replicationCtx, cancelReplication := context.WithCancel(ctx)
+	defer cancelReplication()
+	go func() {
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-replicationCtx.Done():
+				return
+			case <-ticker.C:
+				_, err := p.db.ExecContext(ctx,
+					`UPDATE pending_blobs SET last_seen_at = NOW() WHERE account_name = $1 AND digest = $2`,
+					account.Name, blob.Digest,
+				)
+				if err != nil {
+					if replicationCtx.Err() != nil {
+						return
+					}
+					logg.Error("failed to update heartbeat for pending blob %s in account %s, aborting replication: %s",
+						blob.Digest, account.Name, err.Error())
+					cancelReplication()
+					return
+				}
+			}
+		}
+	}()
+
 	// query upstream for the blob
-	client, err := p.getRepoClientForUpstream(ctx, account, repo)
+	client, err := p.getRepoClientForUpstream(replicationCtx, account, repo)
 	if err != nil {
 		return false, err
 	}
-	blobReadCloser, blobLengthBytes, err := client.DownloadBlob(ctx, blob.Digest)
+	blobReadCloser, blobLengthBytes, err := client.DownloadBlob(replicationCtx, blob.Digest)
 	if err != nil {
 		return false, err
 	}
@@ -172,7 +201,7 @@ func (p *Processor) ReplicateBlob(ctx context.Context, blob models.Blob, account
 		blobReader = io.TeeReader(blobReader, w)
 	}
 
-	err = p.uploadBlobToLocal(ctx, blob, account, blobReader, blobLengthBytes)
+	err = p.uploadBlobToLocal(replicationCtx, blob, account, blobReader, blobLengthBytes)
 	if err != nil {
 		return true, err
 	}

--- a/internal/tasks/pending_blobs.go
+++ b/internal/tasks/pending_blobs.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-bits/jobloop"
+	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/sqlext"
+
+	"github.com/sapcc/keppel/internal/models"
+)
+
+var deleteStalePendingBlobsQuery = sqlext.SimplifyWhitespace(`
+	DELETE FROM pending_blobs
+	WHERE last_seen_at < $1
+	RETURNING *
+`)
+
+// CleanupPendingBlobsJob is a jobloop.Job. Each task deletes all pending_blobs whose heartbeat is older than 1 minute.
+func (j *Janitor) CleanupPendingBlobsJob(registerer prometheus.Registerer) jobloop.Job {
+	return (&jobloop.CronJob{
+		Metadata: jobloop.JobMetadata{
+			ReadableName: "cleanup pending blobs",
+			CounterOpts: prometheus.CounterOpts{
+				Name: "keppel_cleanup_pending_blobs",
+				Help: "Counter for garbage collections on orphaned pending blobs.",
+			},
+		},
+		Interval: 1 * time.Minute,
+		Task:     j.cleanupPendingBlobs,
+	}).Setup(registerer)
+}
+
+func (j *Janitor) cleanupPendingBlobs(ctx context.Context, _ prometheus.Labels) error {
+	maxLastSeenAt := j.timeNow().Add(-1 * time.Minute)
+	return models.PendingBlobStore.Select(ctx, j.db, deleteStalePendingBlobsQuery, maxLastSeenAt).Foreach(func(pendingBlob models.PendingBlob) error {
+		logg.Info("cleaned up stale pending blob %s in account %s", pendingBlob.Digest, pendingBlob.AccountName)
+		return nil
+	})
+}

--- a/internal/tasks/pending_blobs_test.go
+++ b/internal/tasks/pending_blobs_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/sapcc/go-bits/easypg"
+	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
+
+	"github.com/sapcc/keppel/internal/models"
+)
+
+func TestCleanupPendingBlobs(t *testing.T) {
+	j, s := setup(t)
+
+	tr, _ := easypg.NewTracker(t, s.DB.DB)
+	cleanupJob := j.CleanupPendingBlobsJob(s.Registry)
+
+	// right now, there are no pending blobs, so CleanupPendingBlobsJob should report nothing to do
+	assert.ErrEqual(t, cleanupJob.ProcessOne(s.Ctx), nil)
+	tr.DBChanges().AssertEmpty()
+
+	// insert a pending blob into the DB
+	testDigest := digest.Canonical.FromBytes([]byte("test content"))
+	pendingBlob := models.PendingBlob{
+		AccountName:  "test1",
+		Digest:       testDigest,
+		Reason:       models.PendingBecauseOfReplication,
+		PendingSince: s.Clock.Now(),
+		LastSeenAt:   s.Clock.Now(),
+	}
+	must.SucceedT(t, models.PendingBlobStore.Insert(s.Ctx, s.DB, &pendingBlob))
+	tr.DBChanges().AssertEqualf(`
+		INSERT INTO pending_blobs (account_name, digest, reason, since, last_seen_at) VALUES ('test1', '%s', 'replication', %d, %d);
+	`, testDigest, s.Clock.Now().Unix(), s.Clock.Now().Unix(),
+	)
+
+	// the pending blob's heartbeat is too recent (less than 1 minute old), so it should not be cleaned up
+	s.Clock.StepBy(30 * time.Second)
+	assert.ErrEqual(t, cleanupJob.ProcessOne(s.Ctx), nil)
+	tr.DBChanges().AssertEmpty()
+
+	// after 1 minute has passed since the last heartbeat, the pending blob should be cleaned up
+	s.Clock.StepBy(45 * time.Second)
+	assert.ErrEqual(t, cleanupJob.ProcessOne(s.Ctx), nil)
+	tr.DBChanges().AssertEqualf(`
+		DELETE FROM pending_blobs WHERE account_name = 'test1' AND digest = '%s';
+	`, testDigest,
+	)
+}


### PR DESCRIPTION
Alternative to #768 which requires less active database connections

Closes #768