### PR TITLE
AccountDeletionJob: fix non-idempotent storage cleanup

### DIFF
--- a/internal/tasks/account_deletion.go
+++ b/internal/tasks/account_deletion.go
@@ -267,7 +267,7 @@ func (j *Janitor) deleteMarkedAccount(ctx context.Context, accountName models.Ac
 	// before committing the transaction, confirm account deletion with the
 	// storage driver and the federation driver
 	err = j.sd.CleanupAccount(ctx, accountReduced)
-	if err != nil {
+	if err != nil && !errors.Is(err, keppel.NotFoundInStorageError{}) {
 		return fmt.Errorf("while cleaning up storage for account: %w", err)
 	}
 	err = j.fd.ForfeitAccountName(ctx, accountReduced)


### PR DESCRIPTION
We encountered a bug in prod where deletion of a primary account executed CleanupAccount() successfully on the first attempt, but then failed during ForfeitAccountName() because of replicas with the same name that are still attached to this primary. Subsequent deletion attempts then failed because CleanupAccount() raised a NotFoundInStorageError.