### PR TITLE
raise limit for accounts.anon_rbac_policies_json

### DIFF
--- a/internal/api/keppel/accounts_test.go
+++ b/internal/api/keppel/accounts_test.go
@@ -292,11 +292,11 @@ func TestAccountsAPI(t *testing.T) {
 	// (this protects against unbounded growth of ReducedAccount contents)
 	newRBACPoliciesJSON = []jsonmatch.Object{
 		{
-			"match_repository": "verylongverylongverylongverylong",
+			"match_repository": "verylongverylongverylongverylongverylongverylong",
 			"permissions":      []string{"anonymous_pull"},
 		},
 		{
-			"match_repository": "evenlongerevenlongerevenlongerevenlonger",
+			"match_repository": "evenlongerevenlongerevenlongerevenlongerevenlongerevenlonger",
 			"permissions":      []string{"anonymous_pull"},
 		},
 	}
@@ -317,7 +317,7 @@ func TestAccountsAPI(t *testing.T) {
 	})
 	// in the diff below, it is noteworthy that accounts.anon_rbac_policies_json remains at its previous value of "[]"
 	tr.DBChanges().AssertEqual(`
-		UPDATE accounts SET rbac_policies_json = '[{"match_repository":"verylongverylongverylongverylong","permissions":["anonymous_pull"]},{"match_repository":"evenlongerevenlongerevenlongerevenlonger","permissions":["anonymous_pull"]}]' WHERE name = 'second';
+		UPDATE accounts SET rbac_policies_json = '[{"match_repository":"verylongverylongverylongverylongverylongverylong","permissions":["anonymous_pull"]},{"match_repository":"evenlongerevenlongerevenlongerevenlongerevenlongerevenlonger","permissions":["anonymous_pull"]}]' WHERE name = 'second';
 	`)
 
 	// test POST /keppel/v1/:accounts/sublease success case (error cases are in

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -143,4 +143,4 @@ func (a ReducedAccount) IsReplica() bool {
 // If this length is exceeded, the field will be left empty (only holding an empty array)
 // and AuthZ for anonymous users needs to inspect the full set of RBAC policies.
 // This protects [ReducedAccount] from growing beyond a reasonable size.
-const AnonymousRBACPoliciesJSONMaxLength = 64
+const AnonymousRBACPoliciesJSONMaxLength = 128


### PR DESCRIPTION
As it turns out, 64 bytes is just too short to hold the policies for our team-internal mirror accounts, which is our most important usecase.