### PR TITLE
implement json.{MarshalerTo,UnmarshalerFrom} for embeddedUserIdentity

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -7,7 +7,8 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"encoding/hex"
-	"encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"time"
@@ -205,43 +206,67 @@ type embeddedUserIdentity struct {
 	AuthDriver keppel.AuthDriver
 }
 
-// MarshalJSON implements the json.Marshaler interface.
-func (e embeddedUserIdentity) MarshalJSON() ([]byte, error) {
-	payload, err := e.UserIdentity.SerializeToJSON()
-	if err != nil {
-		return nil, err
-	}
+// prove interface implementations
+var _ interface {
+	json.MarshalerTo
+	json.UnmarshalerFrom
+} = &embeddedUserIdentity{}
 
+// MarshalJSONTo implements the [json.MarshalerTo] interface.
+func (e embeddedUserIdentity) MarshalJSONTo(enc *jsontext.Encoder) error {
 	// The straight-forward approach would be to serialize as
 	// `{"type":"foo","payload":"something"}`, but we serialize as
 	// `{"foo":"something"}` instead to shave off a few bytes.
-	typeID := e.UserIdentity.PluginTypeID()
-	return json.Marshal(map[string]json.RawMessage{typeID: json.RawMessage(payload)})
+	err := enc.WriteToken(jsontext.BeginObject)
+	if err != nil {
+		return err
+	}
+	err = enc.WriteToken(jsontext.String(e.UserIdentity.PluginTypeID()))
+	if err != nil {
+		return err
+	}
+	err = e.UserIdentity.SerializeToJSON(enc)
+	if err != nil {
+		return err
+	}
+	return enc.WriteToken(jsontext.EndObject)
 }
 
-// UnmarshalJSON implements the json.Marshaler interface.
-func (e *embeddedUserIdentity) UnmarshalJSON(in []byte) error {
+// UnmarshalJSONFrom implements the [json.UnmarshalerFrom] interface.
+func (e *embeddedUserIdentity) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if e.AuthDriver == nil {
 		return errors.New("cannot unmarshal EmbeddedAuthorization without an AuthDriver")
 	}
 
-	m := make(map[string]json.RawMessage)
-	err := json.Unmarshal(in, &m)
+	// parse a structure of the form {"<type_id>":<payload>}
+	k := dec.PeekKind()
+	if k != jsontext.KindBeginObject {
+		return &json.SemanticError{JSONKind: k}
+	}
+	_, err := dec.ReadToken()
 	if err != nil {
 		return err
 	}
-	if len(m) != 1 {
-		return fmt.Errorf("cannot unmarshal EmbeddedAuthorization with %d components", len(m))
+
+	k = dec.PeekKind()
+	if k != jsontext.KindString {
+		return &json.SemanticError{JSONKind: k}
+	}
+	var typeID string
+	err = json.UnmarshalDecode(dec, &typeID)
+	if err != nil {
+		return err
 	}
 
-	for typeID, payload := range m {
-		e.UserIdentity, err = keppel.DeserializeUserIdentity(typeID, []byte(payload), e.AuthDriver)
-		if err != nil {
-			return fmt.Errorf("cannot unmarshal EmbeddedAuthorization of type %q: %w", typeID, err)
-		}
-		return nil
+	e.UserIdentity, err = keppel.DeserializeUserIdentity(typeID, dec, e.AuthDriver)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal EmbeddedAuthorization of type %q: %w", typeID, err)
 	}
 
-	// the loop body executes exactly once, therefore this location is unreachable
-	panic("unreachable")
+	k = dec.PeekKind()
+	if k != jsontext.KindEndObject {
+		return &json.SemanticError{JSONKind: k}
+	}
+	_, err = dec.ReadToken()
+	return err
 }

--- a/internal/auth/uid_anonymous.go
+++ b/internal/auth/uid_anonymous.go
@@ -4,7 +4,8 @@
 package auth
 
 import (
-	"fmt"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 
 	"github.com/sapcc/go-bits/audittools"
 
@@ -46,14 +47,17 @@ func (anonUserIdentity) UserInfo() audittools.UserInfo {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (anonUserIdentity) SerializeToJSON() (payload []byte, err error) {
-	return []byte("true"), nil
+func (anonUserIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
+	return enc.WriteToken(jsontext.True)
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (anonUserIdentity) DeserializeFromJSON(in []byte, _ keppel.AuthDriver) error {
-	if string(in) != "true" {
-		return fmt.Errorf("%q is not a valid payload for AnonymousUserIdentity", string(in))
+func (anonUserIdentity) DeserializeFromJSON(dec *jsontext.Decoder, _ keppel.AuthDriver) error {
+	// accept only the payload `true` (exactly as emitted above)
+	k := dec.PeekKind()
+	if k != jsontext.KindTrue {
+		return &json.SemanticError{JSONKind: k}
 	}
-	return nil
+	_, err := dec.ReadToken()
+	return err
 }

--- a/internal/auth/uid_peer.go
+++ b/internal/auth/uid_peer.go
@@ -5,7 +5,8 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/sapcc/go-bits/audittools"
@@ -56,13 +57,13 @@ func (uid *PeerUserIdentity) UserInfo() audittools.UserInfo {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (uid *PeerUserIdentity) SerializeToJSON() (payload []byte, err error) {
-	return json.Marshal(uid.PeerHostName)
+func (uid *PeerUserIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
+	return enc.WriteToken(jsontext.String(uid.PeerHostName))
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (uid *PeerUserIdentity) DeserializeFromJSON(in []byte, _ keppel.AuthDriver) error {
-	return json.Unmarshal(in, &uid.PeerHostName)
+func (uid *PeerUserIdentity) DeserializeFromJSON(dec *jsontext.Decoder, _ keppel.AuthDriver) error {
+	return json.UnmarshalDecode(dec, &uid.PeerHostName)
 }
 
 // Returns whether the given peer credentials are valid. On success, the Peer

--- a/internal/auth/uid_trivy.go
+++ b/internal/auth/uid_trivy.go
@@ -4,7 +4,8 @@
 package auth
 
 import (
-	"fmt"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"time"
 
 	"github.com/sapcc/go-bits/audittools"
@@ -47,16 +48,19 @@ func (uid *TrivyUserIdentity) UserInfo() audittools.UserInfo {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (uid *TrivyUserIdentity) SerializeToJSON() (payload []byte, err error) {
-	return []byte("true"), nil
+func (uid *TrivyUserIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
+	return enc.WriteToken(jsontext.True)
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (uid *TrivyUserIdentity) DeserializeFromJSON(in []byte, _ keppel.AuthDriver) error {
-	if string(in) != "true" {
-		return fmt.Errorf("%q is not a valid payload for TrivyUserIdentity", string(in))
+func (uid *TrivyUserIdentity) DeserializeFromJSON(dec *jsontext.Decoder, _ keppel.AuthDriver) error {
+	// accept only the payload `true` (exactly as emitted above)
+	k := dec.PeekKind()
+	if k != jsontext.KindTrue {
+		return &json.SemanticError{JSONKind: k}
 	}
-	return nil
+	_, err := dec.ReadToken()
+	return err
 }
 
 // IssueTokenForTrivy issues a token for Trivy to pull the image and it's databases with.

--- a/internal/drivers/openstack/keystone.go
+++ b/internal/drivers/openstack/keystone.go
@@ -9,6 +9,9 @@ package openstack
 
 import (
 	"context"
+	json_v1 "encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"net/http"
@@ -275,20 +278,32 @@ func (a *keystoneUserIdentity) UserInfo() audittools.UserInfo {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (a *keystoneUserIdentity) SerializeToJSON() (payload []byte, err error) {
+func (a *keystoneUserIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
 	// We cannot serialize the entire gopherpolicy.Token, that would include the
 	// X-Auth-Token and possibly even the full token response including service
 	// catalog, and thus produce a rather massive payload. We skip the token and
 	// token response and only serialize what we need to make policy decisions and
 	// satisfy the audittools.UserInfo interface.
-	return gopherpolicy.SerializeCompactContextToJSON(a.t.Context)
+	//
+	// TODO: this function in go-bits should take *jsontext.Encoder directly
+	buf, err := gopherpolicy.SerializeCompactContextToJSON(a.t.Context)
+	if err != nil {
+		return err
+	}
+	return enc.WriteValue(jsontext.Value(buf))
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (a *keystoneUserIdentity) DeserializeFromJSON(in []byte, ad keppel.AuthDriver) (err error) {
+func (a *keystoneUserIdentity) DeserializeFromJSON(dec *jsontext.Decoder, ad keppel.AuthDriver) error {
 	d, ok := ad.(*keystoneDriver)
 	if !ok {
 		return keppel.ErrAuthDriverMismatch
+	}
+
+	var payload json_v1.RawMessage
+	err := json.UnmarshalDecode(dec, &payload)
+	if err != nil {
+		return err
 	}
 
 	a.t = &gopherpolicy.Token{
@@ -297,6 +312,7 @@ func (a *keystoneUserIdentity) DeserializeFromJSON(in []byte, ad keppel.AuthDriv
 		ProviderClient: nil,              // cannot be reasonably serialized; see comment above
 		Err:            nil,
 	}
-	a.t.Context, err = gopherpolicy.DeserializeCompactContextFromJSON(in)
+	// TODO: this function in go-bits should take *jsontext.Decoder directly
+	a.t.Context, err = gopherpolicy.DeserializeCompactContextFromJSON(payload)
 	return err
 }

--- a/internal/drivers/trivial/auth.go
+++ b/internal/drivers/trivial/auth.go
@@ -5,7 +5,8 @@ package trivial
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"errors"
 	"net/http"
 
@@ -55,13 +56,13 @@ func (uid *userIdentity) UserType() keppel.UserType {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (uid *userIdentity) SerializeToJSON() (payload []byte, err error) {
-	return json.Marshal(uid.Username)
+func (uid *userIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
+	return enc.WriteToken(jsontext.String(uid.Username))
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (uid *userIdentity) DeserializeFromJSON(in []byte, _ keppel.AuthDriver) error {
-	return json.Unmarshal(in, &uid.Username)
+func (uid *userIdentity) DeserializeFromJSON(dec *jsontext.Decoder, _ keppel.AuthDriver) error {
+	return json.UnmarshalDecode(dec, &uid.Username)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/internal/keppel/user_identity.go
+++ b/internal/keppel/user_identity.go
@@ -4,6 +4,7 @@
 package keppel
 
 import (
+	"encoding/json/jsontext"
 	"fmt"
 
 	"github.com/sapcc/go-bits/audittools"
@@ -85,11 +86,11 @@ type UserIdentity interface {
 
 	// SerializeToJSON serializes this UserIdentity instance into JSON for
 	// inclusion in a token payload.
-	SerializeToJSON() (payload []byte, err error)
+	SerializeToJSON(enc *jsontext.Encoder) error
 	// DeserializeFromJSON deserializes the given token payload (as returned by
 	// SerializeToJSON) into the callee. This is always called on a fresh
 	// instance created by UserIdentityFactory.Instantiate().
-	DeserializeFromJSON(payload []byte, ad AuthDriver) error
+	DeserializeFromJSON(dec *jsontext.Decoder, ad AuthDriver) error
 }
 
 // UserIdentityRegistry is a pluggable.Registry for UserIdentity implementations.
@@ -97,11 +98,11 @@ var UserIdentityRegistry pluggable.Registry[UserIdentity]
 
 // DeserializeUserIdentity deserializes a UserIdentity payload. This is the
 // reverse of UserIdentity.SerializeToJSON().
-func DeserializeUserIdentity(typeID string, payload []byte, ad AuthDriver) (UserIdentity, error) {
+func DeserializeUserIdentity(typeID string, dec *jsontext.Decoder, ad AuthDriver) (UserIdentity, error) {
 	uid := UserIdentityRegistry.Instantiate(typeID)
 	if uid == nil {
 		return nil, fmt.Errorf("cannot unmarshal embedded authorization with unknown payload type %q", typeID)
 	}
-	err := uid.DeserializeFromJSON(payload, ad)
+	err := uid.DeserializeFromJSON(dec, ad)
 	return uid, err
 }

--- a/internal/tasks/janitor.go
+++ b/internal/tasks/janitor.go
@@ -4,7 +4,9 @@
 package tasks
 
 import (
-	"encoding/json"
+	json_v1 "encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"errors"
 	"math/rand"
 	"net/http"
@@ -122,16 +124,16 @@ func (uid janitorUserIdentity) UserInfo() audittools.UserInfo {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (uid janitorUserIdentity) SerializeToJSON() (payload []byte, err error) {
+func (uid janitorUserIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
 	if uid.GCPolicy.IsSome() {
-		return nil, errors.New("janitorUserIdentity.SerializeToJSON is not allowed")
+		return errors.New("janitorUserIdentity.SerializeToJSON is not allowed")
 	}
-	return json.Marshal(uid.TaskName)
+	return enc.WriteToken(jsontext.String(uid.TaskName))
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (uid janitorUserIdentity) DeserializeFromJSON(in []byte, ad keppel.AuthDriver) error {
-	return json.Unmarshal(in, &uid.TaskName)
+func (uid janitorUserIdentity) DeserializeFromJSON(dec *jsontext.Decoder, ad keppel.AuthDriver) error {
+	return json.UnmarshalDecode(dec, &uid.TaskName)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -154,7 +156,7 @@ func (u janitorUserInfo) AsInitiator(_ cadf.Host) cadf.Resource {
 		ID:      u.TaskName,
 	}
 	if gcPolicy, ok := u.GCPolicy.Unpack(); ok {
-		gcPolicyJSON, _ := json.Marshal(gcPolicy)
+		gcPolicyJSON, _ := json_v1.Marshal(gcPolicy)
 		res.Attachments = append(res.Attachments, cadf.Attachment{
 			Name:    "gc-policy",
 			TypeURI: "mime:application/json",

--- a/internal/test/driver_auth.go
+++ b/internal/test/driver_auth.go
@@ -5,7 +5,8 @@ package test
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"net/http"
 	"strings"
 
@@ -106,13 +107,13 @@ func (uid *userIdentity) UserInfo() audittools.UserInfo {
 }
 
 // SerializeToJSON implements the keppel.UserIdentity interface.
-func (uid *userIdentity) SerializeToJSON() (payload []byte, err error) {
-	return json.Marshal(uid)
+func (uid *userIdentity) SerializeToJSON(enc *jsontext.Encoder) error {
+	return json.MarshalEncode(enc, uid)
 }
 
 // DeserializeFromJSON implements the keppel.UserIdentity interface.
-func (uid *userIdentity) DeserializeFromJSON(in []byte, _ keppel.AuthDriver) error {
-	return json.Unmarshal(in, &uid)
+func (uid *userIdentity) DeserializeFromJSON(dec *jsontext.Decoder, _ keppel.AuthDriver) error {
+	return json.UnmarshalDecode(dec, &uid)
 }
 
 type dummyUserInfo struct{}


### PR DESCRIPTION
Not holding the serialized UserIdentity payload in a json.RawMessage during unmarshaling brings a small, but nice improvement of about 3% less memory allocations and a more minute improvement on CPU usage:

```
$ git checkout master
$ go test ./internal/api/registry -benchmem -run None -bench ImportantReadOperations -benchtime 10s
goos: linux
goarch: amd64
pkg: github.com/sapcc/keppel/internal/api/registry
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkImportantReadOperations/GetManifest-8         	   21842	    550272 ns/op	   28835 B/op	     389 allocs/op
BenchmarkImportantReadOperations/GetBlob-8             	   32936	    365975 ns/op	   25534 B/op	     287 allocs/op
BenchmarkImportantReadOperations/ListTags-8            	   39612	    302636 ns/op	   20676 B/op	     253 allocs/op
PASS
ok  	github.com/sapcc/keppel/internal/api/registry	36.328s

$ git checkout optimize-embeddeduseridentity
$ go test ./internal/api/registry -benchmem -run None -bench ImportantReadOperations -benchtime 10s
goos: linux
goarch: amd64
pkg: github.com/sapcc/keppel/internal/api/registry
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkImportantReadOperations/GetManifest-8         	   21865	    547334 ns/op	   28166 B/op	     384 allocs/op
BenchmarkImportantReadOperations/GetBlob-8             	   32948	    364273 ns/op	   24903 B/op	     282 allocs/op
BenchmarkImportantReadOperations/ListTags-8            	   40437	    299032 ns/op	   20062 B/op	     248 allocs/op
PASS
ok  	github.com/sapcc/keppel/internal/api/registry	36.328s
```

This benchmark does not cover the marshaling phase during token issuing, but I suppose that a similar improvement might be seen there.