### PR TITLE
Go 1.27: replace gofrs/uuid with uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/databus23/goslo.policy v0.0.0-20250326134918-4afc2c56a903
 	github.com/dlmiddlecote/sqlstats v1.0.2
 	github.com/go-redis/redis_rate/v10 v10.0.1
-	github.com/gofrs/uuid/v5 v5.5.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gophercloud/gophercloud/v2 v2.13.0
 	github.com/gorilla/mux v1.8.1
@@ -38,6 +37,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.3.2 // indirect
+	github.com/gofrs/uuid/v5 v5.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/gojq v0.12.19 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect

--- a/internal/api/registry/uploads.go
+++ b/internal/api/registry/uploads.go
@@ -20,8 +20,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/gorilla/mux"
 	"github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
@@ -134,13 +134,9 @@ func (a *API) handleStartBlobUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// start a new upload
-	uuidV4, err := uuid.NewV4()
-	if respondWithError(w, r, err) {
-		return
-	}
 	upload := models.Upload{
 		RepositoryID: repo.ID,
-		UUID:         uuidV4.String(),
+		UUID:         uuid.NewV4().String(),
 		StorageID:    a.generateStorageID(),
 		SizeBytes:    0,
 		Digest:       "",
@@ -191,12 +187,8 @@ func (a *API) performCrossRepositoryBlobMount(ctx context.Context, account model
 	}
 
 	// the spec wants a Blob-Upload-Session-Id header even though the upload is done, so just make something up
-	uuidV4, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
 	hdr := make(http.Header)
-	hdr.Set("Blob-Upload-Session-Id", uuidV4.String())
+	hdr.Set("Blob-Upload-Session-Id", uuid.NewV4().String())
 	hdr.Set("Content-Length", "0")
 	hdr.Set("Location", fmt.Sprintf("/v2/%s/blobs/%s", getRepoNameForURLPath(targetRepo, authz), blobDigest.String()))
 	return hdr, nil
@@ -290,11 +282,7 @@ func (a *API) performMonolithicUpload(w http.ResponseWriter, r *http.Request, ac
 	}
 
 	// the spec wants a Blob-Upload-Session-Id header even though the upload is done, so just make something up
-	uuidV4, err := uuid.NewV4()
-	if respondWithError(w, r, err) {
-		return false
-	}
-	w.Header().Set("Blob-Upload-Session-Id", uuidV4.String())
+	w.Header().Set("Blob-Upload-Session-Id", uuid.NewV4().String())
 	w.Header().Set("Content-Length", "0")
 	w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/%s", getRepoNameForURLPath(repo, authz), blobDigest.String()))
 	w.WriteHeader(http.StatusCreated)

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -12,8 +12,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"uuid"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/sapcc/keppel/internal/keppel"
@@ -119,10 +119,6 @@ func (a Authorization) IssueTokenWithExpires(cfg keppel.Configuration, expiresIn
 	// false to reveal the identity of the Keppel API that issued the token
 	issuer := Audience{IsAnycast: false, AccountName: a.Audience.AccountName}
 
-	uuidV4, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
 	publicHost := a.Audience.Hostname(cfg)
 	access := a.ScopeSet
 	if len(access) == 0 {
@@ -130,7 +126,7 @@ func (a Authorization) IssueTokenWithExpires(cfg keppel.Configuration, expiresIn
 	}
 	token := jwt.NewWithClaims(method, tokenClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			ID:        uuidV4.String(),
+			ID:        uuid.NewV4().String(),
 			Audience:  jwt.ClaimStrings{publicHost},
 			Issuer:    "keppel-api@" + issuer.Hostname(cfg),
 			Subject:   a.UserIdentity.UserName(),

--- a/internal/tasks/uploads_test.go
+++ b/internal/tasks/uploads_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/assert"
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	testUploadUUID = uuid.Must(uuid.NewV4()).String()
+	testUploadUUID = uuid.NewV4().String()
 	testStorageID  = keppel.GenerateStorageID()
 )
 


### PR DESCRIPTION
The dependency is not gone yet because libraries are using it, too.