### PR TITLE
Pathrouter

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -77,7 +77,7 @@ func run(cmd *cobra.Command, args []string) {
 	handler := httpapi.Compose(
 		keppelv1.NewAPI(cfg, ad, fd, sd, icd, db, auditor, rle),
 		auth.NewAPI(cfg, ad, fd, db),
-		registryv2.NewAPI(cfg, ad, fd, sd, icd, db, auditor, rle),
+		httpapi.UnmuxedAPI(registryv2.NewAPI(cfg, ad, fd, sd, icd, db, auditor, rle).TryHandler()),
 		peerv1.NewAPI(cfg, ad, db),
 		&headerReflector{enableHeaderReflector}, // the header reflection endpoint is only enabled where debugging is enabled (i.e. usually in dev/QA only)
 		httpapi.HealthCheckAPI{

--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/errext"
@@ -57,13 +56,13 @@ func (a *API) OverrideGenerateStorageID(generateStorageID func() string) *API {
 	return a
 }
 
-// AddTo implements the api.API interface.
-func (a *API) AddTo(r *mux.Router) {
+// TryHandler returns a handler for wrapping in [httpapi.UnmuxedAPI].
+func (a *API) TryHandler() httpapi.TryHandler {
 	// NOTE 1: This uses gg/pathrouter instead of gorilla/mux for the actual path matching
 	//         to improve performance esp. for important endpoints like GetManifest and GetBlob.
 	// NOTE 2: Most HEAD handlers are deleted to match the endpoint list from
 	//         <https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints>.
-	r.PathPrefix("/v2/").Handler(pr.Element("v2", pr.Choice(
+	return pr.Element("v2", pr.Choice(
 		pr.Element("/", pr.Handlers(pr.ByMethod{
 			http.MethodGet:  a.handleToplevel,
 			http.MethodHead: nil,
@@ -105,7 +104,7 @@ func (a *API) AddTo(r *mux.Router) {
 				http.MethodHead: nil,
 			}))),
 		)),
-	)))
+	))
 }
 
 func (a *API) processor() *processor.Processor {

--- a/internal/api/registry/api.go
+++ b/internal/api/registry/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/respondwith"
 	"go.xyrillian.de/gg/gsql"
+	pr "go.xyrillian.de/gg/pathrouter"
 
 	"github.com/sapcc/keppel/internal/auth"
 	"github.com/sapcc/keppel/internal/keppel"
@@ -58,49 +59,53 @@ func (a *API) OverrideGenerateStorageID(generateStorageID func() string) *API {
 
 // AddTo implements the api.API interface.
 func (a *API) AddTo(r *mux.Router) {
-	r.Methods("GET").Path("/v2/").HandlerFunc(a.handleToplevel)
-	r.Methods("GET").Path("/v2/_catalog").HandlerFunc(a.handleGetCatalog)
-
-	//NOTE: We used to match account name and repository name separately here,
-	// but that is not possible anymore since domain-remapped APIs do not have the
-	// account name in the URL path. The "repository" variable is split later in
-	// checkAccountAccess().
-	r.Methods("DELETE").
-		Path("/v2/{repository:.+}/blobs/{digest}").
-		HandlerFunc(a.handleDeleteBlob)
-	r.Methods("GET", "HEAD").
-		Path("/v2/{repository:.+}/blobs/{digest}").
-		HandlerFunc(a.handleGetOrHeadBlob)
-	r.Methods("POST").
-		Path("/v2/{repository:.+}/blobs/uploads/").
-		HandlerFunc(a.handleStartBlobUpload)
-	r.Methods("DELETE").
-		Path("/v2/{repository:.+}/blobs/uploads/{uuid}").
-		HandlerFunc(a.handleDeleteBlobUpload)
-	r.Methods("GET").
-		Path("/v2/{repository:.+}/blobs/uploads/{uuid}").
-		HandlerFunc(a.handleGetBlobUpload)
-	r.Methods("PATCH").
-		Path("/v2/{repository:.+}/blobs/uploads/{uuid}").
-		HandlerFunc(a.handleContinueBlobUpload)
-	r.Methods("PUT").
-		Path("/v2/{repository:.+}/blobs/uploads/{uuid}").
-		HandlerFunc(a.handleFinishBlobUpload)
-	r.Methods("DELETE").
-		Path("/v2/{repository:.+}/manifests/{reference}").
-		HandlerFunc(a.handleDeleteManifest)
-	r.Methods("GET", "HEAD").
-		Path("/v2/{repository:.+}/manifests/{reference}").
-		HandlerFunc(a.handleGetOrHeadManifest)
-	r.Methods("PUT").
-		Path("/v2/{repository:.+}/manifests/{reference}").
-		HandlerFunc(a.handlePutManifest)
-	r.Methods("GET").
-		Path("/v2/{repository:.+}/referrers/{reference}").
-		HandlerFunc(a.handleGetReferrers)
-	r.Methods("GET").
-		Path("/v2/{repository:.+}/tags/list").
-		HandlerFunc(a.handleListTags)
+	// NOTE 1: This uses gg/pathrouter instead of gorilla/mux for the actual path matching
+	//         to improve performance esp. for important endpoints like GetManifest and GetBlob.
+	// NOTE 2: Most HEAD handlers are deleted to match the endpoint list from
+	//         <https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints>.
+	r.PathPrefix("/v2/").Handler(pr.Element("v2", pr.Choice(
+		pr.Element("/", pr.Handlers(pr.ByMethod{
+			http.MethodGet:  a.handleToplevel,
+			http.MethodHead: nil,
+		})),
+		pr.Element("_catalog", pr.Handlers(pr.ByMethod{
+			http.MethodGet:  a.handleGetCatalog,
+			http.MethodHead: nil,
+		})),
+		pr.CatchAllVariable("repository", pr.Choice(
+			pr.Element("blobs", pr.Choice(
+				pr.Variable("digest", pr.Handlers(pr.ByMethod{
+					http.MethodDelete: a.handleDeleteBlob,
+					http.MethodGet:    a.handleGetOrHeadBlob,
+				})),
+				pr.Element("uploads", pr.Choice(
+					pr.Element("/", pr.Handlers(pr.ByMethod{
+						http.MethodPost: a.handleStartBlobUpload,
+					})),
+					pr.Variable("uuid", pr.Handlers(pr.ByMethod{
+						http.MethodDelete: a.handleDeleteBlobUpload,
+						http.MethodGet:    a.handleGetBlobUpload,
+						http.MethodHead:   nil,
+						http.MethodPatch:  a.handleContinueBlobUpload,
+						http.MethodPut:    a.handleFinishBlobUpload,
+					})),
+				)),
+			)),
+			pr.Element("manifests", pr.Variable("reference", pr.Handlers(pr.ByMethod{
+				http.MethodDelete: a.handleDeleteManifest,
+				http.MethodGet:    a.handleGetOrHeadManifest,
+				http.MethodPut:    a.handlePutManifest,
+			}))),
+			pr.Element("referrers", pr.Variable("reference", pr.Handlers(pr.ByMethod{
+				http.MethodGet:  a.handleGetReferrers,
+				http.MethodHead: nil,
+			}))),
+			pr.Element("tags", pr.Element("list", pr.Handlers(pr.ByMethod{
+				http.MethodGet:  a.handleListTags,
+				http.MethodHead: nil,
+			}))),
+		)),
+	)))
 }
 
 func (a *API) processor() *processor.Processor {
@@ -108,7 +113,8 @@ func (a *API) processor() *processor.Processor {
 }
 
 // This implements the GET /v2/ endpoint.
-func (a *API) handleToplevel(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleToplevel(w http.ResponseWriter, r *http.Request, vars map[string]string) {
+	_ = vars
 	httpapi.IdentifyEndpoint(r, "/v2/")
 	ctx := r.Context()
 
@@ -193,7 +199,7 @@ func (info anycastRequestInfo) asPrometheusLabels() prometheus.Labels {
 //
 // TODO: remove `w` argument and return errors using respondwith.CustomStatus(), like in findAccountFromRequest()
 // TODO: return non-pointer arguments to avoid useless heap allocations
-func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strategy repoAccessStrategy, anycastHandler func(http.ResponseWriter, *http.Request, anycastRequestInfo)) (*models.ReducedAccount, *models.ReducedRepository, *auth.Authorization, *auth.Challenge) {
+func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, vars map[string]string, strategy repoAccessStrategy, anycastHandler func(http.ResponseWriter, *http.Request, map[string]string, anycastRequestInfo)) (*models.ReducedAccount, *models.ReducedRepository, *auth.Authorization, *auth.Challenge) {
 	ctx := r.Context()
 
 	// must be set even for 401 responses!
@@ -202,7 +208,7 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 	// check that repo name is wellformed
 	scope := auth.Scope{
 		ResourceType: "repository",
-		ResourceName: mux.Vars(r)["repository"],
+		ResourceName: vars["repository"],
 	}
 	if !models.RepoNameWithLeadingSlashRx.MatchString("/" + scope.ResourceName) {
 		keppel.ErrNameInvalid.With("invalid repository name").WriteAsRegistryV2ResponseTo(w, r)
@@ -247,7 +253,7 @@ func (a *API) checkAccountAccess(w http.ResponseWriter, r *http.Request, strateg
 					keppel.ErrUnknown.With(msg).WriteAsRegistryV2ResponseTo(w, r)
 				} else {
 					mappedPrimaryHostName := authz.Audience.MapPeerHostname(primaryHostName)
-					anycastHandler(w, r, anycastRequestInfo{repoScope.AccountName, repoScope.RepositoryName, mappedPrimaryHostName})
+					anycastHandler(w, r, vars, anycastRequestInfo{repoScope.AccountName, repoScope.RepositoryName, mappedPrimaryHostName})
 				}
 				return nil, nil, nil, nil
 			case errors.Is(err, keppel.ErrNoSuchPrimaryAccount):

--- a/internal/api/registry/blobs.go
+++ b/internal/api/registry/blobs.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gorilla/mux"
 	"github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-bits/httpapi"
@@ -27,11 +26,11 @@ var isImageConfigBlobMediaType = map[string]bool{
 }
 
 // This implements the GET/HEAD /v2/<account>/<repository>/blobs/<digest> endpoint.
-func (a *API) handleGetOrHeadBlob(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleGetOrHeadBlob(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/:digest")
 	ctx := r.Context()
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, failIfRepoMissing, a.handleGetOrHeadBlobAnycast)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, a.handleGetOrHeadBlobAnycast)
 	if account == nil {
 		return
 	}
@@ -41,7 +40,7 @@ func (a *API) handleGetOrHeadBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blobDigest, err := digest.Parse(mux.Vars(r)["digest"])
+	blobDigest, err := digest.Parse(vars["digest"])
 	if err != nil {
 		keppel.ErrDigestInvalid.With(err.Error()).WriteAsRegistryV2ResponseTo(w, r)
 		return
@@ -166,7 +165,7 @@ func (a *API) handleGetOrHeadBlob(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (a *API) handleGetOrHeadBlobAnycast(w http.ResponseWriter, r *http.Request, info anycastRequestInfo) {
+func (a *API) handleGetOrHeadBlobAnycast(w http.ResponseWriter, r *http.Request, vars map[string]string, info anycastRequestInfo) {
 	// NOTE: Rate limits are enforced by the peer that we reverse-proxy to, not by
 	// us. We couldn't enforce them anyway because we don't have this account.
 	err := a.cfg.ReverseProxyAnycastRequestToPeer(w, r, info.PrimaryHostName)
@@ -177,16 +176,16 @@ func (a *API) handleGetOrHeadBlobAnycast(w http.ResponseWriter, r *http.Request,
 }
 
 // This implements the DELETE /v2/<account>/<repository>/blobs/<digest> endpoint.
-func (a *API) handleDeleteBlob(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleDeleteBlob(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/:digest")
 	ctx := r.Context()
 
-	account, repo, _, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, _, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
 
-	blobDigest, err := digest.Parse(mux.Vars(r)["digest"])
+	blobDigest, err := digest.Parse(vars["digest"])
 	if err != nil {
 		keppel.ErrDigestInvalid.With(err.Error()).WriteAsRegistryV2ResponseTo(w, r)
 		return

--- a/internal/api/registry/catalog.go
+++ b/internal/api/registry/catalog.go
@@ -23,7 +23,8 @@ import (
 const maxLimit = 100
 
 // This implements the GET /v2/_catalog endpoint.
-func (a *API) handleGetCatalog(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleGetCatalog(w http.ResponseWriter, r *http.Request, vars map[string]string) {
+	_ = vars
 	httpapi.IdentifyEndpoint(r, "/v2/_catalog")
 	ctx := r.Context()
 

--- a/internal/api/registry/manifests.go
+++ b/internal/api/registry/manifests.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-bits/httpapi"
@@ -29,11 +28,11 @@ import (
 )
 
 // This implements the HEAD/GET /v2/<repo>/manifests/<reference> endpoint.
-func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/manifests/:reference")
 	ctx := r.Context()
 
-	account, repo, authz, challenge := a.checkAccountAccess(w, r, createRepoIfMissingAndReplica, a.handleGetOrHeadManifestAnycast)
+	account, repo, authz, challenge := a.checkAccountAccess(w, r, vars, createRepoIfMissingAndReplica, a.handleGetOrHeadManifestAnycast)
 	if account == nil {
 		return
 	}
@@ -43,7 +42,7 @@ func (a *API) handleGetOrHeadManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reference := models.ParseManifestReference(mux.Vars(r)["reference"])
+	reference := models.ParseManifestReference(vars["reference"])
 	dbManifest, err := a.findManifestInDB(ctx, *repo, reference)
 	var manifestBytes []byte
 
@@ -293,7 +292,7 @@ func (a *API) getManifestContentFromDB(repoID int64, digestStr digest.Digest) ([
 	)
 }
 
-func (a *API) handleGetOrHeadManifestAnycast(w http.ResponseWriter, r *http.Request, info anycastRequestInfo) {
+func (a *API) handleGetOrHeadManifestAnycast(w http.ResponseWriter, r *http.Request, vars map[string]string, info anycastRequestInfo) {
 	err := a.cfg.ReverseProxyAnycastRequestToPeer(w, r, info.PrimaryHostName)
 	if respondWithError(w, r, err) {
 		return
@@ -302,11 +301,11 @@ func (a *API) handleGetOrHeadManifestAnycast(w http.ResponseWriter, r *http.Requ
 }
 
 // This implements the DELETE /v2/<repo>/manifests/<reference> endpoint.
-func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/manifests/:reference")
 	ctx := r.Context()
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
@@ -317,7 +316,7 @@ func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// delete tag or manifest from the database
-	ref := models.ParseManifestReference(mux.Vars(r)["reference"])
+	ref := models.ParseManifestReference(vars["reference"])
 	actx := keppel.AuditContext{
 		UserIdentity: authz.UserIdentity,
 		Request:      r,
@@ -339,11 +338,11 @@ func (a *API) handleDeleteManifest(w http.ResponseWriter, r *http.Request) {
 }
 
 // This implements the PUT /v2/<repo>/manifests/<reference> endpoint.
-func (a *API) handlePutManifest(w http.ResponseWriter, r *http.Request) {
+func (a *API) handlePutManifest(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/manifests/:reference")
 	ctx := r.Context()
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, createRepoIfMissing, nil)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, createRepoIfMissing, nil)
 	if account == nil {
 		return
 	}
@@ -387,7 +386,7 @@ func (a *API) handlePutManifest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// validate and store manifest
-	ref := models.ParseManifestReference(mux.Vars(r)["reference"])
+	ref := models.ParseManifestReference(vars["reference"])
 	incomingManifest := processor.IncomingManifest{
 		Reference: ref,
 		MediaType: r.Header.Get("Content-Type"),

--- a/internal/api/registry/referrers.go
+++ b/internal/api/registry/referrers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sapcc/go-bits/httpapi"
 
@@ -20,16 +19,16 @@ var (
 	getManifestBySubjectAndArtifactTypeQuery = models.ManifestStore.MustPrepareSelectQueryWhere(`repo_id = $1 AND subject_digest = $2 AND artifact_type = $3`)
 )
 
-func (a *API) handleGetReferrers(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleGetReferrers(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/referrers/:reference")
 	ctx := r.Context()
 
-	account, repo, _, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, _, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
 
-	digest := mux.Vars(r)["reference"]
+	digest := vars["reference"]
 	filterArtifactType := r.URL.Query().Get("artifactType")
 	var (
 		dbManifests []models.Manifest

--- a/internal/api/registry/tags.go
+++ b/internal/api/registry/tags.go
@@ -23,9 +23,9 @@ var tagsListQuery = sqlext.SimplifyWhitespace(`
 	 ORDER BY name ASC LIMIT $3
 `)
 
-func (a *API) handleListTags(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleListTags(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/tags/list")
-	account, repo, _, _ := a.checkAccountAccess(w, r, failIfRepoMissing, a.handleListTagsAnycast)
+	account, repo, _, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, a.handleListTagsAnycast)
 	if account == nil {
 		return
 	}
@@ -84,7 +84,7 @@ func (a *API) handleListTags(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (a *API) handleListTagsAnycast(w http.ResponseWriter, r *http.Request, info anycastRequestInfo) {
+func (a *API) handleListTagsAnycast(w http.ResponseWriter, r *http.Request, vars map[string]string, info anycastRequestInfo) {
 	err := a.cfg.ReverseProxyAnycastRequestToPeer(w, r, info.PrimaryHostName)
 	if respondWithError(w, r, err) {
 		return

--- a/internal/api/registry/uploads.go
+++ b/internal/api/registry/uploads.go
@@ -22,7 +22,6 @@ import (
 	"time"
 	"uuid"
 
-	"github.com/gorilla/mux"
 	"github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-bits/httpapi"
@@ -37,11 +36,11 @@ import (
 )
 
 // This implements the POST /v2/<account>/<repository>/blobs/uploads/ endpoint.
-func (a *API) handleStartBlobUpload(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleStartBlobUpload(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/uploads/")
 	ctx := r.Context()
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, createRepoIfMissing, nil)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, createRepoIfMissing, nil)
 	if account == nil {
 		return
 	}
@@ -290,15 +289,15 @@ func (a *API) performMonolithicUpload(w http.ResponseWriter, r *http.Request, ac
 }
 
 // This implements the DELETE /v2/<account>/<repository>/blobs/uploads/<uuid> endpoint.
-func (a *API) handleDeleteBlobUpload(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleDeleteBlobUpload(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/uploads/:uuid")
 	ctx := r.Context()
 
-	account, repo, _, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, _, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
-	upload, ok := a.findUpload(w, r, *repo)
+	upload, ok := a.findUpload(w, r, vars, *repo)
 	if !ok {
 		return
 	}
@@ -332,14 +331,14 @@ func (a *API) handleDeleteBlobUpload(w http.ResponseWriter, r *http.Request) {
 }
 
 // This implements the GET /v2/<account>/<repository>/blobs/uploads/<uuid> endpoint.
-func (a *API) handleGetBlobUpload(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleGetBlobUpload(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/uploads/:uuid")
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
-	upload, ok := a.findUpload(w, r, *repo)
+	upload, ok := a.findUpload(w, r, vars, *repo)
 	if !ok {
 		return
 	}
@@ -369,15 +368,15 @@ func (a *API) handleGetBlobUpload(w http.ResponseWriter, r *http.Request) {
 }
 
 // This implements the PATCH /v2/<account>/<repository>/blobs/uploads/<uuid> endpoint.
-func (a *API) handleContinueBlobUpload(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleContinueBlobUpload(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/uploads/:uuid")
 	ctx := r.Context()
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
-	upload, ok := a.findUpload(w, r, *repo)
+	upload, ok := a.findUpload(w, r, vars, *repo)
 	if !ok {
 		return
 	}
@@ -421,15 +420,15 @@ func (a *API) handleContinueBlobUpload(w http.ResponseWriter, r *http.Request) {
 }
 
 // This implements the PUT /v2/<account>/<repository>/blobs/uploads/<uuid> endpoint.
-func (a *API) handleFinishBlobUpload(w http.ResponseWriter, r *http.Request) {
+func (a *API) handleFinishBlobUpload(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 	httpapi.IdentifyEndpoint(r, "/v2/:account/:repo/blobs/uploads/:uuid")
 	ctx := r.Context()
 
-	account, repo, authz, _ := a.checkAccountAccess(w, r, failIfRepoMissing, nil)
+	account, repo, authz, _ := a.checkAccountAccess(w, r, vars, failIfRepoMissing, nil)
 	if account == nil {
 		return
 	}
-	upload, ok := a.findUpload(w, r, *repo)
+	upload, ok := a.findUpload(w, r, vars, *repo)
 	if !ok {
 		return
 	}
@@ -497,8 +496,8 @@ func (a *API) handleFinishBlobUpload(w http.ResponseWriter, r *http.Request) {
 }
 
 // TODO: remove `w` argument and return errors using respondwith.CustomStatus(), like in findAccountFromRequest()
-func (a *API) findUpload(w http.ResponseWriter, r *http.Request, repo models.ReducedRepository) (models.Upload, bool) {
-	uploadUUID := mux.Vars(r)["uuid"]
+func (a *API) findUpload(w http.ResponseWriter, r *http.Request, vars map[string]string, repo models.ReducedRepository) (models.Upload, bool) {
+	uploadUUID := vars["uuid"]
 	ctx := r.Context()
 
 	upload, err := keppel.FindUploadByRepository(ctx, a.db, uploadUUID, repo)

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -312,7 +312,7 @@ func NewSetup(t testing.TB, opts ...SetupOption) Setup {
 		httpapi.WithoutLogging(),
 		// Registry API (and thus Auth API) are nearly always needed for
 		// Bytes.Upload, Image.Upload and ImageList.Upload
-		registryv2.NewAPI(s.Config, ad, fd, sd, icd, s.DB, s.Auditor, params.RateLimitEngine).OverrideTimeNow(s.Clock.Now).OverrideGenerateStorageID(s.SIDGenerator.Next),
+		httpapi.UnmuxedAPI(registryv2.NewAPI(s.Config, ad, fd, sd, icd, s.DB, s.Auditor, params.RateLimitEngine).OverrideTimeNow(s.Clock.Now).OverrideGenerateStorageID(s.SIDGenerator.Next).TryHandler()),
 		authapi.NewAPI(s.Config, ad, fd, s.DB),
 	}
 	if params.WithKeppelAPI {

--- a/vendor/github.com/sapcc/go-bits/httpapi/api.go
+++ b/vendor/github.com/sapcc/go-bits/httpapi/api.go
@@ -20,6 +20,16 @@ type API interface {
 	AddTo(r *mux.Router)
 }
 
+// TryHandler is TODO.
+type TryHandler interface {
+	TryServeHTTP(http.ResponseWriter, *http.Request) bool
+}
+
+// UnmuxedAPI is TODO.
+func UnmuxedAPI(h TryHandler) API {
+	return pseudoAPI{tryHandler: h}
+}
+
 // HealthCheckAPI is an API with one endpoint, "GET /healthcheck", that
 // usually just prints "ok". If the application knows how to perform a more
 // elaborate healthcheck, it can provide a check function in the Check field.
@@ -56,7 +66,9 @@ func (h HealthCheckAPI) handleRequest(w http.ResponseWriter, r *http.Request) {
 // API. The AddTo() implementation is empty; Compose() will call the provided
 // configure() method instead.
 type pseudoAPI struct {
-	configure func(*middleware)
+	// exactly one field must be set
+	tryHandler TryHandler
+	configure  func(*middleware)
 }
 
 // AddTo implements the API interface.

--- a/vendor/github.com/sapcc/go-bits/httpapi/compose.go
+++ b/vendor/github.com/sapcc/go-bits/httpapi/compose.go
@@ -15,33 +15,51 @@ import (
 func Compose(apis ...API) http.Handler {
 	autoConfigureMetricsIfNecessary()
 
-	r := mux.NewRouter()
-	m := middleware{inner: r}
+	c := composition{
+		mainRouter: mux.NewRouter(),
+	}
+	var m middleware
 
 	// Automatically identify the endpoint for go-bits metrics using EndpointNamer,
 	// called here inside the gorilla/mux chain where route context is available.
-	r.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if EndpointNamer != nil {
-				if name, ok := EndpointNamer(r).Unpack(); ok {
-					IdentifyEndpoint(r, name)
-				}
+	m.inner = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if EndpointNamer != nil {
+			if name, ok := EndpointNamer(r).Unpack(); ok {
+				IdentifyEndpoint(r, name)
 			}
-			next.ServeHTTP(w, r)
-		})
+		}
+		c.ServeHTTP(w, r)
 	})
 
 	for _, a := range apis {
 		switch a := a.(type) {
 		case pseudoAPI:
-			a.configure(&m)
+			if a.tryHandler != nil {
+				c.tryHandlers = append(c.tryHandlers, a.tryHandler)
+			} else {
+				a.configure(&m)
+			}
 		default:
-			a.AddTo(r)
+			a.AddTo(c.mainRouter)
 		}
 	}
 
 	h := http.Handler(m)
 	return h
+}
+
+type composition struct {
+	tryHandlers []TryHandler
+	mainRouter  *mux.Router
+}
+
+func (c composition) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, h := range c.tryHandlers {
+		if h.TryServeHTTP(w, r) {
+			return
+		}
+	}
+	c.mainRouter.ServeHTTP(w, r)
 }
 
 type oobKey string

--- a/vendor/go.xyrillian.de/gg/options/options.go
+++ b/vendor/go.xyrillian.de/gg/options/options.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package options provides additional functions for type option.Option
+// that cannot be expressed as methods on the Option type itself.
+package options // import "go.xyrillian.de/gg/options"
+
+import (
+	"cmp"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// NOTE: Keep functions sorted by name.
+
+// FromPointer converts a *T into an Option[T].
+func FromPointer[T any](value *T) Option[T] {
+	if value == nil {
+		return None[T]()
+	} else {
+		return Some(*value)
+	}
+}
+
+// IsNoneOrZero returns whether o is either empty, or contains a zero value.
+func IsNoneOrZero[T comparable](o Option[T]) bool {
+	return o.IsNoneOr(func(value T) bool {
+		var zero T
+		return zero == value
+	})
+}
+
+// Map applies the given function to the value contained in o, if there is one.
+func Map[T, U any](o Option[T], mapping func(T) U) Option[U] {
+	if t, ok := o.Unpack(); ok {
+		return Some(mapping(t))
+	} else {
+		return None[U]()
+	}
+}
+
+// Max returns the largest of its input values, while disregarding None values.
+// If there are no Some values, None is returned.
+func Max[T cmp.Ordered](inputs ...Option[T]) Option[T] {
+	var (
+		result T
+		isSome = false
+	)
+	for _, i := range inputs {
+		value, ok := i.Unpack()
+		if ok && (!isSome || result < value) {
+			result = value
+			isSome = true
+		}
+	}
+	if isSome {
+		return Some(result)
+	} else {
+		return None[T]()
+	}
+}
+
+// Min returns the smallest of its input values, while disregarding None values.
+// If there are no Some values, None is returned.
+func Min[T cmp.Ordered](inputs ...Option[T]) Option[T] {
+	var (
+		result T
+		isSome = false
+	)
+	for _, i := range inputs {
+		value, ok := i.Unpack()
+		if ok && (!isSome || result > value) {
+			result = value
+			isSome = true
+		}
+	}
+	if isSome {
+		return Some(result)
+	} else {
+		return None[T]()
+	}
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/catchallvariable.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/catchallvariable.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import (
+	"strings"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// CatchAllVariable is a [Matcher] that accepts subpaths with an arbitrary number of path elements.
+// The value of any amount of leading path elements will be collected into vars[name],
+// such that the remainder is accepted by the next matcher.
+// At least one element must be collected into vars[name].
+//
+// CatchAllVariable() may appear at any point within the routing tree,
+// but it may not contain another CatchAllVariable() anywhere within it.
+func CatchAllVariable(name string, matcher Matcher) Matcher {
+	return catchAllVariable(name, matcher.downcast())
+}
+
+func catchAllVariable(name string, matcher realMatcher) Matcher {
+	// NOTE: The specific behavior of CatchAllVariable() is why this package exists in the first place.
+	//       I wanted to replace gorilla/mux with something more performance in Keppel,
+	//       but all the fast routers do not accept catch-all variables in the middle of a path
+	//       like the OCI Distribution API requires (e.g. "/v2/*repo/manifests/:reference" with "repo" being a full path).
+
+	innerMinLength := matcher.minLength
+	innerMaxLength, ok := matcher.maxLength.Unpack()
+	if !ok {
+		panic("matcher within CatchAllVariable() may not accept unlimited path lengths")
+	}
+
+	accept := func(path []string, vars map[string]string) HandlerFunc {
+		for length := innerMinLength; length <= innerMaxLength; length++ {
+			if length > len(path) {
+				break
+			}
+			caughtPath, subpath := path[0:len(path)-length], path[len(path)-length:]
+			if len(caughtPath) == 0 {
+				continue
+			}
+
+			handlerFunc := matcher.accept(subpath, vars)
+			if handlerFunc == nil {
+				continue
+			}
+			vars[name] = pathUnescape(strings.Join(caughtPath, "/"))
+			return handlerFunc
+		}
+		return nil
+	}
+
+	return realMatcher{
+		minLength: innerMinLength + 1,
+		maxLength: None[int](),
+		accept:    accept,
+	}
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/choice.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/choice.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import (
+	"slices"
+
+	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/options"
+)
+
+// Choice is a [Matcher] that accepts all subpaths that are accepted by any of its contained matchers.
+// If multiple matchers accept the requested subpath, the first match wins.
+//
+// Choice is used to specify different matchers for different subpaths,
+// as illustrated in the example in the package docstring.
+func Choice(matchers ...Matcher) Matcher {
+	downcasted := make([]realMatcher, len(matchers))
+	for idx, matcher := range matchers {
+		downcasted[idx] = matcher.downcast()
+	}
+	return choice(downcasted)
+}
+
+func choice(matchers []realMatcher) Matcher {
+	if len(matchers) == 0 {
+		panic("Choice() called without any matchers")
+	}
+
+	var (
+		minLengths     = make([]int, len(matchers))
+		maxLengths     = make([]Option[int], len(matchers))
+		maxLengthIsInf = false
+	)
+	for idx, m := range matchers {
+		minLengths[idx] = m.minLength
+		maxLengths[idx] = m.maxLength
+		if m.maxLength.IsNone() {
+			maxLengthIsInf = true
+		}
+	}
+	maxLength := None[int]()
+	if !maxLengthIsInf {
+		maxLength = options.Max(maxLengths...)
+	}
+
+	return realMatcher{
+		minLength: slices.Min(minLengths),
+		maxLength: maxLength,
+		accept: func(path []string, vars map[string]string) HandlerFunc {
+			for _, m := range matchers {
+				hf := m.accept(path, vars)
+				if hf != nil {
+					return hf
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/element.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/element.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import "go.xyrillian.de/gg/options"
+
+// Element is a [Matcher] that accepts subpaths with at least one path element.
+// The first path element must be equal to the given value,
+// and the remaining subpath will have to be accepted by the next matcher.
+func Element(value string, matcher Matcher) Matcher {
+	return element(value, matcher.downcast())
+}
+
+func element(value string, matcher realMatcher) Matcher {
+	switch value {
+	case "":
+		panic(`Element() called with value = ""`)
+	case "/":
+		value = "" // trailing slash will lead to an empty element in `path`, e.g. strings.Split("foo/bar/") == []string{"foo","bar",""}
+	default:
+	}
+
+	return realMatcher{
+		minLength: matcher.minLength + 1,
+		maxLength: options.Map(matcher.maxLength, increment),
+		accept: func(path []string, vars map[string]string) HandlerFunc {
+			if len(path) == 0 || path[0] != value {
+				return nil
+			}
+			return matcher.accept(path[1:], vars)
+		},
+	}
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/handler.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/handler.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// HandlerFunc is like [http.HandlerFunc], but also receives variable values that were extracted from the URL path.
+//
+// Package pathrouter passes variables explicitly like this, instead of via [context.Context.WithValue],
+// because doing so imposes a performance penalty for every usage of the respective context.
+type HandlerFunc = func(w http.ResponseWriter, r *http.Request, vars map[string]string)
+
+// ByMethod is a set of request handlers matching the same request path, keyed on request method.
+// It is commonly constructed as a literal using the respective constants from the net/http package, such as [http.MethodGet].
+// This type appears in the signature of func [Handlers], see documentation over there for details.
+type ByMethod map[string]HandlerFunc
+
+// Handlers is a [Matcher] that accepts empty subpaths only.
+// It appears at the leaf nodes of a [Matcher] tree, which correspond to specific endpoint paths,
+// and contains the actual request handlers for one endpoint path:
+//
+//	import pr "go.xyrillian.de/gg/pathrouter"
+//	handler := pr.Element("v1", pr.Choice(
+//		pr.Element("teams", pr.Variable("id", pr.Handlers(pr.ByMethod{
+//			http.MethodGet:    handleGetTeam,    // GET /v1/teams/:id
+//			http.MethodPut:    handlePutTeam,    // PUT /v1/teams/:id
+//			http.MethodDelete: handleDeleteTeam, // DELETE /v1/teams/:id
+//		}))),
+//		pr.Element("employees", pr.Variable("id", pr.Handlers(pr.ByMethod{
+//			http.MethodGet: handleGetEmployee, // GET /v1/employees/:id
+//		}))),
+//	))
+//
+// If there is a handler for [http.MethodGet], but none for [http.MethodHead], the GET handler will be called for HEAD as well.
+// To have a GET handler, but no HEAD handler, set the handler for [http.MethodHead] to nil.
+// Any other use of a nil [HandlerFunc] is invalid and will cause a panic.
+func Handlers(m ByMethod) Matcher {
+	// reuse GET handler for HEAD if not overridden
+	if handler, exists := m[http.MethodGet]; exists {
+		if _, exists := m[http.MethodHead]; !exists {
+			m[http.MethodHead] = handler
+		}
+		if m[http.MethodHead] == nil {
+			delete(m, http.MethodHead)
+		}
+	}
+
+	// check that all handlers are valid
+	for method, handler := range m {
+		if handler == nil {
+			panic(fmt.Sprintf("handler is nil for method %q", method))
+		}
+	}
+
+	// precomputations for accept()
+	allowHeader := m.buildAllowHeader()
+	serve := func(w http.ResponseWriter, r *http.Request, vars map[string]string) {
+		handler, ok := m[r.Method]
+		if ok {
+			handler(w, r, vars)
+			return
+		}
+
+		w.Header().Set("Allow", allowHeader)
+		if r.Method == http.MethodOptions {
+			http.Error(w, "", http.StatusOK)
+		} else {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	}
+
+	return realMatcher{
+		minLength: 0,
+		maxLength: Some(0),
+		accept: func(path []string, vars map[string]string) HandlerFunc {
+			if len(path) != 0 {
+				return nil
+			}
+			return serve
+		},
+	}
+}
+
+func (m ByMethod) buildAllowHeader() string {
+	allowedMethods := make([]string, 0, len(m))
+	for method := range m {
+		allowedMethods = append(allowedMethods, method)
+	}
+	slices.Sort(allowedMethods)
+	return strings.Join(allowedMethods, ", ")
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/here.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/here.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import (
+	. "go.xyrillian.de/gg/option"
+)
+
+// Here is a [Matcher] that matches effectively empty subpaths, that is:
+// subpaths that are either empty or only contain a heretofore unmatched trailing slash.
+// It can be used to opt-in to allowing trailing slashes at the ends of URL paths:
+//
+//	// only matches "/foo/bar"
+//	pr.Element("foo", pr.Element("bar", pr.Handlers(...))
+//
+//	// also matches "/foo/bar/"
+//	pr.Element("foo", pr.Element("bar", pr.Here(pr.Handlers(...)))
+//
+// The next matcher must match only the empty path, so currently only [Handlers] is allowed.
+//
+// Here is provided as a useful shorthand, but could be implemented using the other matchers like so:
+//
+//	// this...
+//	m := pr.Here(pr.Handlers(byMethod))
+//
+//	// ...is equivalent to this
+//	h := pr.Handlers(byMethod)
+//	m := pr.Choice(h, pr.Element("/", h))
+//
+// The name "Here" makes sense when Here() appears as one of several options within Choice(),
+// where the other options would match subpaths, while Here() matches, well, "here".
+// The example in the package docstring illustrates this.
+func Here(matcher Matcher) Matcher {
+	return here(matcher.downcast())
+}
+
+func here(matcher realMatcher) Matcher {
+	if matcher.minLength != 0 || matcher.maxLength != Some(0) {
+		panic("matcher within Here() must be Handlers()")
+	}
+
+	return realMatcher{
+		minLength: 0,
+		maxLength: Some(1),
+		accept: func(path []string, vars map[string]string) HandlerFunc {
+			if len(path) == 0 || (len(path) == 1 && path[0] == "") {
+				return matcher.accept(nil, vars)
+			}
+			return nil
+		},
+	}
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/matcher.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/matcher.go
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pathrouter contains an HTTP router that differentiates endpoints based on paths without any regex matching.
+//
+// # Comparison to other HTTP router libraries
+//
+// In contrast to most other router implementations, pathrouter does not take its routes as a list of declarations.
+// Instead, the routing table is declared as a nested structure describing the decision tree that the router follows:
+//
+//	// not like this (this is sometimes called "Sinatra style" after a popular framework using this approach)
+//	r := otherlibrary.NewRouter()
+//	r.Handle(http.MethodGet, "/v1/objects", api.ListObjects)
+//	r.Handle(http.MethodPost, "/v1/objects/new", api.CreateObject)
+//	r.Handle(http.MethodDelete, "/v1/objects/:id", api.DeleteObject)
+//	r.Handle(http.MethodGet, "/v1/objects/:id", api.GetObject)
+//	r.Handle(http.MethodPatch, "/v1/objects/:id", api.PatchObject)
+//
+//	// but like this
+//	import pr "go.xyrillian.de/gg/pathrouter"
+//	r := pr.Element("v1",
+//		pr.Element("objects",
+//			pr.Choice(
+//				pr.Here(pr.Handlers(pr.ByMethod{
+//					http.MethodGet: api.ListObjects,
+//				})),
+//				pr.Element("new", pr.Here(pr.Handlers(pr.ByMethod{
+//					http.MethodPost: api.CreateObject,
+//				}))),
+//				pr.Variable("id", pr.Here(pr.Handlers(pr.ByMethod{
+//					http.MethodDelete: api.DeleteObject,
+//					http.MethodGet:    api.GetObject,
+//					http.MethodPatch:  api.PatchObject,
+//				}))),
+//			),
+//		),
+//	)
+//
+// Compared to other common router libraries like [gorilla/mux],
+// pathrouter does not use regular expressions in its implementation,
+// thus making it extremely fast at the expense of reducing flexibility in what can be matched.
+// For instance, in the example above, requests for /v1/objects/:id will accept any non-empty string for the "id" variable.
+// Package pathrouter expects that request handlers will perform additional format checks on extracted path variables as required.
+//
+// Unlike other fast HTTP router libraries such as [httprouter] or [httptreemux], pathrouter can match a catch-all path (i.e. a variable extending over multiple path elements) anywhere in the path, not just at the end.
+// The only limitation with catch-all paths is that only one catch-all path may be matched per route, e.g. "/v1/objects/*path/relations" can be matched, but "v1/objects/*path/compare/*otherpath" cannot.
+//
+// # Handling of escape sequences in paths
+//
+// Path matching is performed on the escaped form of the URL path, as returned by [url.URL.EscapedPath],
+// so any slashes that were encoded as %2F in the URL path will be considered part of a path element instead of a boundary.
+//
+// For instance, using the example above, the URL path "/v1/objects/42/23" would not match and generate a 404 response,
+// but the URL path "/v1/objects/42%2F23" would match and invoke (e.g. with method GET) the GetObject handler with vars["id"] = "42/23".
+// Like in this example, [HandlerFunc] will receive unescaped values in its vars argument.
+//
+// # Implicit normalizations
+//
+// If the request path contains consecutive runs of unescaped slashes, they will be normalized to behave like a single slash.
+// For example, "http://localhost//foo%2F//bar//" is identical to "http://localhost/foo%2F/bar/".
+//
+// [gorilla/mux]: https://github.com/gorilla/mux
+// [httprouter]: https://github.com/julienschmidt/httprouter
+// [httptreemux]: https://github.com/dimfeld/httptreemux
+package pathrouter
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+var (
+	// force imports that are necessary to make docstring links work
+	_ context.Context = nil
+	_ url.URL
+)
+
+// Matcher is the common type for any actor that can inspect the path of a request URL (or a suffix of it)
+// and either accept or decline to handle the request.
+//
+// Matcher implements the ServeHTTP method of [http.Handler] and can thus be used with any net/http facility like [http.ListenAndServe].
+//
+// Alternatively, the TryServeHTTP method behaves like ServeHTTP, but will not render a "404 Not Found" response
+// when the matcher is not capable of handling requests with the given path, instead only returning false without touching the ResponseWriter.
+// This method may be useful when composing e.g. multiple [Matcher] instances that each implement a different API with different endpoints.
+type Matcher interface {
+	http.Handler
+	TryServeHTTP(w http.ResponseWriter, r *http.Request) bool
+
+	// Casts a Matcher into type realMatcher, which is the only type that actually implements this interface.
+	// This allows eliminating fat pointers in the matcher tree.
+	downcast() realMatcher
+}
+
+type realMatcher struct {
+	accept func(path []string, vars map[string]string) HandlerFunc
+
+	// The smallest len(path) that accept() can accept.
+	minLength int
+	// The largest len(path) that accept() can accept, or None if accept() can handle arbitrarily long paths.
+	maxLength Option[int]
+}
+
+// ServeHTTP implements the [Matcher] interface.
+func (m realMatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !m.TryServeHTTP(w, r) {
+		http.NotFound(w, r)
+	}
+}
+
+// TryServeHTTP implements the [Matcher] interface.
+func (m realMatcher) TryServeHTTP(w http.ResponseWriter, r *http.Request) bool {
+	path := extractPath(r.URL)
+	vars := make(map[string]string)
+	handlerFunc := m.accept(path, vars)
+	if handlerFunc == nil {
+		return false
+	} else {
+		handlerFunc(w, r, vars)
+		return true
+	}
+}
+
+// realMatcher implements the [Matcher] interface.
+func (m realMatcher) downcast() realMatcher {
+	return m
+}
+
+func extractPath(u *url.URL) []string {
+	// e.g. u.Path = "//foo//bar//" becomes ["", "", "foo", "", "", "bar", "", ""]
+	path := strings.Split(u.EscapedPath(), "/")
+
+	// sequences of slashes are supposed to behave like single slashes
+	// e.g. u.Path = "//foo//bar//" becomes ["foo", "bar", ""] here
+	for idx := 0; idx < len(path)-1; idx++ {
+		if path[idx] == "" {
+			copy(path[idx:], path[idx+1:])
+			path = path[0 : len(path)-1]
+			idx--
+		}
+	}
+
+	return path
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/utils.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/utils.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func pathUnescape(in string) string {
+	out, err := url.PathUnescape(in)
+	if err != nil {
+		// defense in depth: should not fail because `in` was indirectly obtained from r.URL.EscapedPath()
+		panic(fmt.Sprintf("PathUnescape failed on %q: %s", in, err.Error()))
+	}
+	return out
+}
+
+func increment(x int) int {
+	return x + 1
+}

--- a/vendor/go.xyrillian.de/gg/pathrouter/variable.go
+++ b/vendor/go.xyrillian.de/gg/pathrouter/variable.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pathrouter
+
+import "go.xyrillian.de/gg/options"
+
+// Variable is a [Matcher] that accepts subpaths with at least one path element.
+// The value of the first path element will be collected into vars[name],
+// and the remaining subpath will have to be accepted by the next matcher.
+func Variable(name string, matcher Matcher) Matcher {
+	return variable(name, matcher.downcast())
+}
+
+func variable(name string, matcher realMatcher) Matcher {
+	return realMatcher{
+		minLength: matcher.minLength + 1,
+		maxLength: options.Map(matcher.maxLength, increment),
+		accept: func(path []string, vars map[string]string) HandlerFunc {
+			if len(path) == 0 || path[0] == "" {
+				return nil
+			}
+			handlerFunc := matcher.accept(path[1:], vars)
+			if handlerFunc == nil {
+				return nil
+			}
+			vars[name] = pathUnescape(path[0])
+			return handlerFunc
+		},
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -253,6 +253,8 @@ go.xyrillian.de/gg/gsql
 go.xyrillian.de/gg/internal/path
 go.xyrillian.de/gg/jsonmatch
 go.xyrillian.de/gg/option
+go.xyrillian.de/gg/options
+go.xyrillian.de/gg/pathrouter
 go.xyrillian.de/gg/pgruntime
 go.xyrillian.de/gg/testcapture
 # go.xyrillian.de/oblast v0.13.2


### PR DESCRIPTION
gg has recently gained a new package, `pathrouter`, that does the same things as gorilla/mux (routing of HTTP requests to specific endpoints), but without expensive regex matches. I had the suspicion that Keppel (with its very large number of endpoints across several APIs) would benefit the most from this, and thus started with the Registry API implementation in Keppel. I also had to patch go-bits/httpapi to ensure that, when a Registry API endpoint is hit, we bypass the gorilla/mux router entirely. Benchmarks (shown below) show a 3-4% performance improvement both on CPU and RAM usage for the important read operations.

**Draft:** If this is a worthwhile improvement, we need to adjust go-bits first, with the change that is currently done in the vendor directory in this PR.

```
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

$ GOEXPERIMENT=jsonv2 go test ./internal/api/registry -run None -bench ImportantReadOperations -benchmem -benchtime 10s -cpuprofile cpu.out -memprofile mem.out
goos: linux
goarch: amd64
pkg: github.com/sapcc/keppel/internal/api/registry
cpu: AMD Ryzen 9 7900X 12-Core Processor
BenchmarkImportantReadOperations/GetManifest-24         	   26065	    458641 ns/op	   28315 B/op	     388 allocs/op
BenchmarkImportantReadOperations/GetBlob-24             	   40834	    292272 ns/op	   25227 B/op	     287 allocs/op
BenchmarkImportantReadOperations/ListTags-24            	   49050	    243068 ns/op	   20669 B/op	     257 allocs/op
PASS
ok  	github.com/sapcc/keppel/internal/api/registry	36.074s

$ git checkout pathrouter
Switched to branch 'pathrouter'
Your branch is up to date with 'origin/pathrouter'.

$ GOEXPERIMENT=jsonv2 go test ./internal/api/registry -run None -bench ImportantReadOperations -benchmem -benchtime 10s -cpuprofile cpu.out -memprofile mem.out
goos: linux
goarch: amd64
pkg: github.com/sapcc/keppel/internal/api/registry
cpu: AMD Ryzen 9 7900X 12-Core Processor
BenchmarkImportantReadOperations/GetManifest-24         	   26660	    445257 ns/op	   27554 B/op	     383 allocs/op
BenchmarkImportantReadOperations/GetBlob-24             	   40885	    287794 ns/op	   24423 B/op	     282 allocs/op
BenchmarkImportantReadOperations/ListTags-24            	   51819	    233371 ns/op	   19878 B/op	     252 allocs/op
PASS
ok  	github.com/sapcc/keppel/internal/api/registry	35.989s

--------------------------------------------------------------------------------

GetManifest: -2.8% cpu -2.7% mem
GetBlob:     -1.6% cpu -3.2% mem
ListTags:    -4.0% cpu -3.9% mem
```